### PR TITLE
Decide the unrecognised {mode} refusal at the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Changed
 
+- **A misspelled protocol segment on a link route now answers 400 (#1399).**
+  The three account-link routes carry an `oid` or `saml` segment in their path,
+  and a value that is neither used to throw. The refusal was correct and is
+  unchanged; what the caller saw afterwards was not decided by this plugin but
+  by whatever the server does with an exception, which made it the one refusal
+  on that surface an integration could not rely on while its four neighbours
+  each answer a chosen status with a chosen message. All three routes now answer
+  `400` with the same fixed sentence naming the two accepted values. The
+  sentence never repeats what was sent, so a mistyped segment is not reflected
+  back into the response. This matters where the segment comes from a
+  provisioning tool's own configuration, which is the ordinary way a wrong one
+  arrives.
+
 - **The redirect URI on the settings page now comes from the server (#1303).**
   The page used to work the value out for itself, in the browser, from the base
   URL override and a fixed path. That made two things compose a string an

--- a/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
@@ -88,25 +88,68 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
-    public async Task AddCanonicalLink_AuthorizedButInvalidMode_Throws()
+    public async Task AddCanonicalLink_AuthorizedButInvalidMode_Returns400()
     {
         var harness = ForCaller(isAdmin: true, callerId: Target);
 
         // The guard passes (admin), so the mode dispatch runs and rejects an unknown mode fail-closed.
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            harness.Controller.AddCanonicalLink("ldap", "keycloak", Target, new AuthResponse()));
+        // #1399: the rejection is a status this repository chose, not one the host's exception middleware
+        // chose for it. Delete the RefuseUnknownMode arm in the controller and this assertion goes red,
+        // because the call throws out of the controller instead of returning.
+        var result = await harness.Controller.AddCanonicalLink("ldap", "keycloak", Target, new AuthResponse());
+
+        Assert.Equal(400, Assert.IsType<BadRequestObjectResult>(result).StatusCode);
     }
 
     [Fact]
-    public async Task DeleteCanonicalLink_AuthorizedButInvalidMode_Throws()
+    public async Task DeleteCanonicalLink_AuthorizedButInvalidMode_Returns400()
     {
         // #369: the DELETE route parses {mode} at the same boundary as the add route, so an unknown mode is
         // rejected there once - fail closed, exactly like AddCanonicalLink - rather than being forwarded raw
         // to the service to throw deep inside TryGetLinks. Pins the previously-untested DELETE invalid-mode path.
         var harness = ForCaller(isAdmin: true, callerId: Target);
 
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            harness.Controller.DeleteCanonicalLink("ldap", "keycloak", Target, "sub-1"));
+        var result = await harness.Controller.DeleteCanonicalLink("ldap", "keycloak", Target, "sub-1");
+
+        Assert.Equal(400, Assert.IsType<BadRequestObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task EveryModeCarryingRoute_RefusesAnUnknownModeWithTheSameBody()
+    {
+        // #1399: three routes carry a {mode} segment and all three route it through one parse. The value of
+        // deciding the status here is that an integrator can depend on it, which only holds if the three
+        // agree - so the body is asserted, not just the status, and the assertion is made across all three
+        // rather than on the one route that happened to be measured.
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        // The pre-provision route answers 404 for a user id nobody holds before it looks at {mode}, so the
+        // account has to exist for that route to reach the parse at all.
+        harness.UserManager.GetUserById(Target).Returns(TestUsers.Named("caller", Target));
+
+        var add = await harness.Controller.AddCanonicalLink("ldap", "keycloak", Target, new AuthResponse());
+        var delete = await harness.Controller.DeleteCanonicalLink("ldap", "keycloak", Target, "sub-1");
+        var preprovision = await harness.Controller.PreprovisionCanonicalLink("ldap", "keycloak", Target, "sub-1");
+
+        foreach (var result in new[] { add, delete, preprovision })
+        {
+            var refusal = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, refusal.StatusCode);
+            Assert.Equal("The mode segment must be 'oid' or 'saml'.", refusal.Value);
+        }
+    }
+
+    [Fact]
+    public async Task AnUnknownMode_IsRefusedWithoutEchoingWhatTheCallerSent()
+    {
+        // The refusal body is fixed text. Echoing the supplied token would reflect caller-controlled bytes
+        // into a response an administrator's tooling renders, and there is nothing an integrator learns from
+        // seeing their own typo repeated that the fixed sentence does not already tell them.
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        var result = await harness.Controller.AddCanonicalLink("<script>ldap</script>", "keycloak", Target, new AuthResponse());
+
+        Assert.Equal("The mode segment must be 'oid' or 'saml'.", Assert.IsType<BadRequestObjectResult>(result).Value);
     }
 
     [Fact]

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -52,6 +52,10 @@ public class SSOController : ControllerBase
     // defined once (#318).
     private const string NoMatchingProviderMessage = LoginStatusMapper.NoMatchingProviderMessage;
 
+    // The refusal body for an unrecognized {mode} route token (#1399), named here beside the other fixed
+    // refusal wordings. It names the two accepted tokens and never echoes the supplied one.
+    private const string UnknownModeMessage = "The mode segment must be 'oid' or 'saml'.";
+
     // Display names for the audit log (the internal link-map mode tokens are the lowercase "oid"/"saml").
     private const string OpenIdProtocol = "OpenID";
     private const string SamlProtocol = "SAML";
@@ -1816,7 +1820,11 @@ public class SSOController : ControllerBase
             return NotFound("No Jellyfin account exists with that user id.");
         }
 
-        var parsed = ParseMode(mode);
+        if (RefuseUnknownMode(mode, out var parsed) is { } unknownMode)
+        {
+            return unknownMode;
+        }
+
         var result = _canonicalLinks.TryPreprovisionLink(parsed, provider, canonicalName, jellyfinUserId);
         if (result == CanonicalLinkWriteResult.Created)
         {
@@ -1941,7 +1949,12 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        return ParseMode(mode) switch
+        if (RefuseUnknownMode(mode, out var parsed) is { } unknownMode)
+        {
+            return unknownMode;
+        }
+
+        return parsed switch
         {
             ProviderMode.Saml => SamlLink(provider, jellyfinUserId, authResponse),
             ProviderMode.Oid => OidLink(provider, jellyfinUserId, authResponse),
@@ -1976,7 +1989,12 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        var removal = _canonicalLinks.TryRemoveLink(ParseMode(mode), provider, canonicalName, jellyfinUserId);
+        if (RefuseUnknownMode(mode, out var parsed) is { } unknownMode)
+        {
+            return unknownMode;
+        }
+
+        var removal = _canonicalLinks.TryRemoveLink(parsed, provider, canonicalName, jellyfinUserId);
 
         // Terminate the user's already-issued tokens ONLY when this unlink removed their LAST canonical SSO
         // link (#468) - the terminal "can no longer SSO in at all" state that matches the hard-lockdown
@@ -2101,12 +2119,18 @@ public class SSOController : ControllerBase
     // Parse the {mode} route token once, at the HTTP boundary (#369): every link endpoint routes its raw
     // route string through here, so the protocol is validated in exactly one place and the typed
     // ProviderMode is threaded inward - no inner layer re-parses or re-compares the string. Fail closed: an
-    // unknown token throws (an ArgumentException, surfacing as the same rejection the two former divergent
-    // ToLower()/ToLowerInvariant() dispatches produced), never defaulting to a protocol.
-    private static ProviderMode ParseMode(string mode) =>
-        ProviderModeParser.TryParse(mode, out var parsed)
-            ? parsed
-            : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'", nameof(mode));
+    // unknown token refuses, never defaulting to a protocol.
+    //
+    // The refusal is a mapped 400 rather than a throw (#1399). Fail-closed is unchanged; what changed is who
+    // decides the wire behaviour. A throw left the status and the body to the host's exception middleware,
+    // making this the one input on this surface whose answer is not decided in this repository, while every
+    // neighbouring refusal renders a chosen status with a chosen body (400 empty key, 400 unknown provider,
+    // 404 unknown user id, 409 subject linked elsewhere). A route token typed wrong in a provisioning tool's
+    // configuration is the ordinary way this input arrives, so an integrator needs a status they can depend
+    // on. The body names the two accepted tokens and never echoes the supplied one, which would reflect
+    // caller-controlled text into the response.
+    private static BadRequestObjectResult? RefuseUnknownMode(string mode, out ProviderMode parsed) =>
+        ProviderModeParser.TryParse(mode, out parsed) ? null : new BadRequestObjectResult(UnknownModeMessage);
 
     // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382, #516): null when the
     // request may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login

--- a/docs/ACCOUNT-MANAGEMENT-API.md
+++ b/docs/ACCOUNT-MANAGEMENT-API.md
@@ -51,12 +51,12 @@ it on, and it keys on the connection's remote address only. Of the endpoints on
 this page:
 
 - the pre-provision write, the unlink and the link-backup restore share the
-  `link` budget (`SSOController.cs:1806`, `:1974`, `:1563`)
-- the revoke has its own `unregister` budget (`SSOController.cs:1658`)
+  `link` budget (`SSOController.cs:1810`, `:1974`, `:1563`)
+- the revoke has its own `unregister` budget (`SSOController.cs:1662`)
 - the per-account link export has its own `export` budget
-  (`SSOController.cs:1428`)
+  (`SSOController.cs:1432`)
 - the SSO-managed status read and the two per-user link listings are not
-  rate-limited at all (`SSOController.cs:1741`, `:2020`, `:2038`)
+  rate-limited at all (`SSOController.cs:1745`, `:2020`, `:2038`)
 
 When the limiter refuses a request the response is `429` with a plain-text body
 and a `Retry-After` header carrying whole seconds
@@ -100,7 +100,7 @@ Content-Type: application/json
 "the-canonical-name"
 ```
 
-`SSOController.cs:1798`. `mode` is `oid` or `saml`, case-insensitive. `provider`
+`SSOController.cs:1802`. `mode` is `oid` or `saml`, case-insensitive. `provider`
 is the provider name as configured on the settings page. `jellyfinUserId` is the
 GUID of an account that already exists. The body is a bare JSON string, not an
 object.
@@ -114,13 +114,13 @@ exactly one behaviour, described under the conflict below.
 
 Responses:
 
-| Status | Meaning                                                                 |
-| ------ | ----------------------------------------------------------------------- |
-| 204    | The link was written, or the identical mapping already existed          |
-| 400    | The canonical name was empty, or no provider of that name is configured |
-| 404    | No Jellyfin account holds that user id                                  |
-| 409    | That canonical name is already linked to a different Jellyfin account   |
-| 429    | The `link` budget for this client is exhausted; see `Retry-After`       |
+| Status | Meaning                                                                                                     |
+| ------ | ----------------------------------------------------------------------------------------------------------- |
+| 204    | The link was written, or the identical mapping already existed                                              |
+| 400    | The canonical name was empty, `mode` is neither `oid` nor `saml`, or no provider of that name is configured |
+| 404    | No Jellyfin account holds that user id                                                                      |
+| 409    | That canonical name is already linked to a different Jellyfin account                                       |
+| 429    | The `link` budget for this client is exhausted; see `Retry-After`                                           |
 
 The 409 is the collision behaviour worth designing around. Repeating the same
 mapping succeeds with 204, so a retry after a lost response is safe. Rebinding a
@@ -139,11 +139,16 @@ capability, and every grant path treats a disabled provider like a deleted one
 disabled, because disable-then-clean-up is the ordinary workflow
 (`CanonicalLinkService.cs:1225-1228`).
 
-A `mode` that is neither `oid` nor `saml` throws at the parse boundary
-(`SSOController.cs:2106`, pinned by
-`SSO-Auth.Tests/Http/SSOControllerLinkTests.cs:91`). What status the caller then
-sees is decided by the server's exception middleware rather than by this plugin,
-so do not depend on a particular one; send a valid mode.
+A `mode` that is neither `oid` nor `saml` is refused with `400` and the body
+`The mode segment must be 'oid' or 'saml'.` The parse happens once at the
+controller boundary and all three routes carrying a `{mode}` segment answer
+identically (`SSOController.cs:2132`, pinned across the three by
+`SSO-Auth.Tests/Http/SSOControllerLinkTests.cs:118`). The body is fixed text and
+never repeats the token that was sent.
+
+Until #1399 this input threw and the status was whatever the server's exception
+middleware produced, which made it the one refusal on this surface a caller could
+not depend on. It is decided here now.
 
 A successful write is audited as a pre-provision, naming the administrator that
 drove it (`SSO-Auth/Api/Audit/SsoAudit.cs:288`).
@@ -158,7 +163,7 @@ to bind to, and the binding is taken on the identity's first real login instead.
 GET /sso/SSO-Managed/Status/{jellyfinUserId}
 ```
 
-`SSOController.cs:1741`. Returns `200` with two booleans, or `404` when no such
+`SSOController.cs:1745`. Returns `200` with two booleans, or `404` when no such
 account exists.
 
 ```json
@@ -185,7 +190,7 @@ GET /sso/oid/links/{jellyfinUserId}
 GET /sso/saml/links/{jellyfinUserId}
 ```
 
-`SSOController.cs:2038` and `:2020`. One protocol each. Both return a map of
+`SSOController.cs:2056` and `:2020`. One protocol each. Both return a map of
 provider name to the list of canonical names linked to that account under that
 provider, so an account with no links under a configured provider yields an empty
 list rather than a missing key.
@@ -199,7 +204,7 @@ check lets a user read their own links. An administrator reads anybody's.
 GET /sso/Links/Export/{jellyfinUserId}
 ```
 
-`SSOController.cs:1421`. Both protocols at once, in the same document shape the
+`SSOController.cs:1425`. Both protocols at once, in the same document shape the
 whole-table export produces, or `404` when no such account exists. This is the
 route to use when answering a data-subject access request for one person, since
 it produces that subject's linkages without handing over everybody else's.
@@ -216,14 +221,14 @@ Content-Type: application/json
 <the document GET /sso/Config/Links/Export produced>
 ```
 
-`SSOController.cs:1552`. Restores an account-link backup onto this instance,
+`SSOController.cs:1556`. Restores an account-link backup onto this instance,
 rebinding every link to the user id this server holds for that username today.
 It is the half that completes a server migration: links are stored against
 Jellyfin user ids, a rebuilt user database issues new ids, and only a
 username-keyed document can be restored against it.
 
 The document it accepts is exactly what `GET /sso/Config/Links/Export` returns
-(`SSOController.cs:1368`). Post that file back unmodified; nothing has to be
+(`SSOController.cs:1372`). Post that file back unmodified; nothing has to be
 rewritten between the two calls.
 
 ### The document shape
@@ -271,7 +276,7 @@ rather than restored onto a provider no login would resolve.
 Every entry is checked before a single link is written, and the first failure
 rejects the whole document (`LinkImport.cs:64-85`, `:174-182`). The mutation runs
 inside `MutateConfiguration`, which persists nothing when the mutation throws
-(`SSOController.cs:1592-1593`), so a rejected import leaves the stored link table
+(`SSOController.cs:1596-1597`), so a rejected import leaves the stored link table
 exactly as it was. This is the property to know before running it once: the
 instance either gets its complete link table back or is left untouched, and there
 is no half-applied state that looks restored and is not.
@@ -317,11 +322,11 @@ holding is what locates the entry instead (`LinkImport.cs:265-271`).
 | Status | Meaning                                                                                                                         |
 | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | 204    | The document was applied; every link it named is now bound to this instance's accounts                                          |
-| 400    | The body bound to nothing: `The link import document is missing or is not valid JSON.` (`SSOController.cs:1570`)                |
-| 400    | The version is unsupported, or an entry is unrestorable; the body carries the refusal text above (`SSOController.cs:1595-1600`) |
+| 400    | The body bound to nothing: `The link import document is missing or is not valid JSON.` (`SSOController.cs:1574`)                |
+| 400    | The version is unsupported, or an entry is unrestorable; the body carries the refusal text above (`SSOController.cs:1599-1604`) |
 | 429    | The `link` budget for this client is exhausted; see `Retry-After`                                                               |
 
-The route carries a one-mebibyte request-size limit (`SSOController.cs:1553`,
+The route carries a one-mebibyte request-size limit (`SSOController.cs:1557`,
 `:62`). A larger body is refused by the server before the action runs, so the
 plugin decides neither the status nor the body in that case.
 
@@ -345,21 +350,21 @@ last.
 DELETE /sso/{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}
 ```
 
-`SSOController.cs:1961`. Removes exactly one mapping.
+`SSOController.cs:1974`. Removes exactly one mapping.
 
-| Status | Meaning                                                               |
-| ------ | --------------------------------------------------------------------- |
-| 200    | The link was removed                                                  |
-| 400    | No provider of that name is configured                                |
-| 403    | The caller may not edit that user's links                             |
-| 404    | No link is registered for that canonical name                         |
-| 409    | The canonical name is registered, but to a different Jellyfin user id |
-| 429    | The `link` budget for this client is exhausted                        |
+| Status | Meaning                                                                       |
+| ------ | ----------------------------------------------------------------------------- |
+| 200    | The link was removed                                                          |
+| 400    | `mode` is neither `oid` nor `saml`, or no provider of that name is configured |
+| 403    | The caller may not edit that user's links                                     |
+| 404    | No link is registered for that canonical name                                 |
+| 409    | The canonical name is registered, but to a different Jellyfin user id         |
+| 429    | The `link` budget for this client is exhausted                                |
 
 Removing a user's last link across both protocols also revokes their active
 sessions, because a link removal only fails future logins closed and a token
 minted earlier would otherwise stay valid until it expired
-(`SSOController.cs:1995-1997`). Removing a link while the user still holds another one
+(`SSOController.cs:2013-2015`). Removing a link while the user still holds another one
 does not revoke, so unlinking one provider does not log somebody out of a session
 they legitimately hold through another.
 
@@ -372,7 +377,7 @@ Content-Type: application/json
 "the-fallback-auth-provider-id"
 ```
 
-`SSOController.cs:1648`. Note that this one is keyed on the username, not on the
+`SSOController.cs:1652`. Note that this one is keyed on the username, not on the
 user id, unlike everything else above. The body is a bare JSON string naming the
 authentication provider the account is switched back to.
 
@@ -387,7 +392,7 @@ A revoke is not durable against re-adoption. When the provider the person signs
 in through has `AllowExistingAccountLink` enabled, a later SSO login can re-adopt
 the same-named local account and the link comes back. With the fail-closed
 default, where adoption is off, the revoke is durable
-(`SSOController.cs:1671-1674`).
+(`SSOController.cs:1675-1678`).
 
 A revoke of one's own account terminates one's own sessions too, including the
 administrator session that issued the call.


### PR DESCRIPTION
# What & why

Three account-link routes carry a `{mode}` segment in their path, and all three
parse it at one boundary. A token that is neither `oid` nor `saml` refused by
throwing. The refusal is correct and stays; what it left open is everything after
it. The status and the body a caller then sees were produced by the host's
exception middleware, so this was the one input on this surface whose wire answer
is not decided in this repository, while its four neighbours each render a status
and a body chosen here:

- 400 for an empty canonical name, with its own body
- 400 for a provider nobody configured, with a different body
- 404 for a Jellyfin user id nobody holds
- 409 for a subject already linked elsewhere

The parse now returns a mapped 400 carrying one fixed sentence naming the two
accepted tokens, on all three routes.

This matters because of where the value comes from. The pre-provision write is
the endpoint a provisioning tool drives, its `{mode}` is read out of that tool's
own configuration, and a typo there is the ordinary way this input arrives. The
account-management API page had to tell integrators not to depend on the status.
It now states it.

What did not change:

- Fail-closed. An unrecognised token still refuses and still never defaults to a
  protocol.
- The position of the check. In each of the three routes the parse sits exactly
  where it sat before, after the authorization guard and after the rate-limit
  gate, so no ordering moves and no rate-limit oracle appears.
- What the response discloses. The body is fixed text and never echoes the token
  that was sent, so caller-controlled bytes are not reflected into a response an
  administrator's tooling renders. There is nothing an integrator learns from
  seeing their own typo repeated that the fixed sentence does not tell them.

Closes #1399

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader, and the two unticked boxes stay unticked.** This change had
one reader, its author. The evidence stands in place of a second one and is
below rather than described.

The property carrying the security weight is that nothing about the refusal moved
except its rendering. Read at the three call sites: the parse is still the last
thing before the work in `PreprovisionCanonicalLink`, after the 404 for a user id
nobody holds, and still the first thing after `RateLimitCheck` in
`AddCanonicalLink` and `DeleteCanonicalLink`. An unauthorised caller is still
refused 403 by the guard ahead of all of it, so the new 400 is reachable only by
a caller who was already allowed to make the request.

Nothing here touches SAML or OpenID validation, config persistence, or the
release pipeline. The one log-adjacent question, whether the mistyped token
reaches a log line or a response body, is answered by the body being a constant,
and it is pinned by a test.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The helper replaces a helper rather than adding one, and it reuses the
`is { } refusal` idiom the controller already uses for its rate-limit gate, so
the three call sites read like their neighbours.
`docs/ACCOUNT-MANAGEMENT-API.md` is updated in this change, including both status
tables, and a CHANGELOG entry is included.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, warnings as errors, full suite:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3305, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,331s

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3306, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,416s
```

Four tests are skipped on both legs. One of them is disclosed rather than worked
around:
`PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback`
skips because binding a listener off loopback raises a Windows firewall consent
dialog that needs an administrator (#1227). It was not run here, and no attempt
was made to make it run.

The guard was proven by deleting it. Putting the throw back in
`RefuseUnknownMode` and re-running the mode tests:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*Mode*"
   SSO-Auth.Tests  Total: 49, Errors: 0, Failed: 4, Skipped: 0, Not Run: 0, Time: 0,653s
```

Four red, including `EveryModeCarryingRoute_RefusesAnUnknownModeWithTheSameBody`,
which is the one asserting the three routes agree. The real implementation is
what is committed here; that run was a falsifier and was reverted.

Prettier over the changed Markdown:

```
$ npx prettier --check docs/ACCOUNT-MANAGEMENT-API.md
Checking formatting...
All matched files use Prettier code style!
```

`CHANGELOG.md` does not pass `prettier --check`, and did not before this change
either. It is left as it is rather than reformatted in a change about something
else. The added entry itself is byte-identical to what Prettier would write,
checked by formatting a copy and diffing the block.

## Notes

The first done-condition on the issue asks for a run against a live server
recording what the host returns for this input today. **It was not made.** The
issue's second condition is the other arm of an either/or, and taking it removes
the thing that would have been measured: the host no longer sees this input,
because the boundary answers it first. The measurement would document behaviour
this change deletes.

The `docs/ACCOUNT-MANAGEMENT-API.md` diff is larger than the sentence it
replaces. Every `SSOController.cs:N` citation on that page moved when the
controller gained lines, so all of them were re-pointed, and each one was checked
by printing the line it names. Two status tables gained the new row text and
Prettier re-aligned their columns.
