### PR TITLE
Declare providers from the environment, under the same rules as the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **Providers can be declared entirely in environment variables (#1097).** A
+  deployment that describes its identity providers in a mounted file can now
+  describe them in its own environment instead, under the same rules and through
+  the same apply. A variable names a path into the configuration with `__`
+  between the steps, which is the separator a compose file or a Kubernetes
+  manifest already uses elsewhere, so
+  `JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidClientId` sets the client id of
+  the provider called `keycloak`, and `__Roles__0` sets the first entry of a
+  list. The names are resolved against the configuration itself rather than
+  against a list somebody maintains, so every field of an OpenID or SAML
+  provider is settable under its own name, and a field added later is settable
+  the day it arrives. Setting none of these leaves the server behaving exactly as
+  it did before. A variable the plugin cannot place refuses the whole
+  environment instead of applying the rest: a misspelled name, a value that is
+  not the field's type, a gap in a numbered list, and a name aimed at something
+  the server manages for itself are all refusals, and a refusal leaves the stored
+  configuration untouched. Two things are worth knowing before writing one. A
+  provider is declared whole, exactly as it is in a mounted file, because the
+  merge works provider by provider: naming a single field of a provider that
+  already exists leaves the rest of that provider at its defaults, and on an
+  OpenID provider that counts as repointing it, which clears its account links.
+  And where a file and the environment both describe the same provider, the
+  environment is applied second and wins, while a provider neither of them names
+  is left exactly as it was. The rate-limit tuning and the SSO-only switch are
+  not settable this way, because no declarative source applies them; a variable
+  naming one is refused rather than quietly ignored.
+
 - **The account-link roster now reports the last SSO login (#1120).** Each link
   in the roster carries the moment a login last signed in through it, so an
   administrator can tell a live link from one nobody has used. Nothing is added

--- a/SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs
@@ -1,0 +1,554 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="DeclarativeEnvironmentConfig"/> - the environment half of the declarative provider
+/// configuration (#1097). The merge itself belongs to <see cref="ConfigImport"/> and the atomicity to
+/// <see cref="DeclarativeProviderConfig"/>, both already pinned elsewhere; what is pinned here is what this
+/// source adds: the naming scheme and its type handling, that no field of the model is silently
+/// unconfigurable, that anything under the prefix this source cannot place refuses the whole environment
+/// rather than half-configuring a provider, and the silent no-op when nothing is set. The store is driven
+/// with local delegates and a supplied variable map, so no plugin instance and no process environment are
+/// involved.
+/// </summary>
+public class DeclarativeEnvironmentConfigTests
+{
+    private const string Endpoint = "https://idp.example.invalid/.well-known/openid-configuration";
+    private const string ClientId = "the-client";
+
+    private static (ProviderConfigStore Store, PluginConfiguration Live, List<BasePluginConfiguration> Persisted) CreateStore()
+    {
+        var live = new PluginConfiguration();
+        var persisted = new List<BasePluginConfiguration>();
+        return (new ProviderConfigStore(() => live, persisted.Add, new CapturingLogger()), live, persisted);
+    }
+
+    private static string Xml(PluginConfiguration configuration)
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        new XmlSerializer(typeof(PluginConfiguration)).Serialize(writer, configuration);
+        return writer.ToString();
+    }
+
+    private static Dictionary<string, string?> Variables(params (string Name, string? Value)[] entries)
+    {
+        var map = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            // A variable this source does not own, present in every case, so "reads only its own prefix" is
+            // exercised by every test rather than by one.
+            ["PATH"] = "/usr/bin",
+            [DeclarativeProviderConfig.SourcePathVariable] = "/run/secrets/sso.json",
+        };
+
+        foreach (var (name, value) in entries)
+        {
+            map[name] = value;
+        }
+
+        return map;
+    }
+
+    private static (string Name, string? Value) Oid(string provider, string field, string? value) =>
+        ($"{DeclarativeEnvironmentConfig.Prefix}OidConfigs__{provider}__{field}", value);
+
+    private static DeclarativeLoadOutcome Load(
+        ProviderConfigStore store,
+        Dictionary<string, string?> variables,
+        CapturingLogger? logger = null) =>
+        DeclarativeEnvironmentConfig.Apply(store, variables, logger);
+
+    // A provider the validator accepts, spelled entirely in variables.
+    private static (string Name, string? Value)[] AWorkingProvider(string provider = "keycloak") =>
+    [
+        Oid(provider, "OidEndpoint", Endpoint),
+        Oid(provider, "OidClientId", ClientId),
+        Oid(provider, "Enabled", "true"),
+    ];
+
+    [Fact]
+    public void NoVariableUnderThePrefix_ReadsNothing_WritesNothing_AndSaysSo()
+    {
+        // The pin the whole feature rests on. An installation that sets none of these must behave exactly as
+        // one built before this existed, and the neighbouring variable named by the FILE source must not be
+        // mistaken for one of ours - its name starts with the same letters.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+
+        Assert.Equal(DeclarativeLoadOutcome.NotConfigured, Load(store, Variables()));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+    }
+
+    [Fact]
+    public void AProviderSpelledInVariables_IsApplied()
+    {
+        var (store, live, persisted) = CreateStore();
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, Variables(AWorkingProvider())));
+
+        var applied = Assert.IsType<PluginConfiguration>(Assert.Single(persisted));
+        Assert.Equal(Endpoint, applied.OidConfigs["keycloak"].OidEndpoint);
+        Assert.Equal(ClientId, applied.OidConfigs["keycloak"].OidClientId);
+        Assert.True(applied.OidConfigs["keycloak"].Enabled);
+        Assert.Equal(Endpoint, live.OidConfigs["keycloak"].OidEndpoint);
+    }
+
+    [Fact]
+    public void AProviderNobodyDeclared_IsLeftExactlyAsItIs()
+    {
+        // The precedence is a MERGE, inherited from the import the file source already goes through. A
+        // deployment that declares one provider from the environment does not lose the ones it configured on
+        // the settings page.
+        var (store, live, _) = CreateStore();
+        live.OidConfigs["already-there"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "kept", Enabled = true };
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, Variables(AWorkingProvider())));
+
+        Assert.Equal("kept", live.OidConfigs["already-there"].OidClientId);
+        Assert.Equal(ClientId, live.OidConfigs["keycloak"].OidClientId);
+    }
+
+    [Theory]
+    [InlineData("EnableRateLimit", "false")]
+    [InlineData("RateLimitMaxAttempts", "7")]
+    [InlineData("DisablePasswordLogin", "true")]
+    [InlineData("BreakGlassAdminUsername", "root")]
+    public void ASettingTheApplyDoesNotReach_IsRefusedRatherThanDropped(string field, string value)
+    {
+        // These four are deliberately not applied by ConfigImport: instance-local operational tuning with no
+        // blank-means-keep signal, and a mode that needs a user manager to prove a surviving password door.
+        // Accepting a variable for one of them would write it into the document and let the apply drop it,
+        // which is a configuration that reads as applied and changed nothing - the exact failure the
+        // hard-error rule exists against. Delete the DeclaredSurface check and this goes red, because the
+        // variable would be accepted and the setting would still not move.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Rejected,
+            Load(store, Variables(($"{DeclarativeEnvironmentConfig.Prefix}{field}", value))));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+    }
+
+    [Fact]
+    public void AWholeNumberOnAProvider_IsRead()
+    {
+        var (store, live, _) = CreateStore();
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            Load(store, Variables([.. AWorkingProvider(), Oid("keycloak", "MaxAge", "300")])));
+
+        Assert.Equal(300, live.OidConfigs["keycloak"].MaxAge);
+    }
+
+    [Fact]
+    public void AListIsAddressedByIndexFromZero()
+    {
+        var (store, live, _) = CreateStore();
+        var variables = Variables(
+            [
+                .. AWorkingProvider(),
+                Oid("keycloak", "Roles__0", "media"),
+                Oid("keycloak", "Roles__1", "staff"),
+            ]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, variables));
+
+        Assert.Equal(new[] { "media", "staff" }, live.OidConfigs["keycloak"].Roles);
+    }
+
+    [Fact]
+    public void AListOfObjects_IsAddressedByIndexThenField()
+    {
+        // The role maps are lists of objects, which is the shape a table of environment variables is worst
+        // at. It is reachable under the same rule as everything else rather than under a special case.
+        var (store, live, _) = CreateStore();
+        var variables = Variables(
+            [
+                .. AWorkingProvider(),
+                Oid("keycloak", "EnableFolderRoles", "true"),
+                Oid("keycloak", "FolderRoleMapping__0__Role", "staff"),
+                Oid("keycloak", "FolderRoleMapping__0__Folders__0", "library-a"),
+            ]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, variables));
+
+        var mapping = Assert.Single(live.OidConfigs["keycloak"].FolderRoleMapping!);
+        Assert.Equal("staff", mapping.Role);
+        Assert.Equal(new[] { "library-a" }, mapping.Folders);
+    }
+
+    [Fact]
+    public void AVariableSpelledInAnotherCase_ReachesTheSameField()
+    {
+        // The mounted file matches a member without regard to case because it is hand-written as often as it
+        // is exported. A variable is hand-written every time, so it holds the same rule.
+        var (store, live, _) = CreateStore();
+        var variables = Variables(
+            [
+                .. AWorkingProvider(),
+                Oid("keycloak", "hideloginbutton", "true"),
+            ]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, variables));
+
+        Assert.True(live.OidConfigs["keycloak"].HideLoginButton);
+    }
+
+    [Fact]
+    public void AProviderNameIsTakenVerbatim()
+    {
+        // A key names a provider the operator chose. Matching it against anything, or normalising its case,
+        // would make the environment address a different provider from the one the settings page shows.
+        var (store, live, _) = CreateStore();
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, Variables(AWorkingProvider("KeyCloak-Prod"))));
+
+        Assert.True(live.OidConfigs.ContainsKey("KeyCloak-Prod"));
+        Assert.False(live.OidConfigs.ContainsKey("keycloak-prod"));
+    }
+
+    [Fact]
+    public void ASecretIsSetDirectly()
+    {
+        // #1096 refuses a spelled-out secret in the mounted FILE and takes a reference, and one of the two
+        // reference forms it accepts is an environment variable. This is that variable, so a value here is
+        // the same disclosure the file's reference form already points at.
+        var (store, live, _) = CreateStore();
+        var variables = Variables([.. AWorkingProvider(), Oid("keycloak", "OidSecret", "s3cret")]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, variables));
+
+        Assert.False(string.IsNullOrEmpty(live.OidConfigs["keycloak"].OidSecret));
+    }
+
+    [Fact]
+    public void AnUnrecognisedVariableUnderThePrefix_RefusesEverything()
+    {
+        // The load-bearing refusal. A typo in one variable must not leave the other nine applied: a provider
+        // carrying most of what a deployment asked for is a provider whose remaining fields silently hold
+        // whatever was there before, which is the failure this whole source exists to remove. Delete the
+        // refusal in TryResolveStep and this test goes red on the second assertion, because the good
+        // variables would apply around the bad one.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+        var before = Xml(live);
+        var variables = Variables(
+            [
+                .. AWorkingProvider(),
+                Oid("keycloak", "OidClientld", "typo-in-the-field-name"),
+            ]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, variables, logger));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.False(live.OidConfigs.ContainsKey("keycloak"));
+    }
+
+    [Theory]
+    [InlineData("Enabled", "yes")]
+    [InlineData("Enabled", "1")]
+    [InlineData("MaxAge", "soon")]
+    [InlineData("MaxAge", "1.5")]
+    public void AValueThatIsNotTheFieldsType_RefusesEverything(string field, string value)
+    {
+        var (store, live, persisted) = CreateStore();
+        var variables = Variables([.. AWorkingProvider(), Oid("keycloak", field, value)]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, variables));
+
+        Assert.Empty(persisted);
+        Assert.False(live.OidConfigs.ContainsKey("keycloak"));
+    }
+
+    [Fact]
+    public void AListWithAHoleInIt_RefusesEverything()
+    {
+        // Index 1 without index 0 deserializes to a list whose first entry is null, which is a different
+        // configuration from the one that was written and reads downstream as an empty role rather than as a
+        // mistake. Refused rather than closed up, because closing it up would silently renumber what the
+        // operator wrote.
+        var (store, live, persisted) = CreateStore();
+        var variables = Variables([.. AWorkingProvider(), Oid("keycloak", "Roles__1", "staff")]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, variables));
+
+        Assert.Empty(persisted);
+        Assert.False(live.OidConfigs.ContainsKey("keycloak"));
+    }
+
+    [Theory]
+    [InlineData("CanonicalLinkIssuers__somebody", "https://idp.example.invalid/")]
+    [InlineData("CanonicalLinks__somebody", "00000000-0000-0000-0000-000000000001")]
+    public void AServerManagedFieldCannotBeSet(string field, string value)
+    {
+        // The link maps and the issuer bindings are withheld from the JSON boundary and re-injected on every
+        // write, so a variable aimed at one would be accepted, written into the document and then dropped by
+        // the deserializer - a configuration that looks applied and is not. They are refused by name instead.
+        //
+        // The first case is the one that proves the refusal rather than something else: its value type is a
+        // plain string, so with the JsonIgnore check deleted the variable is placed happily and the whole
+        // environment applies while that field stays empty. Delete the check and this case goes red.
+        var (store, live, persisted) = CreateStore();
+        var variables = Variables([.. AWorkingProvider(), Oid("keycloak", field, value)]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, variables));
+
+        Assert.Empty(persisted);
+        Assert.False(live.OidConfigs.ContainsKey("keycloak"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("OidConfigs__")]
+    [InlineData("OidConfigs____keycloak")]
+    public void APathThatIsNotOne_RefusesEverything(string path)
+    {
+        var (store, _, persisted) = CreateStore();
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Rejected,
+            Load(store, Variables(($"{DeclarativeEnvironmentConfig.Prefix}{path}", "x"))));
+
+        Assert.Empty(persisted);
+    }
+
+    [Fact]
+    public void AProviderTheValidatorRefuses_LeavesTheStoredConfigurationByteIdentical()
+    {
+        // The refusal comes from the same validator every other write path uses, reached through the same
+        // apply, so this pins the reach rather than the rule: a base-URL override that is not an absolute
+        // http(s) origin is refused on the settings page and on an import, and it is refused here too. What
+        // matters is that reaching it from the environment leaves nothing behind.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var variables = Variables([.. AWorkingProvider(), Oid("keycloak", "BaseUrlOverride", "not-an-absolute-url")]);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, variables));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.False(live.OidConfigs.ContainsKey("keycloak"));
+    }
+
+    [Fact]
+    public void TheSameEnvironmentAppliedTwice_WritesNothingTheSecondTime()
+    {
+        // A container restarts with the same variables every time. If that rewrote config.xml on every boot,
+        // the feature would churn the file it is meant to describe.
+        var (store, _, persisted) = CreateStore();
+        var variables = Variables(AWorkingProvider());
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, variables));
+        Assert.Single(persisted);
+
+        Assert.Equal(DeclarativeLoadOutcome.AlreadyCurrent, Load(store, variables));
+        Assert.Single(persisted);
+    }
+
+    [Fact]
+    public void TheEnvironmentWinsOverAMountedFile_AndOverWhatIsStored()
+    {
+        // The precedence rule, asserted across both sources rather than described. The two are applied in the
+        // order the plugin's constructor applies them: the file first, the environment second. The unit of
+        // precedence is a PROVIDER, because the apply merges by provider - so the environment declares the
+        // provider whole, exactly as the file does.
+        var (store, live, _) = CreateStore();
+        live.OidConfigs["untouched"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "stored", Enabled = true };
+
+        var file = new PluginConfiguration();
+        file.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            Enabled = true,
+        };
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            DeclarativeProviderConfig.Apply(
+                store,
+                "/run/secrets/sso.json",
+                _ => true,
+                _ => System.Text.Json.JsonSerializer.Serialize(new ConfigExportDocument
+                {
+                    FormatVersion = ConfigExport.FormatVersion,
+                    Configuration = file,
+                }),
+                null));
+
+        Assert.Equal("from-the-file", live.OidConfigs["keycloak"].OidClientId);
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            Load(store, Variables(
+                Oid("keycloak", "OidEndpoint", Endpoint),
+                Oid("keycloak", "OidClientId", "from-the-environment"),
+                Oid("keycloak", "Enabled", "true"))));
+
+        Assert.Equal("from-the-environment", live.OidConfigs["keycloak"].OidClientId);
+        Assert.Equal(Endpoint, live.OidConfigs["keycloak"].OidEndpoint);
+
+        // Neither source named this one, so neither touched it.
+        Assert.Equal("stored", live.OidConfigs["untouched"].OidClientId);
+    }
+
+    [Fact]
+    public void NamingOneFieldOfAnExistingProvider_LeavesTheRestAtItsDefaults()
+    {
+        // The trap worth pinning rather than only documenting: the apply merges by provider, so a partial
+        // declaration is a whole provider whose other fields are defaults - and on an OpenID provider a
+        // blanked client id is a repoint, which clears that provider's links. A deployment declares every
+        // field of a provider it owns from the environment.
+        var (store, live, _) = CreateStore();
+        live.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "was-here",
+            Enabled = true,
+            HideLoginButton = true,
+        };
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            Load(store, Variables(Oid("keycloak", "OidEndpoint", Endpoint))));
+
+        Assert.Equal(Endpoint, live.OidConfigs["keycloak"].OidEndpoint);
+        Assert.Equal(string.Empty, live.OidConfigs["keycloak"].OidClientId);
+        Assert.False(live.OidConfigs["keycloak"].HideLoginButton);
+    }
+
+    [Fact]
+    public void EveryProviderFieldTheModelCarries_IsReachableFromTheEnvironment()
+    {
+        // The guard behind the whole naming scheme, and the reason the scheme is resolved against the model
+        // instead of against a table somebody maintains. It walks the configuration types and asserts that
+        // every settable property is addressable and lands on a leaf kind this source can write, so a field
+        // added tomorrow is either reachable or fails the build - never silently unconfigurable.
+        //
+        // A property withheld from the JSON boundary is deliberately NOT expected to be reachable: it is
+        // server-managed, and refusing it is the behaviour AServerManagedFieldCannotBeSet pins.
+        var unreachable = new List<string>();
+        Walk(typeof(OidConfig), $"{DeclarativeEnvironmentConfig.Prefix}OidConfigs__[provider]", unreachable, []);
+        Walk(typeof(SamlConfig), $"{DeclarativeEnvironmentConfig.Prefix}SamlConfigs__[provider]", unreachable, []);
+
+        Assert.Empty(unreachable);
+    }
+
+    [Fact]
+    public void TheReachabilityWalkActuallyWalksSomething()
+    {
+        // A walk that visited nothing would pass the test above while proving nothing, which is the way an
+        // emptiness assertion usually goes wrong. Pin the population instead of trusting it.
+        var visited = new List<string>();
+        WalkNames(typeof(OidConfig), visited, []);
+        WalkNames(typeof(SamlConfig), visited, []);
+
+        Assert.Contains($"{nameof(OidConfig)}.{nameof(OidConfig.OidClientId)}", visited);
+        Assert.Contains($"{nameof(SamlConfig)}.{nameof(SamlConfig.SamlEndpoint)}", visited);
+        Assert.Contains($"{nameof(FolderRoleMap)}.{nameof(FolderRoleMap.Folders)}", visited);
+        Assert.Contains($"{nameof(ProvisioningPolicyTemplate)}.{nameof(ProvisioningPolicyTemplate.SubtitleMode)}", visited);
+        Assert.True(visited.Count > 60, $"the walk reached only {visited.Count} properties");
+    }
+
+    private static void WalkNames(Type type, List<string> visited, HashSet<Type> seen)
+    {
+        if (!seen.Add(type))
+        {
+            return;
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.SetMethod is null
+                || !property.SetMethod.IsPublic
+                || property.GetCustomAttribute<JsonIgnoreAttribute>() is not null)
+            {
+                continue;
+            }
+
+            visited.Add($"{type.Name}.{property.Name}");
+            var slot = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+            while (DeclarativeEnvironmentConfig.TryResolveStep(slot, "0", out var inner, out _, out _) && inner != slot)
+            {
+                slot = inner;
+            }
+
+            if (slot != typeof(string) && slot != typeof(bool) && slot != typeof(int) && slot.IsClass)
+            {
+                WalkNames(slot, visited, seen);
+            }
+        }
+    }
+
+    private static void Walk(Type type, string path, List<string> unreachable, HashSet<Type> seen)
+    {
+        if (!seen.Add(type))
+        {
+            return;
+        }
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (property.SetMethod is null
+                || !property.SetMethod.IsPublic
+                || property.GetCustomAttribute<JsonIgnoreAttribute>() is not null)
+            {
+                continue;
+            }
+
+            var here = $"{path}__{property.Name}";
+            if (!DeclarativeEnvironmentConfig.TryResolveStep(type, property.Name, out var addressed, out _, out var rejection))
+            {
+                unreachable.Add($"{here}: {rejection}");
+                continue;
+            }
+
+            WalkSlot(addressed, here, unreachable, seen);
+        }
+    }
+
+    private static void WalkSlot(Type slot, string path, List<string> unreachable, HashSet<Type> seen)
+    {
+        if (slot == typeof(string) || slot == typeof(bool) || slot == typeof(int))
+        {
+            return;
+        }
+
+        // A dictionary or a list is one more step, and the step after it is the value's own surface. Driven
+        // through the same resolver the loader uses, so what the test walks is what the loader would walk.
+        if (DeclarativeEnvironmentConfig.TryResolveStep(slot, "0", out var inner, out _, out _)
+            && inner != slot)
+        {
+            WalkSlot(inner, $"{path}__0", unreachable, seen);
+            return;
+        }
+
+        if (slot.IsClass)
+        {
+            Walk(slot, path, unreachable, seen);
+            return;
+        }
+
+        unreachable.Add($"{path}: a {slot.Name} cannot be written as a single variable");
+    }
+}

--- a/SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
+++ b/SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
@@ -1,0 +1,516 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The environment half of the declarative provider configuration (#1097): the same document
+/// <see cref="DeclarativeProviderConfig"/> reads from a mounted file, expressed as environment variables
+/// and applied through the same <see cref="DeclarativeProviderConfig.ApplyDocument"/>. It ships alone - a
+/// deployment that sets variables and mounts no file is fully configured, and one that sets none is
+/// byte-identical to an installation built before this existed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A variable names a path into the document, with <c>__</c> between the steps, which is the hierarchy
+/// separator ASP.NET Core's own environment configuration provider uses and the one an operator writing a
+/// compose file or a Kubernetes manifest already knows:
+/// </para>
+/// <code>
+/// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidClientId=jellyfin
+/// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__Roles__0=media
+/// JELLYFIN_SSO_CONFIG__EnableRateLimit=true
+/// </code>
+/// <para>
+/// The steps are resolved against the configuration model itself rather than against a hand-written table
+/// of field names, so a field cannot be silently unconfigurable: a property added to
+/// <see cref="OidConfig"/> or <see cref="SamlConfig"/> is addressable the day it is added, under its own
+/// name, without an edit here. A step names a property (matched without regard to case, like the file
+/// source), a dictionary key (taken verbatim, so a provider may be called anything), or a list index (from
+/// zero). That the whole settable provider surface really is reachable is not a claim made here - it is
+/// derived by walking the model in
+/// <c>EveryProviderFieldTheModelCarries_IsReachableFromTheEnvironment</c>.
+/// </para>
+/// <para>
+/// The surface is the two provider maps and nothing else, which is exactly what a declarative apply reaches:
+/// <see cref="ConfigImport"/> deliberately leaves the rate-limit tuning and the SSO-only globals to the
+/// settings page. A variable naming one of those is REFUSED rather than accepted and dropped, so the
+/// environment never looks applied where it changed nothing.
+/// </para>
+/// <para>
+/// A PROVIDER IS DECLARED WHOLE, exactly as it is in the mounted file, because the apply merges by provider
+/// and not by field. Naming one field of a provider that already exists therefore leaves its other fields at
+/// their defaults rather than at what was there before - and on an OpenID provider a blanked endpoint or
+/// client id is a repoint, which clears that provider's account links and stored secret through the belt
+/// <see cref="ServerManagedFields"/> already carries (#186). Declare every field of a provider the
+/// environment owns. What is left alone is a provider the environment does not name at all.
+/// </para>
+/// <para>
+/// THE WHOLE SOURCE IS REFUSED AS A UNIT, and an unrecognised variable under the prefix is a refusal rather
+/// than something skipped. A typo is the ordinary failure here - the names are long and nothing completes
+/// them - and a skipped variable leaves a provider carrying half of what the deployment asked for, which is
+/// worse than one that does not start at all. So a step that names no property, a property withheld from
+/// this boundary, an index that leaves a hole in a list, and a value that is not of the field's type each
+/// reject everything and leave the stored configuration untouched.
+/// </para>
+/// <para>
+/// A property the JSON boundary withholds (<c>[JsonIgnore]</c>: the canonical link maps, the issuer
+/// bindings, the SSO-only bookkeeping) is refused by name instead of being accepted and dropped. Those are
+/// server-managed and are re-injected by <see cref="ServerManagedFields"/> on every write path, so a
+/// variable aimed at one would otherwise be accepted, written into the document, and silently discarded by
+/// the deserializer - the exact shape of a configuration that looks applied and is not.
+/// </para>
+/// <para>
+/// A secret IS spelled out here, unlike in the mounted file. #1096 refuses a value in the file and takes a
+/// reference instead, because the file is an artefact a deployment keeps beside its other tracked
+/// configuration, and one of the two reference forms that rule points at is an environment variable. This
+/// IS that environment variable, so requiring a reference from a variable to another variable would buy
+/// nothing.
+/// </para>
+/// <para>
+/// PRECEDENCE: the environment is applied after the mounted file, so where both name the same field the
+/// environment wins, and both win over what is stored. It is a merge on the same terms the file source
+/// already carries - a provider neither source names is left exactly as it is - because both go through one
+/// <see cref="ConfigImport"/>. The two are applied separately rather than merged into one document, so a
+/// refused environment leaves an accepted file standing rather than taking it down with it; each source is
+/// atomic in itself and neither is half-applied.
+/// </para>
+/// <para>
+/// Nothing here throws. This runs while the plugin is being constructed, where a throw takes the plugin, and
+/// with it every SSO login on the server, offline over a configuration mistake.
+/// </para>
+/// <para>
+/// One shape is out of reach and is stated rather than worked around: a provider whose NAME contains a
+/// double underscore cannot be addressed, because the name would be indistinguishable from two steps. Such
+/// a provider is configured from the mounted file or from the settings page.
+/// </para>
+/// </remarks>
+internal static class DeclarativeEnvironmentConfig
+{
+    /// <summary>
+    /// The prefix every variable of this source carries. Deliberately not a prefix of
+    /// <see cref="DeclarativeProviderConfig.SourcePathVariable"/> and not prefixed BY it: that variable ends
+    /// in a single underscore before <c>FILE</c>, this one in the double underscore that starts a path, so
+    /// neither can ever be read as the other.
+    /// </summary>
+    internal const string Prefix = "JELLYFIN_SSO_CONFIG__";
+
+    /// <summary>The separator between the steps of a path, and the same one ASP.NET Core uses.</summary>
+    internal const string Separator = "__";
+
+    /// <summary>
+    /// The only two members of the configuration a declarative apply reaches, read straight off
+    /// <see cref="ConfigImport"/>'s own behaviour rather than restated from it in prose.
+    /// </summary>
+    internal static readonly string[] DeclaredSurface = [nameof(PluginConfiguration.OidConfigs), nameof(PluginConfiguration.SamlConfigs)];
+
+    /// <summary>
+    /// Reads the process environment and applies whatever it declares to <paramref name="store"/>.
+    /// </summary>
+    /// <param name="store">The configuration store to apply through.</param>
+    /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <param name="revealStoredSecret">Recovers the plaintext of a secret as the store holds it (#1096); null skips that comparison.</param>
+    /// <returns>What the load did.</returns>
+    internal static DeclarativeLoadOutcome ApplyFromEnvironment(
+        ProviderConfigStore store,
+        ILogger? logger,
+        Func<string?, string?>? revealStoredSecret = null)
+    {
+        try
+        {
+            return Apply(store, ReadProcessEnvironment(), logger, revealStoredSecret);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            // The same instrument, and for the same reason, as the file source's outer catch: this is called
+            // from the plugin's constructor, so anything escaping fails the plugin load and takes every SSO
+            // login on the server offline. The typed refusals inside Apply name what was reasoned about;
+            // this names what was not, and refuses to let a configuration source decide whether the plugin
+            // exists.
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+            {
+                logger.LogError(
+                    ex,
+                    "The declarative SSO configuration from the environment could not be applied and nothing was changed. The plugin is running on its stored configuration.");
+            }
+
+            return DeclarativeLoadOutcome.Rejected;
+        }
+    }
+
+    /// <summary>
+    /// Applies what <paramref name="environment"/> declares, reading the variables from a supplied map so the
+    /// outcome can be driven without touching the process environment.
+    /// </summary>
+    /// <param name="store">The configuration store to apply through.</param>
+    /// <param name="environment">The variables, including ones this source does not own.</param>
+    /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <param name="revealStoredSecret">Recovers the plaintext of a secret as the store holds it (#1096); null skips that comparison.</param>
+    /// <returns>What the load did.</returns>
+    internal static DeclarativeLoadOutcome Apply(
+        ProviderConfigStore store,
+        IEnumerable<KeyValuePair<string, string?>> environment,
+        ILogger? logger,
+        Func<string?, string?>? revealStoredSecret = null)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        // Ordinal ordering, so two runs of the same environment build the same document and a rejection names
+        // the same variable each time. A dictionary's enumeration order is not a promise anybody made.
+        var declared = environment
+            .Where(entry => entry.Key.StartsWith(Prefix, StringComparison.Ordinal))
+            .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+            .ToList();
+
+        if (declared.Count == 0)
+        {
+            return DeclarativeLoadOutcome.NotConfigured;
+        }
+
+        var root = new JsonObject();
+        foreach (var entry in declared)
+        {
+            if (!TryPlace(root, entry.Key, entry.Value, out var rejection))
+            {
+                return DeclarativeProviderConfig.Reject(logger, Prefix, rejection);
+            }
+        }
+
+        if (FirstHoleInAList(root, Prefix) is { } hole)
+        {
+            return DeclarativeProviderConfig.Reject(logger, Prefix, hole);
+        }
+
+        PluginConfiguration? configuration;
+        try
+        {
+            configuration = root.Deserialize<PluginConfiguration>();
+        }
+        catch (JsonException)
+        {
+            // The reason is deliberately not the exception's own message. Every leaf above was written as the
+            // JSON kind its field is, so reaching here is a fault in this file rather than in the operator's
+            // variables - and a deserializer message can quote the document, which on this source is where the
+            // secrets are. The refusal says which source refused and nothing about what it held.
+            return DeclarativeProviderConfig.Reject(logger, Prefix, "the variables did not describe a configuration this plugin can read");
+        }
+        catch (NotSupportedException)
+        {
+            return DeclarativeProviderConfig.Reject(logger, Prefix, "the variables did not describe a configuration this plugin can read");
+        }
+
+        if (configuration is null)
+        {
+            return DeclarativeProviderConfig.Reject(logger, Prefix, "the variables produced no configuration");
+        }
+
+        return DeclarativeProviderConfig.ApplyDocument(
+            store,
+            new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = configuration },
+            Prefix,
+            logger,
+            revealStoredSecret);
+    }
+
+    /// <summary>
+    /// Resolves one step of a path against the type it is being read out of, which is the whole of the naming
+    /// scheme. Public to the tests so the reachability of every field the model carries is derived rather
+    /// than asserted.
+    /// </summary>
+    /// <param name="container">The type the step is resolved inside.</param>
+    /// <param name="step">The step: a property name, a dictionary key, or a list index.</param>
+    /// <param name="addressed">The type the step addresses, with any nullable wrapper removed.</param>
+    /// <param name="canonical">The step as the document spells it: a property's own casing, or the key or index verbatim.</param>
+    /// <param name="rejection">Why the step could not be resolved.</param>
+    /// <returns><see langword="true"/> when the step addresses something settable.</returns>
+    internal static bool TryResolveStep(Type container, string step, out Type addressed, out string canonical, out string? rejection)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        addressed = typeof(object);
+        canonical = step;
+        rejection = null;
+
+        if (ValueTypeOfDictionary(container) is { } value)
+        {
+            // A dictionary key is taken verbatim and is never matched against anything, because it names a
+            // provider the operator chose and this source has no opinion about what those are called.
+            addressed = Unwrap(value);
+            return true;
+        }
+
+        if (ElementTypeOfList(container) is { } element)
+        {
+            if (!int.TryParse(step, NumberStyles.None, CultureInfo.InvariantCulture, out var index) || index < 0)
+            {
+                rejection = $"'{step}' is not a list index";
+                return false;
+            }
+
+            addressed = Unwrap(element);
+            return true;
+        }
+
+        if (container == typeof(PluginConfiguration) && !DeclaredSurface.Contains(step, StringComparer.OrdinalIgnoreCase))
+        {
+            // The declarative apply reaches the two provider maps and nothing else. ConfigImport deliberately
+            // leaves the rate-limit tuning and the SSO-only globals alone - instance-local operational state
+            // with no blank-means-keep signal, and the SSO-only mode additionally needs a user manager to
+            // prove a surviving password door. A variable naming one of them would be accepted, written into
+            // the document and then dropped by the apply, which is the silently-unconfigurable field this
+            // source exists to make impossible. So it is refused, and the refusal says where the setting does
+            // live.
+            rejection = $"'{step}' is not applied by the declarative configuration; only {string.Join(" and ", DeclaredSurface)} are, and the rate-limit and SSO-only settings are changed on the settings page";
+            return false;
+        }
+
+        var property = container
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(candidate => string.Equals(candidate.Name, step, StringComparison.OrdinalIgnoreCase));
+
+        if (property is null || property.SetMethod is null || !property.SetMethod.IsPublic)
+        {
+            rejection = $"'{step}' names no field of {container.Name}";
+            return false;
+        }
+
+        if (property.GetCustomAttribute<JsonIgnoreAttribute>() is not null)
+        {
+            // Refused by name rather than accepted and dropped. These are the server-managed fields, and a
+            // variable aimed at one would otherwise look applied and change nothing at all.
+            rejection = $"'{property.Name}' is managed by the server and cannot be set from the environment";
+            return false;
+        }
+
+        addressed = Unwrap(property.PropertyType);
+
+        // The property's OWN casing reaches the document, not the operator's. A variable may be spelled in
+        // any case, exactly like a member of the mounted file, and what is built is spelled once.
+        canonical = property.Name;
+        return true;
+    }
+
+    // Walks the path and writes the value at its end, creating the objects and lists it passes through. The
+    // walk and the type resolution are the same ones the reachability test drives, so what the test proves is
+    // reachable is what this places.
+    private static bool TryPlace(JsonObject root, string variable, string? value, out string rejection)
+    {
+        rejection = string.Empty;
+        var path = variable[Prefix.Length..];
+        var steps = path.Split(Separator, StringSplitOptions.None);
+        if (steps.Length == 0 || steps.Any(string.IsNullOrEmpty))
+        {
+            rejection = $"'{variable}' names no path into the configuration";
+            return false;
+        }
+
+        JsonNode container = root;
+        var containerType = typeof(PluginConfiguration);
+
+        for (var i = 0; i < steps.Length; i++)
+        {
+            if (!TryResolveStep(containerType, steps[i], out var addressed, out var canonical, out var stepRejection))
+            {
+                rejection = $"'{variable}': {stepRejection}";
+                return false;
+            }
+
+            if (i == steps.Length - 1)
+            {
+                if (!TryLeaf(addressed, value, out var leaf, out var leafRejection))
+                {
+                    rejection = $"'{variable}': {leafRejection}";
+                    return false;
+                }
+
+                Place(container, canonical, leaf);
+                return true;
+            }
+
+            var existing = Read(container, canonical);
+            if (existing is null)
+            {
+                existing = ElementTypeOfList(addressed) is null ? new JsonObject() : (JsonNode)new JsonArray();
+                Place(container, canonical, existing);
+            }
+
+            container = existing;
+            containerType = addressed;
+        }
+
+        rejection = $"'{variable}' names no path into the configuration";
+        return false;
+    }
+
+    // A list built out of indices can be given 2 without 0 and 1. Deserializing that would hand the model a
+    // list with nulls in it, which is a different configuration from the one the operator wrote and reads as
+    // an empty role rather than as a mistake, so the hole is a refusal.
+    private static string? FirstHoleInAList(JsonNode node, string path)
+    {
+        switch (node)
+        {
+            case JsonArray array:
+                for (var i = 0; i < array.Count; i++)
+                {
+                    if (array[i] is null)
+                    {
+                        return $"'{path}{Separator}{i.ToString(CultureInfo.InvariantCulture)}' is missing, so the list it belongs to has a hole in it";
+                    }
+
+                    if (FirstHoleInAList(array[i]!, $"{path}{Separator}{i.ToString(CultureInfo.InvariantCulture)}") is { } nested)
+                    {
+                        return nested;
+                    }
+                }
+
+                return null;
+
+            case JsonObject obj:
+                foreach (var member in obj)
+                {
+                    if (member.Value is not null && FirstHoleInAList(member.Value, $"{path}{Separator}{member.Key}") is { } nested)
+                    {
+                        return nested;
+                    }
+                }
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    // The value at the end of a path, turned into the JSON kind the field is. A string that does not spell a
+    // number or a boolean is refused here rather than reaching the deserializer, so the message names the
+    // variable instead of a JSON path nobody wrote.
+    private static bool TryLeaf(Type addressed, string? value, out JsonNode? leaf, out string rejection)
+    {
+        leaf = null;
+        rejection = string.Empty;
+
+        if (addressed == typeof(string))
+        {
+            leaf = JsonValue.Create(value);
+            return true;
+        }
+
+        if (addressed == typeof(bool))
+        {
+            if (!bool.TryParse(value, out var parsed))
+            {
+                rejection = "expected true or false";
+                return false;
+            }
+
+            leaf = JsonValue.Create(parsed);
+            return true;
+        }
+
+        if (addressed == typeof(int))
+        {
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                rejection = "expected a whole number";
+                return false;
+            }
+
+            leaf = JsonValue.Create(parsed);
+            return true;
+        }
+
+        // No other leaf kind exists in the model today, and the reachability test fails the build if one
+        // arrives, so this is a refusal rather than a silent pass.
+        rejection = $"a {addressed.Name} cannot be written as a single variable";
+        return false;
+    }
+
+    private static void Place(JsonNode container, string step, JsonNode? value)
+    {
+        if (container is JsonArray array)
+        {
+            var index = int.Parse(step, NumberStyles.None, CultureInfo.InvariantCulture);
+            while (array.Count <= index)
+            {
+                array.Add(null);
+            }
+
+            array[index] = value;
+            return;
+        }
+
+        ((JsonObject)container)[step] = value;
+    }
+
+    private static JsonNode? Read(JsonNode container, string step)
+    {
+        if (container is JsonArray array)
+        {
+            var index = int.Parse(step, NumberStyles.None, CultureInfo.InvariantCulture);
+            return index < array.Count ? array[index] : null;
+        }
+
+        return ((JsonObject)container).TryGetPropertyValue(step, out var existing) ? existing : null;
+    }
+
+    private static Type Unwrap(Type type) => Nullable.GetUnderlyingType(type) ?? type;
+
+    private static Type? ValueTypeOfDictionary(Type type)
+    {
+        for (var candidate = type; candidate is not null; candidate = candidate.BaseType)
+        {
+            if (candidate.IsGenericType
+                && candidate.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+                && candidate.GetGenericArguments()[0] == typeof(string))
+            {
+                return candidate.GetGenericArguments()[1];
+            }
+        }
+
+        return null;
+    }
+
+    private static Type? ElementTypeOfList(Type type)
+    {
+        if (type == typeof(string) || ValueTypeOfDictionary(type) is not null)
+        {
+            return null;
+        }
+
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+        {
+            return type.GetGenericArguments()[0];
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<KeyValuePair<string, string?>> ReadProcessEnvironment()
+    {
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            if (entry.Key is string name)
+            {
+                yield return new KeyValuePair<string, string?>(name, entry.Value as string);
+            }
+        }
+    }
+}

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -266,6 +266,35 @@ internal static class DeclarativeProviderConfig
             return Reject(logger, sourcePath, "the file holds no document");
         }
 
+        return ApplyDocument(store, document, sourcePath, logger, revealStoredSecret);
+    }
+
+    /// <summary>
+    /// Applies an already-parsed document to <paramref name="store"/>, which is everything the two
+    /// declarative sources do identically once each has produced a document (#1097).
+    /// </summary>
+    /// <remarks>
+    /// The whole of the atomicity, the merge precedence, the restart-loop promise and the insecure-option
+    /// audit live here rather than at either caller, so the mounted file and the environment cannot come to
+    /// disagree about them. What each caller owns is only the way it turns its own source into a document
+    /// and refuses one it cannot.
+    /// </remarks>
+    /// <param name="store">The configuration store to apply the document through.</param>
+    /// <param name="document">The parsed document.</param>
+    /// <param name="sourcePath">What names the source in a log line: the document's path, or the variable prefix.</param>
+    /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <param name="revealStoredSecret">Recovers the plaintext of a secret as the store holds it (#1096); null skips that comparison.</param>
+    /// <returns>What the apply did.</returns>
+    internal static DeclarativeLoadOutcome ApplyDocument(
+        ProviderConfigStore store,
+        ConfigExportDocument document,
+        string sourcePath,
+        ILogger? logger,
+        Func<string?, string?>? revealStoredSecret)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(document);
+
         // Applied to a DETACHED COPY of the live configuration first. That is what makes the whole document
         // validate before anything is mutated, and it is also the comparison that keeps a restart loop from
         // rewriting config.xml: the copy either refuses the document or shows exactly what the live
@@ -482,11 +511,21 @@ internal static class DeclarativeProviderConfig
         }
     }
 
-    // A rejection is Error rather than Warning: the operator asked for this file to decide the providers,
-    // and the server is now running on something else. The reason is echoed with its line endings stripped
-    // at the emission point, because it can quote a provider name that came out of the file
-    // (cs/log-forging is sanitized inline, never behind a helper).
-    private static DeclarativeLoadOutcome Reject(ILogger? logger, string sourcePath, string reason)
+    /// <summary>
+    /// Reports a rejection and answers <see cref="DeclarativeLoadOutcome.Rejected"/>, shared by both
+    /// declarative sources so a refused file and a refused environment read identically in the log.
+    /// </summary>
+    /// <remarks>
+    /// Error rather than Warning: the operator asked for this source to decide the providers, and the server
+    /// is now running on something else. The reason is echoed with its line endings stripped at the emission
+    /// point, because it can quote a provider name that came out of the source (cs/log-forging is sanitized
+    /// inline, never behind a helper).
+    /// </remarks>
+    /// <param name="logger">The logger the rejection is reported on.</param>
+    /// <param name="sourcePath">What names the source: the document's path, or the variable prefix.</param>
+    /// <param name="reason">Why the source was refused.</param>
+    /// <returns>Always <see cref="DeclarativeLoadOutcome.Rejected"/>.</returns>
+    internal static DeclarativeLoadOutcome Reject(ILogger? logger, string sourcePath, string reason)
     {
         if (logger?.IsEnabled(LogLevel.Error) == true)
         {

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -78,6 +78,14 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // touches the key file unless a document actually carries a reference over a provider that has a
         // stored secret.
         DeclarativeProviderConfig.ApplyFromEnvironment(ConfigStore, logger, stored => Secrets.Reveal(stored));
+
+        // #1097: the environment half of the same source, applied AFTER the file so that where both name a
+        // field the environment wins - the deployment's own variables are the closer of the two to the
+        // process, and a mounted file is the shared artefact they override. Both merge over what is stored
+        // rather than replacing it, through the same ConfigImport. Applied separately rather than merged
+        // into one document, so an environment the operator got wrong leaves an accepted file standing
+        // instead of taking it down as well. With no variable set it reads nothing and writes nothing.
+        DeclarativeEnvironmentConfig.ApplyFromEnvironment(ConfigStore, logger, stored => Secrets.Reveal(stored));
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

The mounted-file source (#1095) landed the shape of the declarative
configuration. This is the other half of the parent's "file and/or env": a
deployment with no good place to put a file, or one that already keeps its
settings in its own environment, spells the providers there instead, through the
same apply and under the same rules. It ships alone; no file has to be mounted.

## The naming scheme

A variable names a path into the configuration, with `__` between the steps,
which is the hierarchy separator ASP.NET Core's own environment provider uses
and the one an operator writing a compose file or a Kubernetes manifest already
knows:

```
JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidEndpoint=https://idp/.well-known/openid-configuration
JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidClientId=jellyfin
JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__Enabled=true
JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__Roles__0=media
JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__FolderRoleMapping__0__Role=staff
```

The steps are resolved against the configuration model itself, not against a
table of field names somebody keeps in step with it. A step names a property
(matched without regard to case, like a member of the mounted file), a dictionary
key (verbatim, so a provider may be called anything), or a list index (from
zero). The prefix is `JELLYFIN_SSO_CONFIG__`, which is neither a prefix of nor
prefixed by `JELLYFIN_SSO_CONFIG_FILE`: that one has a single underscore before
`FILE`, this one the double underscore that starts a path.

The issue asks for a conformance test asserting every settable `OidConfig` /
`SamlConfig` property has a reachable name, so a field cannot be silently
unconfigurable. That is
`EveryProviderFieldTheModelCarries_IsReachableFromTheEnvironment`, and it walks
the two provider types through the same resolver the source uses. A second test,
`TheReachabilityWalkActuallyWalksSomething`, pins the population, because an
emptiness assertion over a walk that visited nothing passes while proving
nothing.

## What is refused, and why refusal rather than skipping

The whole environment is refused as a unit and nothing is applied. A typo is the
ordinary failure on a surface where the names are long and nothing completes
them, and a provider carrying half of what a deployment asked for silently holds
whatever was there before, which is worse than one that does not come up. So
each of these leaves the stored configuration byte-identical:

- a step that names no field of the type it is read out of
- a value that is not the field's type (`Enabled=yes`, `MaxAge=1.5`)
- an index that leaves a hole in a list (`Roles__1` with no `Roles__0`), because
  the hole deserializes to a null entry and reads downstream as an empty role
  rather than as a mistake
- a name aimed at a field the JSON boundary withholds: the canonical link maps,
  the issuer bindings, the SSO-only bookkeeping. Those are server-managed and
  re-injected on every write, so such a variable would otherwise be accepted,
  written into the document, and dropped by the deserializer
- a name aimed at a setting the declarative apply does not reach at all. This is
  the one that deserves its own sentence: `ConfigImport` deliberately leaves the
  rate-limit tuning and the SSO-only globals to the settings page, so a variable
  naming one would look applied and change nothing, which is exactly the
  silently-unconfigurable field this issue exists to make impossible

## Precedence

The environment is applied after the file, so where both name a provider the
environment wins, and both win over what is stored. A provider neither source
names is left exactly as it was. Asserted across both sources in
`TheEnvironmentWinsOverAMountedFile_AndOverWhatIsStored`, driven in the order the
plugin's constructor drives them.

The unit of precedence is a provider rather than a field, inherited from the
apply both sources go through rather than chosen here. That has a cost and it
has its own test: naming one field of a provider that already exists leaves the
rest of that provider at its defaults, and on an OpenID provider a blanked
endpoint or client id is a repoint, which clears its links and its stored secret
through the belt `ServerManagedFields` already carries. A deployment declares
every field of a provider it owns from the environment. That is the same rule the
mounted file already has; it is stated loudly because a variable is easier to add
one at a time than a file is.

## What is not reimplemented

The atomicity, the merge, the restart-loop comparison and the insecure-option
audit are the same code, not a second copy of it. The part of the file loader
that does them is now `DeclarativeProviderConfig.ApplyDocument`, called by both
sources, so the two cannot come to disagree about them. What each source owns is
only the way it turns its own input into a document and refuses one it cannot.

Closes #1097

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader, and the two unticked boxes stay unticked.** This change had
one reader, its author, on a config-persistence surface. What stands in place of
a second reader is the evidence below and the properties this change does not
touch, both stated rather than described.

What a hostile or mistaken environment cannot do:

- **Turn off password login.** `DisablePasswordLogin` and
  `BreakGlassAdminUsername` are refused by name, and the apply would not have
  applied them anyway. Pinned by `ASettingTheApplyDoesNotReach_IsRefusedRatherThanDropped`.
- **Weaken the rate limiter.** Same refusal, same test. This is the reason
  `ConfigImport` excluded those settings in the first place, and reaching them
  from a new source would have undone that decision quietly.
- **Write an account link.** Every `[JsonIgnore]` field is refused by name, so
  the link maps and issuer bindings cannot be aimed at.
  `AServerManagedFieldCannotBeSet` covers two of them, and the first case is
  chosen so that it proves the refusal rather than something else: its value type
  is a plain string, so with the check deleted the variable places happily.
- **Get past the validator.** The document goes through the same
  `ProviderConfigValidator` pass every write path uses, reached through the same
  `ConfigImport`. `AProviderTheValidatorRefuses_LeavesTheStoredConfigurationByteIdentical`
  pins the reach.
- **Turn off a protection quietly.** The insecure-option audit runs on this path
  because it is inside the shared `ApplyDocument`, so a provider enabled from the
  environment with a default-on check disabled leaves the same `[SSO Audit]`
  trace a form save leaves.
- **Take the server down.** Nothing here throws out to the plugin constructor:
  the outer catch is the same instrument, for the same reason, as the file
  source's.

On logging: no refusal message carries a value, only the name of what was
refused, which matters here because this is the source where a secret is a
variable's value. The deserializer's own message is deliberately not used as a
refusal reason for that reason, and every message reaches the log through the
shared `Reject`, which strips line endings inline at the emission point.

On secrets: a secret IS spelled out in a variable here, unlike in the mounted
file. #1096 refuses a value in the file and takes a reference, and one of the two
reference forms it accepts is an environment variable. This is that variable, so
requiring a reference from a variable to another variable would buy nothing.
Blank-means-keep still holds: the reveal delegate is threaded through, so a
variable carrying the secret already stored leaves the at-rest envelope alone
instead of rewriting it on every boot.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The first box is the reason `ApplyDocument` was extracted rather than the tail of
the file loader being copied. The naming scheme is resolved by one walk that both
the source and its reachability test drive, so there is no second description of
it to drift.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, warnings as errors, full suite:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3333, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,071s

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3334, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,113s
```

Four tests are skipped on both legs, and one of them is disclosed rather than
worked around:
`PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback` and
its three neighbours skip because binding a listener off loopback raises a
Windows firewall consent dialog that needs an administrator (#1227). They were
not run here and no attempt was made to make them run.

Each guard was proven by deleting it and re-running the new class. The
implementation was restored between runs and what is committed is the real one:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class ...DeclarativeEnvironmentConfigTests
   real code       Total: 30, Errors: 0, Failed: 0
   declared-surface check deleted        Failed: 3
   server-managed refusal deleted        Failed: 1
   list-hole refusal deleted             Failed: 1
   unrecognised step skipped not refused Failed: 6
```

The server-managed row is worth reading twice. The first version of that test
used a field whose value type is a `Guid`, and deleting the check left it green -
the refusal was coming from "a Guid cannot be written as a single variable"
rather than from the guard the test named. The test was changed to a field whose
value type is a string, which is what makes the row above mean what it says.

Prettier over the one changed Markdown file: `CHANGELOG.md` does not pass
`prettier --check` and did not before this change either, so it is left as it is
rather than reformatted in a change about something else. The added entry is
byte-identical to what Prettier would write, checked by formatting a copy and
diffing the block.

## Notes

**Size.** The diff is 1149 added lines, of which 554 are the new test class. One
property holds across the rest: a variable is a path, resolved one way, and every
refusal is a step of that resolution failing. There is no second mechanism to
read.

**Documentation.** The file schema, the environment scheme and the precedence
table are #1116, which is open and is the declared home for all of it. Nothing
about this scheme is documented outside the code and the changelog entry here, so
that issue is the one that closes the gap.

**One shape is out of reach and is stated rather than worked around:** a provider
whose NAME contains a double underscore cannot be addressed from the environment,
because the name would be indistinguishable from two steps. Such a provider is
configured from the mounted file or from the settings page. It is written into
the source's own documentation so a reader meets it where it bites.

**The managed set.** #1102 reports which fields a declarative source manages so
the admin surface can refuse a save to one. That report now has two sources to
read rather than one; this change does not touch it, and whoever takes #1102
should know the environment is the second.
