### PR TITLE
Replace the naming-scheme example the loader refuses [#1116]

### DIFF
--- a/SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs
@@ -109,6 +109,33 @@ public class DeclarativeEnvironmentConfigTests
     }
 
     [Fact]
+    public void ASamlProviderSpelledInVariables_IsApplied()
+    {
+        // The SAML map had no end-to-end case at all: every applying test above spells an OpenID provider,
+        // and the only other mention of SamlConfigs in this file is the reflection walk, which never runs the
+        // loader. So "both provider maps are the declared surface" was carried by one of the two being
+        // exercised. This is the second, and it is also the shape the naming-scheme example in
+        // DeclarativeEnvironmentConfig's own documentation now uses, so that example is a run rather than a
+        // sentence somebody wrote (#1116).
+        var (store, live, persisted) = CreateStore();
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            Load(
+                store,
+                Variables(
+                    ($"{DeclarativeEnvironmentConfig.Prefix}SamlConfigs__idp__SamlEndpoint", "https://idp.example.invalid/sso"),
+                    ($"{DeclarativeEnvironmentConfig.Prefix}SamlConfigs__idp__SamlClientId", "jellyfin"),
+                    ($"{DeclarativeEnvironmentConfig.Prefix}SamlConfigs__idp__Enabled", "true"))));
+
+        var applied = Assert.IsType<PluginConfiguration>(Assert.Single(persisted));
+        Assert.Equal("https://idp.example.invalid/sso", applied.SamlConfigs["idp"].SamlEndpoint);
+        Assert.Equal("jellyfin", applied.SamlConfigs["idp"].SamlClientId);
+        Assert.True(applied.SamlConfigs["idp"].Enabled);
+        Assert.True(live.SamlConfigs["idp"].Enabled);
+    }
+
+    [Fact]
     public void AProviderNobodyDeclared_IsLeftExactlyAsItIs()
     {
         // The precedence is a MERGE, inherited from the import the file source already goes through. A

--- a/SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
+++ b/SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
@@ -30,8 +30,19 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// <code>
 /// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidClientId=jellyfin
 /// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__Roles__0=media
-/// JELLYFIN_SSO_CONFIG__EnableRateLimit=true
+/// JELLYFIN_SSO_CONFIG__SamlConfigs__idp__Enabled=true
 /// </code>
+/// <para>
+/// EVERY LINE OF THAT EXAMPLE NAMES A PATH INSIDE ONE OF THE TWO PROVIDER MAPS, which is a correctness
+/// requirement rather than a preference. A variable naming a member of the configuration itself is refused
+/// by the two-provider-maps rule below, and a refusal takes the WHOLE source down with it, so an operator who
+/// copied an example carrying one would get no declarative configuration at all - not the provider lines
+/// applied and the offending one ignored. The third line read <c>EnableRateLimit</c> until #1116, which is
+/// that mistake standing in the canonical statement of the scheme, contradicting the paragraph that refuses
+/// it. <c>ASettingTheApplyDoesNotReach_IsRefusedRatherThanDropped</c> pins the refusal and
+/// <c>ASamlProviderSpelledInVariables_IsApplied</c> pins that the replacement line is a shape this source
+/// accepts, so the example is exercised rather than asserted.
+/// </para>
 /// <para>
 /// The steps are resolved against the configuration model itself rather than against a hand-written table
 /// of field names, so a field cannot be silently unconfigurable: a property added to


### PR DESCRIPTION
# What & why

The environment source's own documentation opened with a three-line example of
the variable naming scheme, and its third line named a variable the loader
refuses:

```
$ git show origin/main:SSO-Auth/Config/DeclarativeEnvironmentConfig.cs | sed -n '30,34p'
/// <code>
/// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__OidClientId=jellyfin
/// JELLYFIN_SSO_CONFIG__OidConfigs__keycloak__Roles__0=media
/// JELLYFIN_SSO_CONFIG__EnableRateLimit=true
/// </code>
```

The declarative apply reaches the two provider maps and nothing else, so
`TryResolveStep` rejects a step naming any other member of the configuration,
and the suite already pinned that exact variable as a refusal:

```
$ git show origin/main:SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs | sed -n '126,131p'
    [Theory]
    [InlineData("EnableRateLimit", "false")]
    [InlineData("RateLimitMaxAttempts", "7")]
    [InlineData("DisablePasswordLogin", "true")]
    [InlineData("BreakGlassAdminUsername", "root")]
    public void ASettingTheApplyDoesNotReach_IsRefusedRatherThanDropped(string field, string value)
```

What an operator meets is worse than a line that does nothing. The source is
refused as a unit, so copying the example block yields no declarative
configuration at all rather than the two provider lines applied and the third
ignored, with one Error log line to find it by. The example also contradicted a
paragraph three below it in the same comment, which states the rule correctly.

The third line now names a SAML provider field, so every line of the example is
a path inside one of the two maps.

Part of #1116. Not closing it: that issue asks for a Config-as-code page, and
this is one sentence of the material it has to document, corrected before it is
copied into prose.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No executable line changed; the refusal
      the comment misdescribed is untouched.
- [x] No secrets logged; secrets are redacted on config export. Unchanged.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged.

The two unticked boxes are unticked because no review was run and no record
exists. The change carries no executable line: `git diff` over the source file
touches only lines inside an XML documentation comment, and the second file is
a new test. Nobody else read this.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No new structural property; the conformance tests are part of the green
      suite below.
- [x] Docs impact considered: the corrected example is the doc surface, and
      #1116 is the open documentation issue this belongs to and is linked above.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No file
      of those kinds is touched.

Both target frameworks, at the head being pushed:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3336, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 39,096s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3337, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 33,694s
```

Four tests are skipped on both runs and the skips are not mine to remove. One
names its reason on the run: `CompositionRoot_GivesEachOutboundName_ItsOwnTier`
skips because binding a listener off loopback raises the Windows firewall
consent dialog, which needs an administrator (#1227). I did not run it and this
change does not reach it.

## The new test bites

`ASamlProviderSpelledInVariables_IsApplied` is not decoration. The SAML map had
no end-to-end case in this suite: every applying test spelled an OpenID
provider, and the only other mention of `SamlConfigs` was the reflection
reachability walk, which never runs the loader.

```
$ git grep -n "SamlConfigs__\|SamlConfigs\[" origin/main -- SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs
origin/main:SSO-Auth.Tests/Config/DeclarativeEnvironmentConfigTests.cs:452:        Walk(typeof(SamlConfig), $"{DeclarativeEnvironmentConfig.Prefix}SamlConfigs__[provider]", unreachable, []);
```

So "both provider maps are the declared surface" rested on one of the two being
exercised. Dropping `SamlConfigs` from `DeclaredSurface` reddens exactly the new
test and nothing else:

```
$ sed -i 's|DeclaredSurface = \[nameof(PluginConfiguration.OidConfigs), nameof(PluginConfiguration.SamlConfigs)\]|DeclaredSurface = [nameof(PluginConfiguration.OidConfigs)]|' SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*DeclarativeEnvironmentConfigTests*"
    Jellyfin.Plugin.SSO_Auth.Tests.DeclarativeEnvironmentConfigTests.ASamlProviderSpelledInVariables_IsApplied [FAIL]
      Assert.Equal() Failure: Values differ
      Expected: Applied
      Actual:   Rejected
   SSO-Auth.Tests  Total: 31, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0, Time: 0,544s
```

The line was restored before the commit; the diff carries the two-member form.

## Notes

Out of scope, and both stay on #1116: the Config-as-code page itself, and the
one clause of that issue's Done-when that has no subject yet, because no field
renders as managed by a file today.

There was no second reader for this change. The evidence above stands in place
of one.
