### PR TITLE
Freeze declaratively managed providers against the config-page save

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -78,6 +78,11 @@ public partial class ArchitectureConformanceTests
         // not the per-user-id enumeration surface that made the two Links routes throttled neighbours.
         "OID/RedirectUri/{provider}",
         "Config/Export", "Config/Import", // elevated config transfer
+        // Elevated read-only report of which providers a declarative source decided (#1102): process
+        // state settled during plugin construction, so it reads no provider, takes no outbound fetch and
+        // writes nothing. It answers with NAMES the elevation-gated Config/Export already lists in full,
+        // so repeating it discloses nothing that route does not, and it takes no caller-supplied id.
+        "Config/Managed",
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
         "Config/Links/Export", // elevated read-only link snapshot (#1126), in-memory, no outbound fetch
         "Links/Roster", // elevated read-only link roster (#1119), in-memory, no outbound fetch, takes no caller-supplied id

--- a/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
@@ -1,0 +1,390 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the declarative freeze (#1102): a provider a mounted document or the environment decided is not
+/// alterable through the config-page save, and the save that tried says so in the audit trail. The merge
+/// rules the freeze rests on belong to <see cref="ConfigImport"/> and the loader's own behaviour to
+/// <see cref="DeclarativeProviderConfigTests"/>; what is pinned here is the part an operator's deployment
+/// depends on and cannot see - which providers end up managed, what a save to one does, and what a save to
+/// an unmanaged provider on the same page still does.
+/// </summary>
+/// <remarks>
+/// The unit is the PROVIDER rather than the field because the merge replaces a named provider whole (a field
+/// the document omits comes back at its default at the next start), so a per-field freeze would promise a
+/// granularity the loader does not have. <see cref="AFieldTheDocumentOmits_ComesBackAtItsDefault"/> is the
+/// measurement that decides it, and it is a test rather than a sentence so the day the merge changes, this
+/// reddens instead of the promise quietly becoming false.
+/// </remarks>
+public class DeclarativeManagedProvidersTests
+{
+    private const string Endpoint = "https://idp.example.invalid/.well-known/openid-configuration";
+
+    private static (ProviderConfigStore Store, PluginConfiguration Live, List<BasePluginConfiguration> Persisted, CapturingLogger Log) CreateStore()
+    {
+        var live = new PluginConfiguration();
+        var persisted = new List<BasePluginConfiguration>();
+        var log = new CapturingLogger();
+        return (new ProviderConfigStore(() => live, persisted.Add, log), live, persisted, log);
+    }
+
+    private static string Document(PluginConfiguration configuration) =>
+        JsonSerializer.Serialize(new ConfigExportDocument
+        {
+            FormatVersion = ConfigExport.FormatVersion,
+            Configuration = configuration,
+        });
+
+    private static DeclarativeLoadOutcome Load(ProviderConfigStore store, PluginConfiguration document, CapturingLogger? logger = null) =>
+        DeclarativeProviderConfig.Apply(store, "/run/secrets/sso.json", _ => true, _ => Document(document), logger);
+
+    // The shape a config-page save arrives in: a FRESH configuration object built from the page's snapshot,
+    // never the live one. That is what makes ProviderConfigStore.Save run its pipeline at all.
+    private static PluginConfiguration PostedFrom(PluginConfiguration live)
+    {
+        var posted = live.DetachedCopy();
+
+        // The JSON boundary withholds the write-only secrets, so a real page save carries them blank. Blanked
+        // here too, because a freeze that only looked right against a posted secret would be a test of the
+        // wrong document.
+        foreach (var kvp in posted.OidConfigs)
+        {
+            kvp.Value.OidSecret = null;
+        }
+
+        foreach (var kvp in posted.SamlConfigs)
+        {
+            kvp.Value.SamlSigningKeyPfx = null;
+            kvp.Value.SamlRolloverSigningKeyPfx = null;
+        }
+
+        return posted;
+    }
+
+    private static IReadOnlyList<string> IgnoredWrites(CapturingLogger log) =>
+        log.Entries
+            .Where(e => e.Message.Contains("Configuration save ignored", StringComparison.Ordinal))
+            .Select(e => e.Message)
+            .ToList();
+
+    [Fact]
+    public void NoDeclarativeSource_ManagesNothing_AndASaveIsUnchanged()
+    {
+        // The pin the whole feature rests on: an installation that mounts nothing must save exactly as one
+        // built before this existed. If the empty set ever froze anything, every deployment on earth would
+        // stop being able to edit its providers, which is the worst failure this change could have.
+        var (store, live, persisted, log) = CreateStore();
+        live.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "before" };
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs["keycloak"].OidClientId = "after";
+        store.Save(posted);
+
+        Assert.True(store.ManagedProviders.IsEmpty);
+        Assert.Equal("after", ((PluginConfiguration)persisted.Single()).OidConfigs["keycloak"].OidClientId);
+        Assert.Empty(IgnoredWrites(log));
+    }
+
+    [Fact]
+    public void ASaveToAManagedProvider_PersistsTheDeclarativeValue_AndAuditsTheIgnoredWrite()
+    {
+        // The first Done-when clause of #1102. An admin editing a file-managed provider on the settings page
+        // is editing something the file wins back at the next start; without this the edit appears to hold
+        // for as long as the server runs, which is the silent fight this issue exists to end.
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs["keycloak"].OidClientId = "typed-into-the-page";
+        posted.OidConfigs["keycloak"].EnableAuthorization = true;
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal("from-the-file", saved.OidConfigs["keycloak"].OidClientId);
+        Assert.False(saved.OidConfigs["keycloak"].EnableAuthorization);
+
+        var ignored = Assert.Single(IgnoredWrites(log));
+        Assert.Contains("keycloak", ignored, StringComparison.Ordinal);
+        Assert.Contains("OpenID", ignored, StringComparison.Ordinal);
+
+        // The audit names WHICH provider, never what was posted to it: a rejected client id is still a value
+        // an operator chose and the audit trail is read by more people than the settings page is.
+        Assert.DoesNotContain("typed-into-the-page", ignored, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ASaveToAnUnmanagedProviderOnTheSamePage_StillSavesNormally()
+    {
+        // The freeze is scoped to the providers a source NAMED. A deployment that manages one provider from a
+        // file and adds a second through the page must keep the second editable, or config-as-code becomes
+        // all-or-nothing and the feature is unusable for anyone migrating onto it.
+        var (store, live, persisted, log) = CreateStore();
+        live.OidConfigs["hand-made"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "before" };
+
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs["hand-made"].OidClientId = "after";
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal("after", saved.OidConfigs["hand-made"].OidClientId);
+        Assert.Equal("from-the-file", saved.OidConfigs["keycloak"].OidClientId);
+        Assert.Empty(IgnoredWrites(log));
+    }
+
+    [Fact]
+    public void ASaveThatDropsAManagedProvider_PutsItBack()
+    {
+        // Deleting a managed provider on the page would break every login against it until the next start, at
+        // which point the source puts it back - so the deletion is never durable, only disruptive. Availability
+        // rather than confidentiality: the failure is a working SSO login that stops answering.
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        document.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs.Remove("keycloak");
+        posted.SamlConfigs.Remove("adfs");
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal("from-the-file", saved.OidConfigs["keycloak"].OidClientId);
+        Assert.True(saved.SamlConfigs.ContainsKey("adfs"));
+        Assert.Equal(2, IgnoredWrites(log).Count);
+    }
+
+    [Fact]
+    public void ASaveThatChangesNothingOnAManagedProvider_AuditsNothing()
+    {
+        // The noise guard, and the reason the freeze runs AFTER ServerManagedFields.Preserve. A page save
+        // posts the whole configuration with the write-only secrets blank, so a comparison made before that
+        // re-injection would call every unrelated settings change an ignored write - and an audit line that
+        // fires on every save is one nobody reads on the save that mattered.
+        var (store, live, persisted, log) = CreateStore();
+
+        // The secret is seeded into the store rather than written into the document, because the document is
+        // JSON and the JSON boundary withholds a secret in both directions (#189/#1096). The document names
+        // the same provider identity and carries no secret, so blank-means-keep leaves this one stored - which
+        // is exactly the state a real deployment is in after a secret reference resolved to what it already
+        // had.
+        live.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            OidSecret = "a-secret-the-page-never-sees",
+        };
+
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.AlreadyCurrent, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.EnableRateLimit = !posted.EnableRateLimit;
+        store.Save(posted);
+
+        Assert.Empty(IgnoredWrites(log));
+        Assert.Equal("a-secret-the-page-never-sees", ((PluginConfiguration)persisted.Last()).OidConfigs["keycloak"].OidSecret);
+    }
+
+    [Fact]
+    public void ADocumentRefusedBeforeItIsRead_ManagesNothing()
+    {
+        // Fail-closed in the direction that matters here: a document the loader refused changed nothing, so
+        // freezing the providers it happened to name would hand a broken file authority over a configuration
+        // it never applied - and leave an admin unable to repair it from the page. This is the arm refused by
+        // the repeated-member screen, before the document is ever deserialized.
+        var (store, _, _, _) = CreateStore();
+        var log = new CapturingLogger();
+
+        var outcome = DeclarativeProviderConfig.Apply(
+            store,
+            "/run/secrets/sso.json",
+            _ => true,
+            _ => "{\"FormatVersion\":1,\"Configuration\":{\"OidConfigs\":{\"keycloak\":{},\"keycloak\":{}}}}",
+            log);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, outcome);
+        Assert.True(store.ManagedProviders.IsEmpty);
+    }
+
+    [Fact]
+    public void ADocumentRefusedByTheMerge_ManagesNothing()
+    {
+        // The OTHER rejection arm, and the one the test above cannot reach. A document that parses, names a
+        // provider and is then refused while being applied gets as far as the code that records the managed
+        // set, so this is where "recorded before it was accepted" would hide. Written after a falsifier proved
+        // the repeated-member case above passes with the recording moved AHEAD of the refusal - it never
+        // reaches that line, so on its own it pins nothing about this order.
+        var (store, live, persisted, _) = CreateStore();
+        var document = new PluginConfiguration();
+
+        // A provider name new to this instance carrying a URI-reserved character is refused by
+        // ProviderConfigValidator inside ConfigImport (#336/#360), which is a refusal raised by the merge
+        // rather than by the reader.
+        document.OidConfigs["bad/name"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, document));
+        Assert.True(store.ManagedProviders.IsEmpty);
+        Assert.Empty(persisted);
+        Assert.Empty(live.OidConfigs);
+    }
+
+    [Fact]
+    public void ADocumentThatChangedNothing_StillManagesItsProviders()
+    {
+        // A restart that finds the mount already applied reports AlreadyCurrent. The providers are no less
+        // decided by the file for it, and a freeze that depended on whether anything moved would release them
+        // on exactly the boot an operator is least likely to notice: the ordinary one.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+        Assert.Equal(DeclarativeLoadOutcome.AlreadyCurrent, Load(store, document));
+
+        Assert.Equal(new[] { "keycloak" }, store.ManagedProviders.OidConfigs);
+    }
+
+    [Fact]
+    public void ASecondSourceDoesNotReleaseTheFirstSourcesProviders()
+    {
+        // The file applies first and the environment second (SSOPlugin's constructor). Each manages what it
+        // named, so the set is a union: a deployment that mounts a file and sets one variable must not find
+        // the file's providers editable again because the variable said nothing about them.
+        var (store, _, _, _) = CreateStore();
+
+        var fromFile = new PluginConfiguration();
+        fromFile.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, fromFile));
+
+        var fromEnvironment = new PluginConfiguration();
+        fromEnvironment.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        Assert.Equal(
+            DeclarativeLoadOutcome.Applied,
+            DeclarativeProviderConfig.ApplyDocument(
+                store,
+                new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = fromEnvironment },
+                "JELLYFIN_SSO_CONFIG__",
+                new CapturingLogger(),
+                null));
+
+        Assert.Equal(new[] { "keycloak" }, store.ManagedProviders.OidConfigs);
+        Assert.Equal(new[] { "adfs" }, store.ManagedProviders.SamlConfigs);
+    }
+
+    [Fact]
+    public void AFieldTheDocumentOmits_ComesBackAtItsDefault()
+    {
+        // The measurement the provider-level granularity rests on, kept as a test rather than as a sentence.
+        // A document naming a provider decides ALL of it: an admin-set field the document is silent about is
+        // gone at the next start, so a surface that froze three fields and left the rest editable would tell
+        // the admin the opposite of what happens. The day the merge becomes per field, this reddens.
+        var (store, live, _, _) = CreateStore();
+        live.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            EnableAuthorization = true,
+            DefaultProvider = "set-by-the-admin",
+        };
+
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        Assert.False(live.OidConfigs["keycloak"].EnableAuthorization);
+        Assert.Null(live.OidConfigs["keycloak"].DefaultProvider);
+    }
+
+    [Fact]
+    public void TheReportedSetIsNamesOnly_AndCarriesNoValue()
+    {
+        // What the admin surface is allowed to be told. The set exists to be rendered in a browser, so a
+        // field value reaching it would widen what a config page holds - and a secret reaching it would be a
+        // disclosure through the one door that was built to describe rather than to reveal.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            OidSecret = "PLAINTEXT-OIDC-SECRET",
+        };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var json = JsonSerializer.Serialize(new ManagedProviderSetDocument
+        {
+            OidConfigs = store.ManagedProviders.OidConfigs,
+            SamlConfigs = store.ManagedProviders.SamlConfigs,
+        });
+
+        Assert.Contains("keycloak", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("PLAINTEXT-OIDC-SECRET", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.DoesNotContain(Endpoint, json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThePersistedProviderIsWhatTheComparisonReads()
+    {
+        // A rotated client secret is withheld at the JSON boundary, so a JSON comparison would call the save
+        // an unchanged provider and let the rotation through the freeze silently. The comparison is the XML
+        // persisted form for that reason, and this is the case that separates the two.
+        var (store, live, persisted, log) = CreateStore();
+        live.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            OidSecret = "the-declared-secret",
+        };
+
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.AlreadyCurrent, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs["keycloak"].OidSecret = "rotated-through-the-page";
+        store.Save(posted);
+
+        Assert.Equal("the-declared-secret", ((PluginConfiguration)persisted.Last()).OidConfigs["keycloak"].OidSecret);
+        Assert.Single(IgnoredWrites(log));
+    }
+
+    [Fact]
+    public void AManagedProviderKeepsTheLinksALoginWroteAfterTheApply()
+    {
+        // The freeze re-injects the STORED provider, not a retained copy of the document, and this is what
+        // that buys: a canonical link written by a login after the apply survives the next page save. Freezing
+        // against the document instead would unlink every account on a managed provider on the first save.
+        var (store, live, persisted, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var linked = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        store.Mutate(c => c.OidConfigs["keycloak"].CanonicalLinks["sub-1"] = linked);
+
+        var posted = PostedFrom(live);
+        posted.OidConfigs["keycloak"].OidClientId = "typed-into-the-page";
+        store.Save(posted);
+
+        Assert.Equal(linked, ((PluginConfiguration)persisted.Last()).OidConfigs["keycloak"].CanonicalLinks["sub-1"]);
+    }
+}

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -43,7 +43,7 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // answers with a provider's configured base-URL override and only an administrator has a use for it.
         "OidRedirectUri",
         "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
-        "ExportConfig", "ImportConfig", "Unregister", "ExportLinks", "ExportUserLinks",
+        "ExportConfig", "ImportConfig", "ManagedProviders", "Unregister", "ExportLinks", "ExportUserLinks",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",
         // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for

--- a/SSO-Auth.Tests/Http/SSOControllerManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerManagedProvidersTests.cs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of <c>GET sso/Config/Managed</c> (#1102) through <see cref="SsoControllerHarness"/>, so
+/// the report the admin page will consume (#1104) is read off the real store rather than a stand-in. What is
+/// pinned here is the contract a browser depends on: both protocols reported, an empty answer rather than an
+/// error where nothing is managed, and names only on the wire.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerManagedProvidersTests
+{
+    private static ManagedProviderSetDocument Reported(SsoControllerHarness harness) =>
+        Assert.IsType<ManagedProviderSetDocument>(Assert.IsType<OkObjectResult>(harness.Controller.ManagedProviders().Result).Value);
+
+    [Fact]
+    public void NoDeclarativeSource_ReportsAnEmptySet_RatherThanFailing()
+    {
+        // The answer every installation that mounts nothing gets, which is most of them. An error here would
+        // make the config page treat "nothing is managed" as "the server is broken" and is the difference
+        // between a feature nobody notices and one that breaks the settings page for everybody.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["hand-made"] = new OidConfig { OidClientId = "client-1" });
+
+        var reported = Reported(harness);
+
+        Assert.Empty(reported.OidConfigs);
+        Assert.Empty(reported.SamlConfigs);
+    }
+
+    [Fact]
+    public void TheManagedSet_IsReportedForBothProtocols()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
+            c.OidConfigs["hand-made"] = new OidConfig { OidClientId = "client-2" };
+            c.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        });
+
+        var declared = new PluginConfiguration();
+        declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
+        declared.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared);
+
+        var reported = Reported(harness);
+
+        Assert.Equal(new[] { "keycloak" }, reported.OidConfigs);
+        Assert.Equal(new[] { "adfs" }, reported.SamlConfigs);
+    }
+
+    [Fact]
+    public void TheSerializedReport_CarriesNamesAndNothingElse()
+    {
+        // The report is built to be rendered in a browser. A field value reaching it would widen what the
+        // config page holds, and a secret reaching it would be a disclosure through the one door that exists
+        // to describe a provider rather than to reveal it.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            OidSecret = "PLAINTEXT-OIDC-SECRET",
+        });
+
+        var declared = new PluginConfiguration();
+        declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared);
+
+        var json = JsonSerializer.Serialize(Reported(harness));
+
+        Assert.Contains("keycloak", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("PLAINTEXT-OIDC-SECRET", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("client-1", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("idp.example.invalid", json, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -212,6 +212,28 @@ internal static class SsoAudit
             provider?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records a config-page save whose changes to a declaratively managed provider were ignored (#1102). The
+    /// provider is decided by the mounted document or the environment, so the stored value was kept and the
+    /// posted one discarded. Warning rather than Information: an administrator has just made an edit the
+    /// server did not take, and the settings page is where they would otherwise wait for it to hold.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name. No field value is recorded - the point is which provider, not what was posted.</param>
+    internal static void DeclarativeWriteIgnored(ILogger logger, string protocol, string provider)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Configuration save ignored for {Protocol} provider '{Provider}': it is managed by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+    }
+
     /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="provider">The provider name.</param>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1356,6 +1356,28 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Reports which providers a declarative source decided on this boot (#1102), so the config page can
+    /// render them as managed instead of letting an admin edit a form the next start wins back (#1104).
+    /// Requires administrator privileges, like the other config endpoints. Read-only - it changes nothing,
+    /// and it carries provider NAMES only: no field value, no secret and no reference, so nothing here is
+    /// sensitive even where the whole set is.
+    /// </summary>
+    /// <returns>The managed provider set; both lists empty when no declarative source is configured.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Config/Managed")]
+    public ActionResult<ManagedProviderSetDocument> ManagedProviders()
+    {
+        // The set is process state decided during plugin construction, not configuration, so this reads no
+        // provider and takes no config lock beyond the one the store holds for its own field.
+        var managed = SSOPlugin.Instance.ConfigStore.ManagedProviders;
+        return Ok(new ManagedProviderSetDocument
+        {
+            OidConfigs = managed.OidConfigs,
+            SamlConfigs = managed.SamlConfigs,
+        });
+    }
+
+    /// <summary>
     /// Exports the account-link table as a portable, username-keyed document (#1126). Requires
     /// administrator privileges. Read-only - it changes nothing.
     /// </summary>

--- a/SSO-Auth/Config/DeclarativeManagedProviders.cs
+++ b/SSO-Auth/Config/DeclarativeManagedProviders.cs
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The providers a declarative source decided on this boot (#1102), so a config-page save cannot alter one
+/// and an admin can be told which ones those are. Recorded by
+/// <see cref="DeclarativeProviderConfig.ApplyDocument"/> once a document has been accepted, held on
+/// <see cref="ProviderConfigStore"/> for the life of the process, and never persisted: the sources are read
+/// while the plugin is being constructed, so the set is re-derived on every start and a mount that is taken
+/// away stops managing anything at the next one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// THE UNIT IS THE PROVIDER, NOT THE FIELD, and that is a measurement rather than a simplification.
+/// <see cref="ConfigImport"/> merges by provider: it replaces the whole stored provider object with the one
+/// the document carries and re-injects only the <see cref="ServerManagedFields"/>. So a field the document
+/// does not name comes back at its deserialized default at the next start, not at whatever an admin last
+/// typed. Every field of a named provider is therefore decided by the source, and a surface that greyed out
+/// three fields and left the rest editable would tell the admin the opposite of what happens.
+/// </para>
+/// <para>
+/// What the freeze re-injects is the LIVE stored provider, not a retained copy of the document. The document
+/// was applied to the store during construction, so the stored provider IS the declarative one, and reaching
+/// the declarative value through the store means no resolved secret has to be held in memory for the life of
+/// the process to answer a save. It also keeps the runtime half of a managed provider - the canonical links,
+/// the deadlines, the login stamps a login writes after the apply - which a retained document would have
+/// thrown away.
+/// </para>
+/// <para>
+/// A managed provider missing from an incoming save is re-added rather than deleted. Deleting one would
+/// break every login against it until the next start, at which point the source would put it back, so the
+/// deletion is never a durable intent; it is a page saved against a set the file owns.
+/// </para>
+/// </remarks>
+internal sealed class DeclarativeManagedProviders
+{
+    /// <summary>
+    /// The set of an installation that configures no declarative source: nothing is managed, nothing is
+    /// frozen, and the config page behaves exactly as it did before this existed.
+    /// </summary>
+    internal static readonly DeclarativeManagedProviders None = new(
+        new HashSet<string>(StringComparer.Ordinal),
+        new HashSet<string>(StringComparer.Ordinal));
+
+    private readonly HashSet<string> _oid;
+    private readonly HashSet<string> _saml;
+
+    private DeclarativeManagedProviders(HashSet<string> oid, HashSet<string> saml)
+    {
+        _oid = oid;
+        _saml = saml;
+    }
+
+    /// <summary>Gets the OpenID provider names the declarative sources named, ordered so the report is stable.</summary>
+    internal IReadOnlyList<string> OidConfigs => _oid.OrderBy(name => name, StringComparer.Ordinal).ToList();
+
+    /// <summary>Gets the SAML provider names the declarative sources named, ordered so the report is stable.</summary>
+    internal IReadOnlyList<string> SamlConfigs => _saml.OrderBy(name => name, StringComparer.Ordinal).ToList();
+
+    /// <summary>Gets a value indicating whether no provider is declaratively managed.</summary>
+    internal bool IsEmpty => _oid.Count == 0 && _saml.Count == 0;
+
+    /// <summary>
+    /// Answers a new set carrying everything this one carries plus every provider <paramref name="applied"/>
+    /// names. A union rather than a replacement, because the two sources apply in sequence (the file, then
+    /// the environment) and each manages what it named - a second source that names nothing must not release
+    /// the first source's providers.
+    /// </summary>
+    /// <param name="applied">The configuration a source just applied; null adds nothing.</param>
+    /// <returns>The widened set.</returns>
+    internal DeclarativeManagedProviders Including(PluginConfiguration? applied)
+    {
+        if (applied is null)
+        {
+            return this;
+        }
+
+        var oid = new HashSet<string>(_oid, StringComparer.Ordinal);
+        var saml = new HashSet<string>(_saml, StringComparer.Ordinal);
+        Add(oid, applied.OidConfigs);
+        Add(saml, applied.SamlConfigs);
+        return new DeclarativeManagedProviders(oid, saml);
+    }
+
+    /// <summary>
+    /// Freezes every managed provider in <paramref name="incoming"/> against its stored value, and reports
+    /// the ones whose posted form differed so the caller can audit the ignored write.
+    /// </summary>
+    /// <remarks>
+    /// Runs AFTER <see cref="ServerManagedFields.Preserve(PluginConfiguration, PluginConfiguration)"/> on
+    /// purpose, and the comparison is the reason. A config-page save arrives with the write-only secrets
+    /// blank and the link maps absent, so comparing before that re-injection would call every save a changed
+    /// provider and audit one on every unrelated settings change. Compared after it, a provider the admin did
+    /// not touch is byte-identical to the stored one and nothing is reported.
+    /// </remarks>
+    /// <param name="incoming">The configuration about to be persisted.</param>
+    /// <param name="live">The current live configuration, which holds the declarative values.</param>
+    /// <param name="ignored">Collects (protocol, provider) for each managed provider whose posted form differed.</param>
+    internal void Reinject(PluginConfiguration? incoming, PluginConfiguration? live, ICollection<(string Protocol, string Provider)> ignored)
+    {
+        ArgumentNullException.ThrowIfNull(ignored);
+
+        if (incoming is null || live is null || IsEmpty)
+        {
+            return;
+        }
+
+        Reinject(_oid, "OpenID", incoming.OidConfigs, live.OidConfigs, ignored, (holder, name, provider) => holder.OidConfigs[name] = provider);
+        Reinject(_saml, "SAML", incoming.SamlConfigs, live.SamlConfigs, ignored, (holder, name, provider) => holder.SamlConfigs[name] = provider);
+    }
+
+    private static void Add<T>(HashSet<string> names, SerializableDictionary<string, T>? providers)
+        where T : ProviderConfigBase
+    {
+        if (providers is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in providers)
+        {
+            names.Add(kvp.Key);
+        }
+    }
+
+    // One loop for both protocols: the maps differ only in the concrete provider type, and every rule below
+    // - freeze, re-add, report a difference - is the same on either.
+    private static void Reinject<T>(
+        HashSet<string> managed,
+        string protocol,
+        SerializableDictionary<string, T>? incoming,
+        SerializableDictionary<string, T>? live,
+        ICollection<(string Protocol, string Provider)> ignored,
+        Action<PluginConfiguration, string, T> place)
+        where T : ProviderConfigBase
+    {
+        if (incoming is null || live is null)
+        {
+            return;
+        }
+
+        foreach (var name in managed)
+        {
+            if (!live.TryGetValue(name, out var stored) || stored is null)
+            {
+                // Named by a source but no longer in the store: a later write removed it, and there is no
+                // declarative value left to re-inject. Nothing is invented here; the next start re-applies
+                // the source and the provider comes back.
+                continue;
+            }
+
+            var posted = incoming.TryGetValue(name, out var candidate) ? candidate : null;
+            if (posted is null || !string.Equals(PersistedForm(name, posted, place), PersistedForm(name, stored, place), StringComparison.Ordinal))
+            {
+                ignored.Add((protocol, name));
+            }
+
+            incoming[name] = stored;
+        }
+    }
+
+    // The persisted form of ONE provider, which is what "did this save change it" has to be asked against:
+    // the persisted form is what the store WRITES, so it sees every field that survives a restart - including
+    // the secrets the JSON boundary withholds. A JSON comparison would call a rotated client secret an
+    // unchanged provider and let the rotation through the freeze in silence.
+    //
+    // The provider is carried in a throwaway configuration and put through the store's OWN round-trip rather
+    // than serialized here. Two reasons, and the second is the one that would be missed. Only the SAML module
+    // may hold an XML parse seam (#1003), and the configuration model is the one allowlisted exception, so
+    // reaching the form through it adds no second stack. And the round-trip is what makes the two sides
+    // comparable at all: XML serialization does not distinguish an absent collection from an empty one, so an
+    // object that has been through one (the posted configuration, which arrived over the wire) and one that
+    // has not (the live object a loader built) emit different bytes for identical content. Measured rather
+    // than supposed - a version of this that serialized once called every untouched provider a changed one.
+    private static string PersistedForm<T>(string name, T provider, Action<PluginConfiguration, string, T> place)
+        where T : ProviderConfigBase
+    {
+        var holder = new PluginConfiguration();
+        place(holder, name, provider);
+        return holder.DetachedCopy().ToPersistedForm();
+    }
+}

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -327,6 +327,12 @@ internal static class DeclarativeProviderConfig
             return Reject(logger, sourcePath, rejection);
         }
 
+        // Recorded before both accepting returns below, and on BOTH of them (#1102). A document that changed
+        // nothing still decided the providers it names - it agrees with the store rather than being absent
+        // from it - so releasing those providers to the config page whenever a restart happens to find the
+        // mount already applied would make the freeze depend on whether anything moved.
+        store.RecordDeclarativelyManaged(document.Configuration);
+
         if (!changed)
         {
             if (logger?.IsEnabled(LogLevel.Debug) == true)

--- a/SSO-Auth/Config/ManagedProviderSetDocument.cs
+++ b/SSO-Auth/Config/ManagedProviderSetDocument.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// What the admin surface is told about declarative management (#1102): which providers a mounted document
+/// or the environment decided on this boot, so the config page can show that they are managed rather than
+/// letting an admin type into a form the next start will win back (#1104).
+/// </summary>
+/// <remarks>
+/// <para>
+/// NAMES ONLY. The document carries no field value, no secret and no reference, because everything it would
+/// have to name to carry one is already available - and already redacted - through
+/// <c>GET /sso/Config/Export</c>. There is nothing here an administrator could not read anyway, and nothing
+/// that becomes sensitive if the report is logged or pasted into an issue.
+/// </para>
+/// <para>
+/// The unit is the provider rather than the field, for the reason set out on
+/// <see cref="DeclarativeManagedProviders"/>: the merge replaces a named provider whole, so every one of its
+/// fields is decided by the source. A consumer renders the whole provider as managed; there is no honest
+/// subset to render.
+/// </para>
+/// <para>
+/// Both lists are empty when no declarative source is configured, which is the answer an installation built
+/// before those sources existed gets, and it is a report rather than an error.
+/// </para>
+/// </remarks>
+public class ManagedProviderSetDocument
+{
+    /// <summary>
+    /// Gets the OpenID providers a declarative source decided, keyed as they are in
+    /// <see cref="PluginConfiguration.OidConfigs"/> so a consumer can match them without a second lookup.
+    /// </summary>
+    public IReadOnlyList<string> OidConfigs { get; init; } = new List<string>();
+
+    /// <summary>
+    /// Gets the SAML providers a declarative source decided, keyed as they are in
+    /// <see cref="PluginConfiguration.SamlConfigs"/>.
+    /// </summary>
+    public IReadOnlyList<string> SamlConfigs { get; init; } = new List<string>();
+}

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -49,6 +49,26 @@ internal sealed class ProviderConfigStore
     }
 
     /// <summary>
+    /// Gets the providers a declarative source decided on this boot (#1102). Empty on an installation that
+    /// configures none, which is every installation built before those sources existed.
+    /// </summary>
+    internal DeclarativeManagedProviders ManagedProviders { get; private set; } = DeclarativeManagedProviders.None;
+
+    /// <summary>
+    /// Records that a declarative source has applied <paramref name="applied"/>, so every provider it names is
+    /// frozen against the config-page save from here on (#1102). Called by the loaders once a document has
+    /// been accepted; a rejected document records nothing, because it changed nothing.
+    /// </summary>
+    /// <param name="applied">The configuration the source applied.</param>
+    internal void RecordDeclarativelyManaged(PluginConfiguration? applied)
+    {
+        lock (Sync)
+        {
+            ManagedProviders = ManagedProviders.Including(applied);
+        }
+    }
+
+    /// <summary>
     /// Reads a value from the live configuration under the same lock as <see cref="Mutate(Action{PluginConfiguration})"/>,
     /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
     /// </summary>
@@ -117,6 +137,7 @@ internal sealed class ProviderConfigStore
     {
         ArgumentNullException.ThrowIfNull(configuration);
         List<(string Protocol, string Provider, IReadOnlyList<string> Options)>? insecureToAudit = null;
+        var declarativeWritesIgnored = new List<(string Protocol, string Provider)>();
         lock (Sync)
         {
             if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
@@ -134,6 +155,14 @@ internal sealed class ProviderConfigStore
 
                 ServerManagedFields.Preserve(incoming, _live());
 
+                // #1102: a provider a declarative source named is decided by that source, so the config-page
+                // save gets the stored (declarative) provider back rather than the posted one. AFTER the
+                // re-injection above, never before: that is what makes an untouched provider compare equal to
+                // the stored one, so the audit below reports a save that actually tried to change a managed
+                // provider instead of firing on every unrelated settings change. Nothing happens here on an
+                // installation that configures no declarative source.
+                ManagedProviders.Reinject(incoming, _live(), declarativeWritesIgnored);
+
                 // Snapshot which providers were saved with an insecure option (#140) while under the
                 // lock, but emit the warnings AFTER releasing it (below) - logging must not run inside
                 // the global config lock, where a slow provider would block concurrent config access.
@@ -150,6 +179,14 @@ internal sealed class ProviderConfigStore
             foreach (var (protocol, provider, options) in insecureToAudit)
             {
                 SsoAudit.InsecureOptionsEnabled(_logger, protocol, provider, options);
+            }
+        }
+
+        if (_logger != null)
+        {
+            foreach (var (protocol, provider) in declarativeWritesIgnored)
+            {
+                SsoAudit.DeclarativeWriteIgnored(_logger, protocol, provider);
             }
         }
     }


### PR DESCRIPTION
# What & why

A provider named by the mounted declarative document or by the environment is
decided by that source. The merge replaces the whole stored provider object at
the next start, so anything an admin types into that provider's form on the
settings page is won back the moment the server restarts, with nothing said
about it. This freezes those providers against the config-page save, records
the ignored write in the audit trail, and reports the managed set so the admin
page can render it (#1104).

#1102 stays open. The second clause of its Done-when asks for a
per-field refusal, and the measurement already recorded on that issue says the
merge cannot honestly give one. That reading is unchanged and is not restated
here.

Refs #1102. The sentence above was first written with a linking keyword directly before the number, which GitHub matched without reading the negation and used to close the issue on merge. It was reopened and the sentence rewritten; the trap is recorded there.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a document that is refused records nothing, so a
      broken file gets no authority over a configuration it never applied and
      an admin can still repair that provider from the page. An installation
      that configures no declarative source is byte-identical to one built
      before this existed.
- [x] No secrets logged; the audit line names the protocol and the provider and
      nothing that was posted to it. The managed-set report carries names only:
      no field value, no secret, no reference. Two tests assert the serialized
      forms carry none.
- [ ] A security review was performed. **No second reader looked at this
      change, and no separate review was run.** What stands in place of one is
      below: the three guards were each deleted and the suite watched, and the
      residual write doors are named rather than left to be discovered.
- [x] Review record: not applicable in the form the box asks for, because no
      lens pass was run. What was produced instead is stated in Notes with its
      evidence, and the one residual it found carries a disposition.
- [x] Log inputs from the IdP are sanitized inline at the log call
      (`provider?.ReplaceLineEndings(string.Empty)` in the new audit record).

## Quality checklist

- [x] No duplicated logic: the freeze joins the existing
      `ServerManagedFields` re-injection step rather than becoming a second
      "a save must not clear this" mechanism, and the per-provider comparison
      goes through the configuration model's own round-trip rather than opening
      a second XML seam.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why rather than what.
- [x] Architecture-conformance tests pass. Three of them refused this change
      first and each refusal was answered rather than silenced: only the SAML
      module may hold an XML parse seam (#1003), so the comparison was rewritten
      to reach the persisted form through `PluginConfiguration`; the new route
      was classified in the rate-limit lists with its reason; and it was added
      to the known elevation surface.
- [x] Docs impact: the config-as-code page is #1116, whose sixth Done-when
      clause is the read-only admin behaviour. That clause needs #1104's
      rendering as well as this, so it is not satisfied here and no separate
      documentation issue is filed for it.

## Verification

- [x] `dotnet build ... --warnaserror` green on both target frameworks, 0
      warnings.
- [x] Full suite green on both: `net9.0` 3352 total, 0 failed, 4 skipped;
      `net10.0` 3353 total, 0 failed, 4 skipped.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched by this
      change.

The four skips are the same four the suite already skips on this host: they
bind a listener off loopback, which raises the Windows firewall consent dialog
and needs an administrator (#1227). They were not worked around.

## Notes

**Each guard was proven by deleting it.**

- Deleting the freeze reddens three tests: the declarative value stops
  surviving a save, a dropped provider stays dropped, and a secret rotation
  posted through the page reaches the store.
- Recording the managed set ahead of the refusal reddens the merge-refusal
  case. This one is worth reading: it first passed with the guard removed,
  because the document that case used is refused by the reader before it ever
  reaches the line under test. The test was replaced with one that reaches it,
  and the original case is kept beside it as the other rejection arm.
- Moving the freeze ahead of the server-managed re-injection reddens the noise
  guard, which is what stops the audit line firing on every unrelated settings
  change.

**One residual, deliberately out of scope and not closed by this.** The freeze
covers `ProviderConfigStore.Save`, which is the only route the settings page
writes through (`config.js` posts through `updatePluginConfiguration` and
nothing else). Four elevated API routes write by a different door and are
unaffected: `OID/Add/{provider}`, `SAML/Add/{provider}`, `OID/Del/{provider}`,
`SAML/Del/{provider}` persist through `MutateConfiguration`, and `Config/Import`
merges through `ConfigImport`. An administrator calling one of those can still
overwrite or delete a managed provider until the next start puts it back. That
is a wider claim than the surface this issue names, it needs a guard and a test
at each door, and it is filed separately rather than absorbed here.

**One measurement is kept as a test rather than as a sentence.** The unit of
management is the provider, not the field, because a field the document omits
comes back at its deserialized default. That is asserted, so the day the merge
becomes per field the assertion reddens instead of the promise quietly becoming
false.

