### PR TITLE
Render a declaratively managed provider read-only in the config page

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ManagedProviderSurface.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ManagedProviderSurface.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rules for the "managed by file" state in the admin page (#1104): the page and the report it
+/// reads have to keep agreeing about the route, the member names and the markup it paints into. None of
+/// this runs in a browser, so a drift between the two sides is otherwise found by an administrator meeting
+/// an editable form over a provider the server will not let them change.
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    private static string ConfigJs() =>
+        File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Web", "config.js"));
+
+    private static string ConfigPageHtml() =>
+        File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Web", "configPage.html"));
+
+    [Fact]
+    public void ConfigPage_ReadsTheManagedSet_FromTheRouteTheServerServes()
+    {
+        // The route is a string on both sides and nothing compiles the pair together. Spelled wrong, the
+        // fetch rejects, the page's failure arm records nothing as managed, and every managed provider then
+        // renders as an ordinary editable form - which is exactly the state #1104 exists to end, arrived at
+        // silently. The controller side is read off the attribute rather than pasted, so renaming the route
+        // reddens this instead of half-renaming the feature.
+        var route = typeof(Jellyfin.Plugin.SSO_Auth.Api.Http.SSOController)
+            .GetMethod(nameof(Jellyfin.Plugin.SSO_Auth.Api.Http.SSOController.ManagedProviders), BindingFlags.Public | BindingFlags.Instance)!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Mvc.HttpGetAttribute), false)
+            .Cast<Microsoft.AspNetCore.Mvc.HttpGetAttribute>()
+            .Single()
+            .Template;
+
+        Assert.Equal("Config/Managed", route);
+        Assert.Contains("\"sso/" + route + "\"", ConfigJs(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigPage_ReadsExactlyTheMembersTheReportDeclares()
+    {
+        // This is the drift guard #1104 asks for, in the shape the server can actually honour. Its own
+        // Done-when asks that every FIELD name the server can report resolve to a marked field in the form;
+        // the server reports PROVIDER names instead, because the declarative merge replaces a named provider
+        // whole (measured on #1102), so there is no field list to resolve. What can still drift is the pair
+        // of member names, and a member read under the wrong spelling is undefined rather than an error:
+        // the page would quietly find nothing managed.
+        var declared = typeof(ManagedProviderSetDocument)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(new[] { "OidConfigs", "SamlConfigs" }, declared);
+
+        var js = ConfigJs();
+        foreach (var member in declared)
+        {
+            Assert.Contains("report." + member, js, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ConfigPage_PaintsTheManagedNoteIntoElementsThatExist()
+    {
+        // config.js addresses the note by id. An id that no element carries is not an error in a browser -
+        // querySelector answers null and the helper's null check swallows it - so the form would be frozen
+        // with no explanation anywhere on the page, which reads as a broken settings page rather than as a
+        // managed provider.
+        var html = ConfigPageHtml();
+        var js = ConfigJs();
+
+        foreach (var id in new[] { "sso-managed-note", "saml-managed-note" })
+        {
+            Assert.Contains("\"" + id + "\"", js, StringComparison.Ordinal);
+            Assert.Contains("id=\"" + id + "\"", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void EveryControlTheManagedStateExempts_IsAnElementInTheForms()
+    {
+        // The exemption list is what stays usable on a managed provider. A stale id there is not inert: the
+        // control it named is renamed rather than gone, so it is now disabled with everything else and the
+        // administrator loses the read action - a connection test on the one provider they cannot edit - with
+        // nothing saying why. Derived from the source rather than restated, so the list and the markup cannot
+        // drift apart quietly.
+        var js = ConfigJs();
+        var html = ConfigPageHtml();
+
+        var start = js.IndexOf("managedReadOnlyActions: [", StringComparison.Ordinal);
+        Assert.True(start >= 0, "config.js no longer declares managedReadOnlyActions.");
+        var end = js.IndexOf("],", start, StringComparison.Ordinal);
+        var block = js.Substring(start, end - start);
+
+        var ids = block
+            .Split('"')
+            .Where((_, index) => index % 2 == 1)
+            .ToList();
+
+        Assert.NotEmpty(ids);
+        foreach (var id in ids)
+        {
+            Assert.Contains("id=\"" + id + "\"", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void TheManagedNoteText_IsACatalogKeyThatExists()
+    {
+        // #1104 asks for the note text to be an i18n key rather than a literal. The key is looked up at
+        // runtime with a built-in English default, so a key absent from the catalog is invisible: the page
+        // renders the English and no localized installation ever shows a translated sentence.
+        var js = ConfigJs();
+        Assert.Contains("\"config.managed_by_file_note\"", js, StringComparison.Ordinal);
+
+        using var catalog = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Localization", "en.json")));
+
+        Assert.True(
+            catalog.RootElement.TryGetProperty("config.managed_by_file_note", out var value),
+            "SSO-Auth/Localization/en.json carries no config.managed_by_file_note entry.");
+        Assert.False(string.IsNullOrWhiteSpace(value.GetString()));
+    }
+}

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -69,5 +69,6 @@
   "config.oidc_do_not_load_profile_label": "Do Not Load Profile Information",
   "config.oidc_do_not_load_profile_help": "May be required for Cloudflare OpenID",
   "config.oidc_scheme_override_help": "If the plugin is redirecting to an insecure URL, set this to \"https\"",
-  "config.oidc_port_override_help": "If the plugin is redirecting to an incorrect port, set this to the appropiate port"
+  "config.oidc_port_override_help": "If the plugin is redirecting to an incorrect port, set this to the appropiate port",
+  "config.managed_by_file_note": "This provider is set by a configuration file or by environment variables, so it cannot be edited here. Change it at that source and restart Jellyfin. A save made here would keep the stored value and leave a record in the log."
 }

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -196,7 +196,124 @@ const ssoConfigurationPage = {
   // backwards and would cause alert fatigue on well-configured providers. Do not add an OFF-direction
   // surfacing for them either: it would be noisy on the default.
   sensitiveFieldIds: ["AllowExistingAccountLink"],
+  // #1104. Which providers a declarative source decided, as the server reports them (#1102). Fetched once
+  // per configuration load and held as a promise, so an editor opened before the answer arrives still waits
+  // for it instead of rendering an editable form over a managed provider.
+  //
+  // ADVISORY ONLY, and that is the reason the failure arm below gives up rather than defending. The guard is
+  // on the server: a save to a managed provider keeps the stored value and is audited whether or not this
+  // page ever learned the provider was managed. So a report that does not arrive leaves the page exactly as
+  // it behaved before this existed, which costs a confusing edit; treating an unreachable report as "assume
+  // everything is managed" would instead lock an administrator out of forms the server would have accepted.
+  managedProviders: { OidConfigs: [], SamlConfigs: [] },
+  managedProvidersLoaded: null,
+  loadManagedProviders: () => {
+    ssoConfigurationPage.managedProvidersLoaded = ApiClient.getJSON(
+      ApiClient.getUrl("sso/Config/Managed"),
+    ).then(
+      (report) => {
+        ssoConfigurationPage.managedProviders = {
+          OidConfigs: Array.isArray(report && report.OidConfigs)
+            ? report.OidConfigs
+            : [],
+          SamlConfigs: Array.isArray(report && report.SamlConfigs)
+            ? report.SamlConfigs
+            : [],
+        };
+      },
+      () => {
+        ssoConfigurationPage.managedProviders = {
+          OidConfigs: [],
+          SamlConfigs: [],
+        };
+      },
+    );
+    return ssoConfigurationPage.managedProvidersLoaded;
+  },
+  // The unit is the PROVIDER and not the field, which is the server's measurement rather than this page's
+  // simplification: the declarative merge replaces a named provider whole, so a field the document omits
+  // comes back at its default at the next start. A form that greyed out three fields and left the rest
+  // editable would tell the administrator the opposite of what happens.
+  isManagedProvider: (protocol, provider_name) => {
+    if (!provider_name) {
+      return false;
+    }
+    const names =
+      protocol === "saml"
+        ? ssoConfigurationPage.managedProviders.SamlConfigs
+        : ssoConfigurationPage.managedProviders.OidConfigs;
+    return Array.isArray(names) && names.indexOf(provider_name) !== -1;
+  },
+  // The controls that stay usable on a managed provider: they read, they never write a provider field, and
+  // they are the ones an administrator most needs while diagnosing a provider they cannot edit here.
+  managedReadOnlyActions: [
+    "TestProvider",
+    "CopyRedirectUri",
+    "saml-TestProvider",
+    "saml-CopyAcsUrl",
+    "saml-CopyMetadataUrl",
+  ],
+  // Render the open editor as managed or as ordinary. Applied AFTER the provider has been loaded, because
+  // the role-map and folder-list widgets create their controls during that load and a pass made before it
+  // would leave every one of them editable. Always applied on both arms, so switching from a managed
+  // provider to an ordinary one restores the form rather than leaving it frozen.
+  applyManagedState: (page, protocol, provider_name) => {
+    const formId =
+      protocol === "saml" ? "sso-new-saml-provider" : "sso-new-oidc-provider";
+    const noteId =
+      protocol === "saml" ? "saml-managed-note" : "sso-managed-note";
+    const form = page.querySelector("#" + formId);
+    const note = page.querySelector("#" + noteId);
+    if (!form) {
+      return Promise.resolve();
+    }
+
+    const pending =
+      ssoConfigurationPage.managedProvidersLoaded || Promise.resolve();
+    return pending.then(() => {
+      // The editor may have moved on while the report was in flight. The selector is the state holder the
+      // save path already reads, so comparing against it is comparing against what would actually be saved.
+      const selectorId =
+        protocol === "saml" ? "#saml-selectProvider" : "#selectProvider";
+      const selector = page.querySelector(selectorId);
+      if (selector && selector.value !== provider_name) {
+        return;
+      }
+
+      const managed = ssoConfigurationPage.isManagedProvider(
+        protocol,
+        provider_name,
+      );
+
+      form
+        .querySelectorAll("input, select, textarea, button")
+        .forEach((element) => {
+          if (
+            ssoConfigurationPage.managedReadOnlyActions.indexOf(element.id) !==
+            -1
+          ) {
+            return;
+          }
+          element.disabled = managed;
+        });
+
+      if (note) {
+        // textContent, never innerHTML (#221). The text is fixed and carries no provider value, so nothing
+        // from the configuration reaches the DOM here at all.
+        note.textContent = managed
+          ? tr(
+              "config.managed_by_file_note",
+              "This provider is set by a configuration file or by environment variables, so it cannot be edited here. Change it at that source and restart Jellyfin. A save made here would keep the stored value and leave a record in the log.",
+            )
+          : "";
+        note.hidden = !managed;
+      }
+    });
+  },
   loadConfiguration: (page) => {
+    // Refreshed with the configuration itself: a provider that stopped being declaratively managed between
+    // two loads must not keep a frozen form, and one that started being managed must not keep an open one.
+    ssoConfigurationPage.loadManagedProviders();
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
         ssoConfigurationPage.populateProviders(page, config.OidConfigs);
@@ -339,6 +456,9 @@ const ssoConfigurationPage = {
       tr("config.new_provider", "New provider"),
     );
     ssoConfigurationPage.syncDependentFields(page);
+    // A new provider is never managed - no source has named it yet - so this arm exists to RESTORE a form
+    // left frozen by a managed provider opened just before (#1104).
+    ssoConfigurationPage.applyManagedState(page, "oid", "");
     ssoConfigurationPage.showEditor(page);
     page.querySelector("#sso-editor").scrollIntoView({ block: "start" });
     page.querySelector("#OidProviderName").focus();
@@ -900,6 +1020,8 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.syncDependentFields(page);
         // Reflect the loaded provider's name + base-URL override in the computed redirect URI (#724).
         ssoConfigurationPage.updateRedirectUri(page);
+        // Last, so the role-map and folder-list controls the calls above created are covered too (#1104).
+        ssoConfigurationPage.applyManagedState(page, "oid", provider_name);
       },
     );
   },
@@ -1587,6 +1709,8 @@ const ssoConfigurationPage = {
       tr("config.new_provider", "New provider"),
     );
     ssoConfigurationPage.syncSamlDependentFields(page);
+    // Restores a form left frozen by a managed provider opened just before (#1104); a new one is never managed.
+    ssoConfigurationPage.applyManagedState(page, "saml", "");
     ssoConfigurationPage.showSamlEditor(page);
     page.querySelector("#saml-editor").scrollIntoView({ block: "start" });
     page.querySelector("#saml-provider-name").focus();
@@ -1782,6 +1906,8 @@ const ssoConfigurationPage = {
 
         ssoConfigurationPage.syncSamlDependentFields(page);
         ssoConfigurationPage.updateSamlUrls(page);
+        // Last, for the same reason as the OpenID arm (#1104).
+        ssoConfigurationPage.applyManagedState(page, "saml", provider_name);
       },
     );
   },

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -475,6 +475,22 @@
               </p>
 
               <!--
+                The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
+                reason the editor title does not: config.js OWNS this text, writing it only for a provider
+                the server reports as declaratively managed, and the catalog is applied asynchronously - a
+                marker would let a late applyTo() paint the sentence over an editor whose provider is
+                ordinary and editable. The wording is localized at its source instead, through tr(). The
+                state is in the text and not in colour alone (#221), and role="status" announces it to a
+                screen reader when the editor is opened.
+              -->
+              <p
+                class="fieldDescription sso-managed-note"
+                id="sso-managed-note"
+                role="status"
+                hidden
+              ></p>
+
+              <!--
                 Start from a template (#726): a NON-persisting picker (no marker class, so it is never
                 saved and the conformance scan ignores it). Choosing a provider pre-fills only the
                 non-secret provider-specific fields (scopes, role-claim path, username claim, an endpoint
@@ -2117,6 +2133,22 @@
                 <span class="sso-required" aria-hidden="true">*</span>
                 are required.
               </p>
+
+              <!--
+                The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
+                reason the editor title does not: config.js OWNS this text, writing it only for a provider
+                the server reports as declaratively managed, and the catalog is applied asynchronously - a
+                marker would let a late applyTo() paint the sentence over an editor whose provider is
+                ordinary and editable. The wording is localized at its source instead, through tr(). The
+                state is in the text and not in colour alone (#221), and role="status" announces it to a
+                screen reader when the editor is opened.
+              -->
+              <p
+                class="fieldDescription sso-managed-note"
+                id="saml-managed-note"
+                role="status"
+                hidden
+              ></p>
 
               <!--
                 Start from a template (#726): the SAML counterpart of the OpenID picker above.


### PR DESCRIPTION
# What & why

Since #1102 a provider a declarative source decided cannot be changed through
the settings page: the save keeps the stored value and records the ignored
write. The page did not say so, so an administrator still filled in a form,
pressed Save, and had to read a log to learn why nothing moved. This makes that
state visible where the editing happens.

Opening a managed provider now disables its controls and shows one sentence
saying where the value comes from and what to do instead. Opening an ordinary
provider afterwards restores the form.

Refs #1104. It does not close it: the fourth clause of its Done-when asks for a
conformance test resolving every FIELD name the server can report to a marked
field in the form, and the server reports provider names rather than field
names, for the reason measured on #1102. The nearest guard the server can
actually honour is in place instead and is described below.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved where it belongs, which is the server. This page is
      advisory: the refusal and the audit happen in `ProviderConfigStore.Save`
      whether or not the browser ever learned a provider was managed. So an
      unreachable report leaves the page as it behaved before rather than
      freezing forms the server would have accepted - the opposite choice would
      turn one failed request into a settings page an administrator cannot use.
- [x] No secrets: the note is fixed text carrying no provider value, and the
      report it is driven from carries names only.
- [ ] A security review was performed. **No second reader looked at this
      change, and no separate review was run.** This is browser JavaScript,
      which CI does not exercise, so the conformance rules below and the
      falsifications stand in place of one and are named rather than implied.
- [x] Review record: no lens pass was run, so there is no per-lens verdict to
      record. What was produced instead is in Notes.
- [x] No IdP input is logged here. The note is set with `textContent`, never
      `innerHTML` (#221), so nothing from the configuration reaches the DOM as
      markup.

## Quality checklist

- [x] One helper serves both protocols; the OpenID and SAML paths differ only
      in the ids they pass.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why, not what.
- [x] Architecture-conformance: five new rules, in
      `ArchitectureConformanceTests.ManagedProviderSurface`.
- [x] Docs impact: the config-as-code page (#1116) has a clause describing this
      behaviour; it stays owed there rather than being filed again here.

## Verification

- [x] `--warnaserror` green on both target frameworks, 0 warnings.
- [x] Full suite green on both: `net9.0` 3357 total, 0 failed, 4 skipped;
      `net10.0` 3358 total, 0 failed, 4 skipped.
- [x] `npx prettier --check` clean for the two web files this touches.

Two disclosures on that last line. Local Prettier is 3.9.6 and reports style
issues in 22 files that this change does not touch and did not introduce; only
the two changed files were written, and both are clean. And the four skipped
tests are the four the suite already skips on this host: they bind a listener
off loopback, which raises a Windows consent dialog and needs an administrator
(#1227). They were not worked around.

## Notes

**None of this runs in a browser anywhere in CI**, which is why the guarding is
done at the source level and why each rule was broken before it was trusted.
Five rules read the two sides out of the files and compare them:

- the fetched route against the controller's own `HttpGet` template, read by
  reflection rather than pasted;
- the member names the page reads against the properties the report type
  declares;
- both note element ids against the markup, because `querySelector` answering
  null would leave a frozen form with no explanation on the page;
- every control id the managed state exempts against the markup, because a
  stale id there silently takes a read action away from the one provider an
  administrator cannot edit;
- the catalog key against `en.json`, because a missing key falls back to the
  built-in English and no localized installation would ever show the sentence.

Each was falsified: renaming the route, lower-casing a member name, renaming a
note id, renaming an exempted control, and deleting the catalog entry each
redden exactly the rule that covers it. The member-name falsification is worth
one line: it first appeared not to bite, because only one of the two
occurrences had been changed. Changing both reddens it.

**What is deliberately not here.** The provider cards in the list are not
marked as managed; only the editor says so. And the residual from #1102 is
unchanged: four elevated API routes and the config import write by a different
door than the settings page, so they are unaffected by either change. That is
#1415.
