### PR TITLE
Refuse every elevated write door to a declaratively managed provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,23 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **A provider a mounted file or the environment declared can no longer be
+  altered or deleted through the plugin's other administrator endpoints
+  (#1415).** The settings page already kept the declared value and discarded
+  what was posted over it, but that only covered the one route the page saves
+  through. Four endpoints wrote by a different door, and importing a
+  configuration wrote by a fifth, so an administrator adding or deleting a
+  declared provider through the API replaced or removed it until the next
+  restart put it back, and every login against that provider could fail in the
+  meantime with nothing in the log saying why. All five now refuse, and the
+  refusal names the provider and the source that decided it, so the change can
+  be made where it will survive a restart. A configuration import that names a
+  declared provider is refused whole rather than applied with those providers
+  quietly dropped, and it says how many it found, so a restore that cannot be
+  completed is never reported as one that was. A provider no source declared
+  adds, deletes and imports exactly as before, which is every provider on a
+  server that declares none.
+
 - **A back-channel logout token can no longer break the check that decides
   whether it is one (#1349).** The plugin looks for a fixed member in a logout
   token's `events` claim, and found it with the same call #1340 took out of the

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
@@ -63,8 +63,17 @@ public partial class ArchitectureConformanceTests
         //   ONE shape this rule has to keep out: a per-login event log would need a cap and a sweep, and the
         //   reason this needs neither is the bound, so the exemption is granted to the bounded design and not
         //   to the subject matter.
+        // - DeclarativeManagedProviders._oid / ._saml: the provider-name-to-source map (#1415). Exempt for a
+        //   different reason from the four above, and it is the reason rather than the subject that is
+        //   exempted. The type is IMMUTABLE - both fields are assigned once in a private constructor and
+        //   never written again, and Including() builds a whole new instance - so there is no mutable keyed
+        //   state here for a cap, a lifetime or a sweep to bound. Its population is the set of providers a
+        //   declarative document names, which the configuration already holds and already bounds, and the
+        //   whole instance is discarded at process exit because it is re-derived on every start. These two
+        //   fields were HashSets until a refusal had to say WHICH source owns a provider, so what changed is
+        //   the value beside each name, not where the state lives or how long it lives.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins", "DeclarativeManagedProviders._oid", "DeclarativeManagedProviders._saml" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
@@ -387,4 +387,77 @@ public class DeclarativeManagedProvidersTests
 
         Assert.Equal(linked, ((PluginConfiguration)persisted.Last()).OidConfigs["keycloak"].CanonicalLinks["sub-1"]);
     }
+
+    [Fact]
+    public void AFileDeclaredProvider_CarriesThePathAsItsSource()
+    {
+        // #1415: a write door that refuses has to say WHERE the change belongs, and the two sources are
+        // edited in different places. Pinned on the loader rather than only at the door, so the attribution
+        // is proven at the point it is recorded instead of at a point a test could hand-feed it.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        Assert.Equal("/run/secrets/sso.json", store.ManagedProviders.OidSource("keycloak"));
+        Assert.Null(store.ManagedProviders.OidSource("never-declared"));
+        Assert.Null(store.ManagedProviders.SamlSource("keycloak"));
+    }
+
+    [Fact]
+    public void AnEnvironmentDeclaredProvider_CarriesTheVariablePrefixAsItsSource()
+    {
+        // The other source, and the reason the attribution is not a path: an operator told to edit
+        // "/run/secrets/sso.json" for a provider that came out of the environment would look at a file that
+        // does not name it.
+        var (store, _, _, _) = CreateStore();
+        var variables = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [DeclarativeEnvironmentConfig.Prefix + "OidConfigs__keycloak__OidEndpoint"] = Endpoint,
+            [DeclarativeEnvironmentConfig.Prefix + "OidConfigs__keycloak__OidClientId"] = "from-the-environment",
+        };
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, DeclarativeEnvironmentConfig.Apply(store, variables, null));
+
+        Assert.Equal(DeclarativeEnvironmentConfig.Prefix, store.ManagedProviders.OidSource("keycloak"));
+    }
+
+    [Fact]
+    public void WhereBothSourcesNameOneProvider_TheAttributionIsTheOneThatAppliedLast()
+    {
+        // The sources apply in sequence and the environment is applied second, so the stored provider is the
+        // environment's. Attributing it to the file would send an operator to edit a value the next start
+        // would overwrite again, which is a worse answer than no attribution at all.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var variables = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [DeclarativeEnvironmentConfig.Prefix + "OidConfigs__keycloak__OidEndpoint"] = Endpoint,
+            [DeclarativeEnvironmentConfig.Prefix + "OidConfigs__keycloak__OidClientId"] = "from-the-environment",
+        };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, DeclarativeEnvironmentConfig.Apply(store, variables, null));
+
+        Assert.Equal(DeclarativeEnvironmentConfig.Prefix, store.ManagedProviders.OidSource("keycloak"));
+    }
+
+    [Fact]
+    public void ASecondSourceThatNamesNothing_ReleasesNothingTheFirstOneDeclared()
+    {
+        // The union rule the set already carried, re-asserted now that each name also carries a value: a
+        // dictionary rebuild that dropped the earlier entries would silently reopen every write door on a
+        // provider the file owns.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.NotConfigured,
+            DeclarativeEnvironmentConfig.Apply(store, new Dictionary<string, string?>(StringComparer.Ordinal), null));
+
+        Assert.Equal("/run/secrets/sso.json", store.ManagedProviders.OidSource("keycloak"));
+    }
 }

--- a/SSO-Auth.Tests/Http/SSOControllerManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerManagedProvidersTests.cs
@@ -48,7 +48,7 @@ public class SSOControllerManagedProvidersTests
         var declared = new PluginConfiguration();
         declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
         declared.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
-        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared);
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared, "/config/sso.json");
 
         var reported = Reported(harness);
 
@@ -71,7 +71,7 @@ public class SSOControllerManagedProvidersTests
 
         var declared = new PluginConfiguration();
         declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
-        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared);
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared, "/config/sso.json");
 
         var json = JsonSerializer.Serialize(Reported(harness));
 

--- a/SSO-Auth.Tests/Http/SSOControllerManagedWriteDoorTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerManagedWriteDoorTests.cs
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the elevated write doors that reach a provider WITHOUT going through the config-page
+/// save (#1415), via <see cref="SsoControllerHarness"/>. The freeze #1102 landed sits in
+/// <c>ProviderConfigStore.Save</c>, which only the settings page writes through; these five routes persist
+/// through <c>MutateConfiguration</c> or through <c>ConfigImport</c> and so walked straight past it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// What is pinned here is one property per door, in both directions. A declaratively managed provider is
+/// refused and nothing is written; a provider no source named still adds and deletes exactly as it did
+/// before, which is the half that would otherwise be broken in silence for every installation that mounts
+/// no document at all.
+/// </para>
+/// <para>
+/// The refusal has to name the SOURCE. Without it an administrator is told the change was refused and given
+/// nowhere to make it instead, and the two sources - a mounted file and the environment - are edited in
+/// different places on different machines.
+/// </para>
+/// </remarks>
+[Collection("SSOController")]
+public class SSOControllerManagedWriteDoorTests
+{
+    private const string Source = "/run/secrets/sso-providers.json";
+
+    // The store is process state on the plugin singleton the harness rebuilds per test, so declaring a set
+    // here cannot leak into the next test. Declared AFTER the harness is constructed for the same reason.
+    private static void Manage(Action<PluginConfiguration> declare)
+    {
+        var declared = new PluginConfiguration();
+        declare(declared);
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared, Source);
+    }
+
+    private static SsoControllerHarness ManagedKeycloakAndAdfs()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client" };
+            c.OidConfigs["hand-made"] = new OidConfig { OidClientId = "typed-client" };
+            c.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+            c.SamlConfigs["shib"] = new SamlConfig { SamlEndpoint = "https://shib.example.invalid/sso" };
+        });
+
+        Manage(declared =>
+        {
+            declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client" };
+            declared.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        });
+
+        return harness;
+    }
+
+    private static void AssertNamesTheSource(SsoControllerHarness harness, string message, string provider)
+    {
+        Assert.Contains(Source, message, StringComparison.Ordinal);
+        Assert.Contains(provider, message, StringComparison.Ordinal);
+
+        // The operator half: a refusal an administrator meets in a browser is also an audit line, or the
+        // server keeps no record of an elevated write it declined.
+        var audited = Assert.Single(
+            harness.ControllerLog.Entries,
+            e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal)
+                 && e.Message.Contains(Source, StringComparison.Ordinal));
+        Assert.Contains(provider, audited.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OidAdd_ManagedProvider_Throws_AndLeavesTheDeclaredValueStored()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => harness.Controller.OidAdd("keycloak", new OidConfig { OidClientId = "attacker-client" }));
+
+        AssertNamesTheSource(harness, ex.Message, "keycloak");
+        Assert.Equal("declared-client", SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidClientId));
+    }
+
+    [Fact]
+    public void SamlAdd_ManagedProvider_Throws_AndLeavesTheDeclaredValueStored()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => harness.Controller.SamlAdd("adfs", new SamlConfig { SamlEndpoint = "https://attacker.example.invalid/sso" }));
+
+        AssertNamesTheSource(harness, ex.Message, "adfs");
+        Assert.Equal(
+            "https://adfs.example.invalid/sso",
+            SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].SamlEndpoint));
+    }
+
+    [Fact]
+    public void OidDel_ManagedProvider_Throws_AndTheProviderSurvives()
+    {
+        // The availability half of this issue. Deleting a managed provider fails every login against it
+        // until the next start puts it back, and nothing in the log said why.
+        var harness = ManagedKeycloakAndAdfs();
+
+        var ex = Assert.Throws<ArgumentException>(() => harness.Controller.OidDel("keycloak"));
+
+        AssertNamesTheSource(harness, ex.Message, "keycloak");
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("keycloak")));
+    }
+
+    [Fact]
+    public void SamlDel_ManagedProvider_Throws_AndTheProviderSurvives()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        var ex = Assert.Throws<ArgumentException>(() => harness.Controller.SamlDel("adfs"));
+
+        AssertNamesTheSource(harness, ex.Message, "adfs");
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("adfs")));
+    }
+
+    [Fact]
+    public void OidAdd_UnmanagedProvider_StillStores_WhileAnotherProviderIsManaged()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        harness.Controller.OidAdd("hand-made", new OidConfig { OidClientId = "re-typed-client" });
+
+        Assert.Equal("re-typed-client", SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["hand-made"].OidClientId));
+    }
+
+    [Fact]
+    public void SamlAdd_UnmanagedProvider_StillStores_WhileAnotherProviderIsManaged()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        harness.Controller.SamlAdd("shib", new SamlConfig { SamlEndpoint = "https://shib2.example.invalid/sso" });
+
+        Assert.Equal(
+            "https://shib2.example.invalid/sso",
+            SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["shib"].SamlEndpoint));
+    }
+
+    [Fact]
+    public void OidDel_UnmanagedProvider_StillDeletes_WhileAnotherProviderIsManaged()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        harness.Controller.OidDel("hand-made");
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("hand-made")));
+    }
+
+    [Fact]
+    public void SamlDel_UnmanagedProvider_StillDeletes_WhileAnotherProviderIsManaged()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        harness.Controller.SamlDel("shib");
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("shib")));
+    }
+
+    [Fact]
+    public void NoDeclarativeSource_LeavesAllFourDoorsExactlyAsTheyWere()
+    {
+        // Most installations mount nothing. If the guard read an empty set as "everything is managed" the
+        // settings page would still work (it writes through Save) while the API doors all refused, which is
+        // the regression a test of the refusal alone would not catch.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
+            c.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        });
+
+        harness.Controller.OidAdd("keycloak", new OidConfig { OidClientId = "client-2" });
+        harness.Controller.SamlAdd("adfs", new SamlConfig { SamlEndpoint = "https://adfs2.example.invalid/sso" });
+        harness.Controller.OidDel("keycloak");
+        harness.Controller.SamlDel("adfs");
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("keycloak")));
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("adfs")));
+        Assert.DoesNotContain(harness.ControllerLog.Entries, e => e.Message.Contains("refused", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ImportConfig_DocumentNamingAManagedProvider_RefusesTheWholeDocument()
+    {
+        // The stated answer for the fifth door: the whole import is refused, not the managed entries
+        // silently dropped. An administrator restoring a backup is told which providers stopped it, and the
+        // provider the document did NOT own is not applied either - a half-applied restore is the state
+        // nobody can see.
+        var harness = ManagedKeycloakAndAdfs();
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["keycloak"] = new OidConfig { OidClientId = "from-the-backup" };
+        imported.OidConfigs["from-elsewhere"] = new OidConfig { OidClientId = "unrelated-client" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        var refusal = Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(document));
+
+        var message = Assert.IsType<string>(refusal.Value);
+        AssertNamesTheSource(harness, message, "keycloak");
+        Assert.Equal("declared-client", SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidClientId));
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("from-elsewhere")));
+    }
+
+    [Fact]
+    public void ImportConfig_DocumentNamingNoManagedProvider_StillMerges()
+    {
+        var harness = ManagedKeycloakAndAdfs();
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["from-elsewhere"] = new OidConfig { OidClientId = "unrelated-client" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.IsType<NoContentResult>(harness.Controller.ImportConfig(document));
+
+        Assert.Equal(
+            "unrelated-client",
+            SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["from-elsewhere"].OidClientId));
+    }
+
+    [Fact]
+    public void ImportConfig_RefusalNamesEveryManagedProviderItFound()
+    {
+        // The count is what makes the refusal actionable: an administrator editing the document out of the
+        // first name only, and re-importing into the same refusal, is the loop a single name would create.
+        var harness = ManagedKeycloakAndAdfs();
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["keycloak"] = new OidConfig { OidClientId = "from-the-backup" };
+        imported.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://backup.example.invalid/sso" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        var refusal = Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(document));
+
+        Assert.Contains("2 declaratively managed provider", Assert.IsType<string>(refusal.Value), StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            harness.ControllerLog.Entries.Count(e => e.Message.Contains("Config/Import refused", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ImportConfig_RefusalIsSingleLine_SoItCannotSplitALogLine()
+    {
+        // The source is read from the environment or from a path an operator supplies, so it is not trusted
+        // to be one line. The echoed body is the place a line ending would reach a log through a caller.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client" });
+        var declared = new PluginConfiguration();
+        declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client" };
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared, "/mnt/sso.json\nINJECTED audit line");
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["keycloak"] = new OidConfig { OidClientId = "from-the-backup" };
+        var refusal = Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(
+            new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported }));
+
+        var message = Assert.IsType<string>(refusal.Value);
+        Assert.DoesNotContain('\n', message);
+        Assert.DoesNotContain('\r', message);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -234,6 +234,33 @@ internal static class SsoAudit
             provider?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records an elevated write door refusing to alter or delete a declaratively managed provider (#1415).
+    /// The config-page save IGNORES such a write and keeps the stored value (see
+    /// <see cref="DeclarativeWriteIgnored"/>); these doors carry a single-provider intent that cannot be
+    /// half-honoured, so they refuse instead and nothing is written. Warning for the same reason: an
+    /// administrator has just asked for a change the server did not make.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="door">The route that was refused, e.g. <c>OID/Del</c>.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name. No field value is recorded - the point is which provider, not what was posted.</param>
+    /// <param name="source">What names the source that owns the provider, so the line says where the change belongs.</param>
+    internal static void DeclarativeWriteRefused(ILogger logger, string door, string protocol, string provider, string source)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] {Door} refused for {Protocol} provider '{Provider}': it is managed by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
+            door?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            source?.ReplaceLineEndings(string.Empty));
+    }
+
     /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="provider">The provider name.</param>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -674,6 +674,47 @@ public class SSOController : ControllerBase
         }
     }
 
+    // The refusal every elevated write door gives for a declaratively managed provider (#1415), defined once
+    // so five doors and their tests cannot drift into five wordings. It names the source, because a refusal
+    // that does not say where the change belongs leaves an administrator with nowhere to make it.
+    private static string ManagedProviderRefusal(string protocol, string provider, string source) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"The {protocol} provider '{provider}' is managed by the declarative source {source}. Edit that source and restart the server; a change made here would be undone at the next start.");
+
+    /// <summary>
+    /// Refuses an elevated single-provider write against a provider a declarative source decided (#1415), and
+    /// audits the refusal so an operator reading the log sees why nothing changed.
+    /// </summary>
+    /// <remarks>
+    /// REFUSE rather than the config-page save's ignore-and-keep, and the difference is what the caller asked
+    /// for. A settings-page save posts the WHOLE configuration, so a managed provider inside it is almost
+    /// always an untouched form field riding along with an unrelated edit, and refusing the save would block
+    /// that edit; the freeze there keeps the stored value and lets the rest through. These four doors carry a
+    /// single-provider intent and nothing else, so there is no unrelated work to protect: honouring the call
+    /// while doing nothing would report success for a change that did not happen.
+    /// <para>
+    /// Runs BEFORE the body validators on the Add doors, because a managed provider's posted body is never
+    /// applied and its shape therefore decides nothing. That also keeps the door from answering a body
+    /// complaint an administrator would then fix, only to meet this refusal on the next attempt.
+    /// </para>
+    /// </remarks>
+    /// <param name="door">The route being refused, for the audit line.</param>
+    /// <param name="protocol">The protocol label, <c>OpenID</c> or <c>SAML</c>.</param>
+    /// <param name="provider">The provider the caller named.</param>
+    /// <param name="source">What names the owning source, or null when the provider is not managed and the call proceeds.</param>
+    /// <exception cref="ArgumentException">The provider is declaratively managed.</exception>
+    private void RejectManagedProviderWrite(string door, string protocol, string provider, string? source)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        SsoAudit.DeclarativeWriteRefused(_logger, door, protocol, provider, source);
+        throw new ArgumentException(ManagedProviderRefusal(protocol, provider, source), nameof(provider));
+    }
+
     /// <summary>
     /// Adds an OpenID auth configuration. Requires administrator privileges. If the provider already exists, it will be removed and readded.
     /// </summary>
@@ -683,6 +724,7 @@ public class SSOController : ControllerBase
     [HttpPost("OID/Add/{provider}")]
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
+        RejectManagedProviderWrite("OID/Add", OpenIdProtocol, provider, SSOPlugin.Instance.ConfigStore.ManagedProviders.OidSource(provider));
         RejectNullProviderBody(config);
         RejectInvalidBaseUrlOverride(config.BaseUrlOverride);
         // Reject a malformed generic permission-role mapping (#164) at the door, exactly like the base-URL
@@ -738,6 +780,7 @@ public class SSOController : ControllerBase
     [HttpGet("OID/Del/{provider}")]
     public void OidDel(string provider)
     {
+        RejectManagedProviderWrite("OID/Del", OpenIdProtocol, provider, SSOPlugin.Instance.ConfigStore.ManagedProviders.OidSource(provider));
         var removed = SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
         if (removed)
         {
@@ -1201,6 +1244,7 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/Add/{provider}")]
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
+        RejectManagedProviderWrite("SAML/Add", SamlProtocol, provider, SSOPlugin.Instance.ConfigStore.ManagedProviders.SamlSource(provider));
         RejectNullProviderBody(newConfig);
         RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
         RejectInvalidSamlSloEndpoint(newConfig.SamlSloEndpoint);
@@ -1251,6 +1295,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/Del/{provider}")]
     public OkResult SamlDel(string provider)
     {
+        RejectManagedProviderWrite("SAML/Del", SamlProtocol, provider, SSOPlugin.Instance.ConfigStore.ManagedProviders.SamlSource(provider));
         var removed = SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
         if (removed)
         {
@@ -1489,6 +1534,26 @@ public class SSOController : ControllerBase
         if (document is null)
         {
             return BadRequest("The configuration import document is missing or is not valid JSON.");
+        }
+
+        // #1415: a document naming a declaratively managed provider refuses the WHOLE import, before anything
+        // is merged. The whole document rather than the offending providers, because an import is already
+        // all-or-nothing on every other rejection (one invalid provider rejects the document), and because
+        // dropping part of a document silently is the worse failure: an administrator restoring a backup
+        // would be told it succeeded and would have no way to see which providers did not arrive. Refusing
+        // names them, so the repair is to delete those entries from the document and import the rest.
+        var managed = SSOPlugin.Instance.ConfigStore.ManagedProviders.NamedIn(document.Configuration);
+        if (managed.Count > 0)
+        {
+            foreach (var (protocol, provider, source) in managed)
+            {
+                SsoAudit.DeclarativeWriteRefused(_logger, "Config/Import", protocol, provider, source);
+            }
+
+            var (firstProtocol, firstProvider, firstSource) = managed[0];
+            return BadRequest(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{ManagedProviderRefusal(firstProtocol, firstProvider, firstSource)} The import names {managed.Count} declaratively managed provider(s) and none of it was applied; remove them from the document and import the rest.").ReplaceLineEndings(string.Empty));
         }
 
         try

--- a/SSO-Auth/Config/DeclarativeManagedProviders.cs
+++ b/SSO-Auth/Config/DeclarativeManagedProviders.cs
@@ -40,28 +40,37 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// </remarks>
 internal sealed class DeclarativeManagedProviders
 {
+    /// <summary>The protocol label a refusal and an audit line name an OpenID provider by.</summary>
+    internal const string OpenIdProtocol = "OpenID";
+
+    /// <summary>The protocol label a refusal and an audit line name a SAML provider by.</summary>
+    internal const string SamlProtocol = "SAML";
+
     /// <summary>
     /// The set of an installation that configures no declarative source: nothing is managed, nothing is
     /// frozen, and the config page behaves exactly as it did before this existed.
     /// </summary>
     internal static readonly DeclarativeManagedProviders None = new(
-        new HashSet<string>(StringComparer.Ordinal),
-        new HashSet<string>(StringComparer.Ordinal));
+        new Dictionary<string, string>(StringComparer.Ordinal),
+        new Dictionary<string, string>(StringComparer.Ordinal));
 
-    private readonly HashSet<string> _oid;
-    private readonly HashSet<string> _saml;
+    // Name -> what names the source that owns it. A dictionary rather than a set because a refusal that
+    // cannot say WHICH source decided a provider leaves an administrator with nothing to edit: the two
+    // sources are a mounted document and the environment, and they are changed in different places.
+    private readonly Dictionary<string, string> _oid;
+    private readonly Dictionary<string, string> _saml;
 
-    private DeclarativeManagedProviders(HashSet<string> oid, HashSet<string> saml)
+    private DeclarativeManagedProviders(Dictionary<string, string> oid, Dictionary<string, string> saml)
     {
         _oid = oid;
         _saml = saml;
     }
 
     /// <summary>Gets the OpenID provider names the declarative sources named, ordered so the report is stable.</summary>
-    internal IReadOnlyList<string> OidConfigs => _oid.OrderBy(name => name, StringComparer.Ordinal).ToList();
+    internal IReadOnlyList<string> OidConfigs => _oid.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList();
 
     /// <summary>Gets the SAML provider names the declarative sources named, ordered so the report is stable.</summary>
-    internal IReadOnlyList<string> SamlConfigs => _saml.OrderBy(name => name, StringComparer.Ordinal).ToList();
+    internal IReadOnlyList<string> SamlConfigs => _saml.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList();
 
     /// <summary>Gets a value indicating whether no provider is declaratively managed.</summary>
     internal bool IsEmpty => _oid.Count == 0 && _saml.Count == 0;
@@ -73,19 +82,66 @@ internal sealed class DeclarativeManagedProviders
     /// the first source's providers.
     /// </summary>
     /// <param name="applied">The configuration a source just applied; null adds nothing.</param>
+    /// <param name="source">
+    /// What names the source in a refusal: the document's path, or the environment variable prefix. Where
+    /// both sources name one provider the LAST one wins the attribution, because the sources apply in
+    /// sequence and the later one is the value the store now holds.
+    /// </param>
     /// <returns>The widened set.</returns>
-    internal DeclarativeManagedProviders Including(PluginConfiguration? applied)
+    internal DeclarativeManagedProviders Including(PluginConfiguration? applied, string source)
     {
         if (applied is null)
         {
             return this;
         }
 
-        var oid = new HashSet<string>(_oid, StringComparer.Ordinal);
-        var saml = new HashSet<string>(_saml, StringComparer.Ordinal);
-        Add(oid, applied.OidConfigs);
-        Add(saml, applied.SamlConfigs);
+        var oid = new Dictionary<string, string>(_oid, StringComparer.Ordinal);
+        var saml = new Dictionary<string, string>(_saml, StringComparer.Ordinal);
+        Add(oid, applied.OidConfigs, source);
+        Add(saml, applied.SamlConfigs, source);
         return new DeclarativeManagedProviders(oid, saml);
+    }
+
+    /// <summary>
+    /// Answers what names the source that owns the OpenID provider <paramref name="name"/>, or null where no
+    /// declarative source named it and every write door is open on it exactly as it always was.
+    /// </summary>
+    /// <param name="name">The OpenID provider name a write door was asked to alter or delete.</param>
+    /// <returns>The source, or null when the provider is not declaratively managed.</returns>
+    internal string? OidSource(string name) => Source(_oid, name);
+
+    /// <summary>
+    /// Answers what names the source that owns the SAML provider <paramref name="name"/>, or null where no
+    /// declarative source named it.
+    /// </summary>
+    /// <param name="name">The SAML provider name a write door was asked to alter or delete.</param>
+    /// <returns>The source, or null when the provider is not declaratively managed.</returns>
+    internal string? SamlSource(string name) => Source(_saml, name);
+
+    /// <summary>
+    /// Answers every managed provider <paramref name="incoming"/> names, so a whole-document write door
+    /// (<c>Config/Import</c>) can refuse before it merges anything and say which providers stopped it.
+    /// </summary>
+    /// <remarks>
+    /// Ordered by protocol then by name, so one document produces the same refusal on two runs and a test can
+    /// pin the wording. The comparison is by NAME only: the unit of management is the provider, so a document
+    /// naming a managed one is refused whether or not the fields it carries differ from the stored ones.
+    /// Comparing values instead would admit a document that happens to agree today through a door the next
+    /// edit of that same document walks straight past.
+    /// </remarks>
+    /// <param name="incoming">The document's configuration payload; null names nothing.</param>
+    /// <returns>The (protocol, provider, source) of each managed provider the payload names; empty when it names none.</returns>
+    internal IReadOnlyList<(string Protocol, string Provider, string Source)> NamedIn(PluginConfiguration? incoming)
+    {
+        if (incoming is null || IsEmpty)
+        {
+            return [];
+        }
+
+        var named = new List<(string Protocol, string Provider, string Source)>();
+        Collect(_oid, OpenIdProtocol, incoming.OidConfigs, named);
+        Collect(_saml, SamlProtocol, incoming.SamlConfigs, named);
+        return named;
     }
 
     /// <summary>
@@ -111,11 +167,11 @@ internal sealed class DeclarativeManagedProviders
             return;
         }
 
-        Reinject(_oid, "OpenID", incoming.OidConfigs, live.OidConfigs, ignored, (holder, name, provider) => holder.OidConfigs[name] = provider);
-        Reinject(_saml, "SAML", incoming.SamlConfigs, live.SamlConfigs, ignored, (holder, name, provider) => holder.SamlConfigs[name] = provider);
+        Reinject(_oid, OpenIdProtocol, incoming.OidConfigs, live.OidConfigs, ignored, (holder, name, provider) => holder.OidConfigs[name] = provider);
+        Reinject(_saml, SamlProtocol, incoming.SamlConfigs, live.SamlConfigs, ignored, (holder, name, provider) => holder.SamlConfigs[name] = provider);
     }
 
-    private static void Add<T>(HashSet<string> names, SerializableDictionary<string, T>? providers)
+    private static void Add<T>(Dictionary<string, string> names, SerializableDictionary<string, T>? providers, string source)
         where T : ProviderConfigBase
     {
         if (providers is null)
@@ -125,14 +181,40 @@ internal sealed class DeclarativeManagedProviders
 
         foreach (var kvp in providers)
         {
-            names.Add(kvp.Key);
+            names[kvp.Key] = source;
+        }
+    }
+
+    private static string? Source(Dictionary<string, string> managed, string name) =>
+        name is not null && managed.TryGetValue(name, out var source) ? source : null;
+
+    private static void Collect<T>(
+        Dictionary<string, string> managed,
+        string protocol,
+        SerializableDictionary<string, T>? incoming,
+        List<(string Protocol, string Provider, string Source)> named)
+        where T : ProviderConfigBase
+    {
+        if (incoming is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in incoming.OrderBy(entry => entry.Key, StringComparer.Ordinal))
+        {
+            // A null-valued entry carries nothing to import and is skipped by the merge (#538), so refusing
+            // on one would refuse a document that could not have altered the managed provider anyway.
+            if (kvp.Value is not null && managed.TryGetValue(kvp.Key, out var source))
+            {
+                named.Add((protocol, kvp.Key, source));
+            }
         }
     }
 
     // One loop for both protocols: the maps differ only in the concrete provider type, and every rule below
     // - freeze, re-add, report a difference - is the same on either.
     private static void Reinject<T>(
-        HashSet<string> managed,
+        Dictionary<string, string> managed,
         string protocol,
         SerializableDictionary<string, T>? incoming,
         SerializableDictionary<string, T>? live,
@@ -145,7 +227,7 @@ internal sealed class DeclarativeManagedProviders
             return;
         }
 
-        foreach (var name in managed)
+        foreach (var name in managed.Keys)
         {
             if (!live.TryGetValue(name, out var stored) || stored is null)
             {

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -331,7 +331,7 @@ internal static class DeclarativeProviderConfig
         // nothing still decided the providers it names - it agrees with the store rather than being absent
         // from it - so releasing those providers to the config page whenever a restart happens to find the
         // mount already applied would make the freeze depend on whether anything moved.
-        store.RecordDeclarativelyManaged(document.Configuration);
+        store.RecordDeclarativelyManaged(document.Configuration, sourcePath);
 
         if (!changed)
         {

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -60,11 +60,16 @@ internal sealed class ProviderConfigStore
     /// been accepted; a rejected document records nothing, because it changed nothing.
     /// </summary>
     /// <param name="applied">The configuration the source applied.</param>
-    internal void RecordDeclarativelyManaged(PluginConfiguration? applied)
+    /// <param name="source">
+    /// What names the source in a refusal an administrator reads: the document's path, or the environment
+    /// variable prefix. Carried per provider so a write door that refuses can say where to make the change
+    /// instead, which is the difference between a refusal and a dead end (#1415).
+    /// </param>
+    internal void RecordDeclarativelyManaged(PluginConfiguration? applied, string source)
     {
         lock (Sync)
         {
-            ManagedProviders = ManagedProviders.Including(applied);
+            ManagedProviders = ManagedProviders.Including(applied, source);
         }
     }
 


### PR DESCRIPTION
# What & why

The freeze that came with the declarative sources sits in `ProviderConfigStore.Save`, which is the only route the settings page writes through. Five other elevated routes reach a provider without passing it, so a provider a mounted file or the environment decided could be overwritten or deleted through the API and stayed that way until the next start put it back. Every login against that provider could fail in between, and no line in the log said why.

All five refuse now.

| Door | Persists through | Before | Now |
| --- | --- | --- | --- |
| `POST OID/Add/{provider}` | `MutateConfiguration` | overwrote the declared provider | refuses, naming the source |
| `POST SAML/Add/{provider}` | `MutateConfiguration` | overwrote the declared provider | refuses, naming the source |
| `GET OID/Del/{provider}` | `MutateConfiguration` | deleted the declared provider | refuses, naming the source |
| `GET SAML/Del/{provider}` | `MutateConfiguration` | deleted the declared provider | refuses, naming the source |
| `POST Config/Import` | `ConfigImport.Apply` | merged over the declared provider | refuses the whole document |

The four single-provider doors throw before touching the configuration, which is the shape their existing body guards already use. `Config/Import` refuses the whole document and reports how many managed providers it found, rather than merging the rest with those entries dropped: an import is already all-or-nothing on every other rejection, and a half-applied restore is a state the administrator cannot see.

**Refusing rather than the save's ignore-and-keep** is a difference in what the caller asked for. A settings-page save posts the whole configuration, so a managed provider inside it is usually an untouched form field riding along with an unrelated edit, and refusing the save would block that edit. These doors carry a single-provider intent and nothing else, so honouring the call while doing nothing would report success for a change that did not happen.

**Naming the source** needed the managed set to carry one, so it keys each provider name to the path or the variable prefix that declared it instead of holding a bare name. Where both sources name one provider the later one wins the attribution: the environment applies second and is the value the store now holds, and sending an operator to edit the file for a provider the environment decided would send them to a change the next start overwrites.

A provider no source declared adds, deletes and imports exactly as before, which is every provider on a server that declares none, and that direction is pinned per route rather than left to follow from the refusal.

Closes #1415

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export. The refusal and
      the audit line carry the protocol, the provider name and the source, and
      no field value. `Config/Managed` is unchanged and still carries names only.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. Every finding of either kind carries
      a disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader on this change, and the two boxes above are left unticked
rather than answered.** No review lens was run and no review record exists. What
stands in its place is the evidence under Verification: every guard was removed
and the suite watched, and the falsifier output is quoted rather than described.

The source string reaches an administrator in a refusal body. It comes from an
environment variable or a path an operator supplied, so it is not trusted to be
one line: the echoed import body strips line endings, and both audit calls strip
them inline at the log call rather than through a helper.
`ImportConfig_RefusalIsSingleLine_SoItCannotSplitALogLine` pins that. The doors
are all behind `Policies.RequiresElevation`, which is where they already were.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. One refusal wording and one guard method serve all five
      doors.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki page describes the declarative
      sources today (`grep -ril declarative` over the tracked markdown returns
      `CHANGELOG.md` only), so there is nothing to bring into step. The CHANGELOG
      entry is included here.

`MutableKeyedState_LivesOnlyInsideStoreLikeTypes` reddened on this change, because
the two fields moved from `HashSet` to `Dictionary` to carry the attribution. The
exemption added there is granted to the reason rather than to the subject: the
type is immutable, both fields are assigned once in a private constructor and
never written again, `Including` builds a whole new instance, and the population
is the provider set the configuration already holds and bounds.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror` on the test project so the analyzers are
promoted, and the full suite through the built runner:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror -v q   ->  0 warnings, 0 errors
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror -v q   ->  0 warnings, 0 errors
$ dotnet build --warnaserror -v q                                                   ->  0 warnings, 0 errors

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3374, Errors: 0, Failed: 0, Skipped: 4
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3375, Errors: 0, Failed: 0, Skipped: 4
```

The four skips are `SsoHttpTests`, unrelated to this change and skipped on this
platform for the reason each one prints: binding a listener off loopback raises a
Windows consent dialog that needs an administrator (#1227). They were not worked
around.

Prettier reports every markdown, js and css file in the tree as unformatted on
this machine, including files this branch does not touch, because the checkout
carries CRLF. The check that means something is the one against what git stores:

```
$ tr -d '\r' < CHANGELOG.md > /tmp/CHANGELOG.md && npx prettier --check /tmp/CHANGELOG.md
Checking formatting...
All matched files use Prettier code style!
```

### Every guard proven by deleting it

One guard removed at a time, rebuilt, and the class re-run. A build that failed
to compile was treated as no result and redone, because a stale runner prints a
green suite.

```
--- OID/Add guard deleted  ---  Total: 13, Failed: 1
--- SAML/Add guard deleted ---  Total: 13, Failed: 1
--- OID/Del guard deleted  ---  Total: 13, Failed: 1
--- SAML/Del guard deleted ---  Total: 13, Failed: 1
--- Config/Import guard block deleted ---
    ImportConfig_RefusalIsSingleLine_SoItCannotSplitALogLine [FAIL]
    ImportConfig_RefusalNamesEveryManagedProviderItFound [FAIL]
    ImportConfig_DocumentNamingAManagedProvider_RefusesTheWholeDocument [FAIL]
    Total: 13, Failed: 3
```

And the attribution, falsified by recording a constant instead of the real source:

```
--- store.RecordDeclarativelyManaged(document.Configuration, "a declarative source") ---
    WhereBothSourcesNameOneProvider_TheAttributionIsTheOneThatAppliedLast [FAIL]
    ASecondSourceThatNamesNothing_ReleasesNothingTheFirstOneDeclared [FAIL]
    AFileDeclaredProvider_CarriesThePathAsItsSource [FAIL]
    AnEnvironmentDeclaredProvider_CarriesTheVariablePrefixAsItsSource [FAIL]
    Total: 17, Failed: 4
```

Each deletion reddens only the test that names the guard, and the four
"still works when nothing is managed" tests stay green through every one of them.

## Notes

Out of scope, and deliberately so:

- The attribution is per provider, not per field. That is the unit the merge
  works in, as `DeclarativeManagedProviders` already records: naming one field of
  an existing provider leaves the rest of it at its defaults.
- `Config/Managed` is untouched. It still carries names only, which is what the
  config page consumes, and the source is not added to it: this change needed it
  in a refusal an administrator reads, not in a document a browser renders.
- The refusal is not localized. Every other refusal on these doors is English
  too, and splitting one out would leave a page with two conventions.
