### PR TITLE
Add account-link export and import to the config page transfer section

### DIFF
--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -70,5 +70,17 @@
   "config.oidc_do_not_load_profile_help": "May be required for Cloudflare OpenID",
   "config.oidc_scheme_override_help": "If the plugin is redirecting to an insecure URL, set this to \"https\"",
   "config.oidc_port_override_help": "If the plugin is redirecting to an incorrect port, set this to the appropiate port",
-  "config.managed_by_file_note": "This provider is set by a configuration file or by environment variables, so it cannot be edited here. Change it at that source and restart Jellyfin. A save made here would keep the stored value and leave a record in the log."
+  "config.managed_by_file_note": "This provider is set by a configuration file or by environment variables, so it cannot be edited here. Change it at that source and restart Jellyfin. A save made here would keep the stored value and leave a record in the log.",
+  "config.link_transfer_title": "Export / Import Account Links",
+  "config.link_transfer_help": "Account links are stored against Jellyfin user ids, which a rebuilt user database does not reissue, so a migration needs this second file as well as the configuration file above. It is keyed on usernames and is NOT redacted: it contains usernames and the identity-provider subject identifiers behind each link, so treat it as identity data. Import restores every link onto the account this server holds for that username today, and rejects the whole file rather than restoring part of it if it names a user or a provider this instance does not have, or a link this instance already holds for a different account. Requires administrator privileges.",
+  "config.export_links": "Export Account Links",
+  "config.import_links": "Import Account Links",
+  "config.link_export_running": "Exporting account links…",
+  "config.link_export_done": "Exported. This file is not redacted: it carries usernames and the identity-provider subject identifier behind each link.",
+  "config.link_export_failed": "Could not export the account links. Make sure you are signed in as an administrator, then try again.",
+  "config.link_import_running": "Importing account links…",
+  "config.link_import_done": "Imported. Each link was restored onto the account this server holds for its username today.",
+  "config.link_import_not_json": "That file is not valid JSON. Choose an account-link file exported from this plugin.",
+  "config.link_import_failed": "Could not import the account links. The file was rejected by the server, or you are not signed in as an administrator.",
+  "config.link_import_rejected": "The server rejected the file: {reason}"
 }

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -1450,6 +1450,133 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.renderTransferMessage(container, message);
       });
   },
+  // Account-link export (#1131). The second half of a migration: the configuration export deliberately
+  // withholds the link maps, and a rebuilt user database reissues every id the links are stored against, so
+  // the links travel in their own username-keyed file. Same Blob download as exportConfig - never
+  // navigation - so the admin's auth header is sent and nothing lands in a URL. The file is NOT redacted,
+  // and the status line says so rather than leaving the admin to infer it from the config export's wording.
+  exportLinks: (page) => {
+    const container = page.querySelector("#LinkTransferResult");
+    ssoConfigurationPage.renderTransferMessage(
+      container,
+      tr("config.link_export_running", "Exporting account links…"),
+    );
+
+    return ApiClient.getJSON(ApiClient.getUrl("sso/Config/Links/Export")).then(
+      (document_json) => {
+        const blob = new Blob([JSON.stringify(document_json, null, 2)], {
+          type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = window.document.createElement("a");
+        anchor.href = url;
+        anchor.download = "sso-account-links.json";
+        window.document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          tr(
+            "config.link_export_done",
+            "Exported. This file is not redacted: it carries usernames and the identity-provider subject identifier behind each link.",
+          ),
+        );
+      },
+      () =>
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          tr(
+            "config.link_export_failed",
+            "Could not export the account links. Make sure you are signed in as an administrator, then try again.",
+          ),
+        ),
+    );
+  },
+  // Account-link import (#1131). Parses locally first, so a file that is not JSON is reported here and
+  // never sent. The server validates the whole document before writing a single link and persists nothing
+  // when it refuses, so a rejection leaves the stored link table exactly as it was.
+  //
+  // Unlike importConfig, a refusal reports the SERVER's reason. The refusals that matter here name the
+  // entry that could not be restored - an unknown username, an absent provider, a canonical name this
+  // instance already links to a different account - and a generic message would leave an admin with a file
+  // they cannot fix. The reason is admin-supplied data (it echoes the file the admin chose) returned to
+  // that same admin, and it reaches the DOM through renderTransferMessage's textContent, so it is inert.
+  // A rejection body that cannot be read falls back to the generic message rather than showing nothing.
+  importLinks: (page, file) => {
+    const container = page.querySelector("#LinkTransferResult");
+    if (!file) {
+      return Promise.resolve();
+    }
+
+    ssoConfigurationPage.renderTransferMessage(
+      container,
+      tr("config.link_import_running", "Importing account links…"),
+    );
+    return file
+      .text()
+      .then((text) => {
+        let document_json;
+        try {
+          document_json = JSON.parse(text);
+        } catch (e) {
+          throw new Error("not-json");
+        }
+
+        return ApiClient.fetch({
+          type: "POST",
+          url: ApiClient.getUrl("sso/Config/Links/Import"),
+          data: JSON.stringify(document_json),
+          contentType: "application/json",
+        });
+      })
+      .then(() => {
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          tr(
+            "config.link_import_done",
+            "Imported. Each link was restored onto the account this server holds for its username today.",
+          ),
+        );
+      })
+      .catch((e) => {
+        if (e && e.message === "not-json") {
+          ssoConfigurationPage.renderTransferMessage(
+            container,
+            tr(
+              "config.link_import_not_json",
+              "That file is not valid JSON. Choose an account-link file exported from this plugin.",
+            ),
+          );
+          return;
+        }
+
+        // ApiClient.fetch rejects with the Response on a non-2xx status, so the refusal text is read off it
+        // when it is there. Anything else - an expired session, a network failure, a rejection shape this
+        // does not recognise - falls through to the generic message.
+        const generic = tr(
+          "config.link_import_failed",
+          "Could not import the account links. The file was rejected by the server, or you are not signed in as an administrator.",
+        );
+        const body =
+          e && typeof e.text === "function" ? e.text() : Promise.reject();
+
+        return Promise.resolve(body).then(
+          (reason) =>
+            ssoConfigurationPage.renderTransferMessage(
+              container,
+              reason
+                ? tr(
+                    "config.link_import_rejected",
+                    "The server rejected the file: {reason}",
+                    { reason: String(reason) },
+                  )
+                : generic,
+            ),
+          () => ssoConfigurationPage.renderTransferMessage(container, generic),
+        );
+      });
+  },
   renderTransferMessage: (container, message) => {
     container.replaceChildren();
     const line = window.document.createElement("p");
@@ -2557,6 +2684,27 @@ export default function initSsoConfigurationPage(view) {
     // Clear the input so choosing the same file again re-triggers change.
     e.target.value = "";
     ssoConfigurationPage.importConfig(view, file);
+  });
+
+  // Account-link transfer (#1131): the exact parallel of the configuration pair above, against its own
+  // endpoints and its own status region, so one file's outcome never overwrites the other's.
+  view.querySelector("#ExportLinks").addEventListener("click", (e) => {
+    ssoConfigurationPage.exportLinks(view);
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#ImportLinks").addEventListener("click", (e) => {
+    view.querySelector("#ImportLinksFile").click();
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#ImportLinksFile").addEventListener("change", (e) => {
+    const file = e.target.files && e.target.files[0];
+    // Clear the input so choosing the same file again re-triggers change.
+    e.target.value = "";
+    ssoConfigurationPage.importLinks(view, file);
   });
 
   view.querySelector("#sso-self-service-link").href =

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -223,6 +223,71 @@
                 </button>
 
                 <div id="ConfigTransferResult"></div>
+
+                <!--
+                  Account-link transfer (#1131). The SECOND file of a migration, kept in the same section as
+                  the configuration transfer so an administrator meets both together, and separated from it
+                  by its own heading because the two files differ in the way that matters: the configuration
+                  export is redacted, this one is not. It carries usernames paired with identity-provider
+                  subject identifiers, which is why the server makes an administrator ask for it explicitly
+                  (SSOController.ExportLinks) rather than folding it into the configuration export. Both
+                  endpoints are elevation-gated; the import is validated whole and applied atomically, and it
+                  refuses a canonical name this instance already links to a different account, so a crafted
+                  file cannot remap a subject onto another account. Status is rendered with textContent,
+                  never innerHTML (#221).
+                -->
+                <h3
+                  class="checkboxListLabel"
+                  data-i18n="config.link_transfer_title"
+                >
+                  Export / Import Account Links
+                </h3>
+                <div
+                  class="fieldDescription"
+                  data-i18n="config.link_transfer_help"
+                >
+                  Account links are stored against Jellyfin user ids, which a
+                  rebuilt user database does not reissue, so a migration needs
+                  this second file as well as the configuration file above. It
+                  is keyed on usernames and is NOT redacted: it contains
+                  usernames and the identity-provider subject identifiers behind
+                  each link, so treat it as identity data. Import restores every
+                  link onto the account this server holds for that username
+                  today, and rejects the whole file rather than restoring part
+                  of it if it names a user or a provider this instance does not
+                  have, or a link this instance already holds for a different
+                  account. Requires administrator privileges.
+                </div>
+
+                <button
+                  id="ExportLinks"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span data-i18n="config.export_links"
+                    >Export Account Links</span
+                  >
+                </button>
+
+                <input
+                  id="ImportLinksFile"
+                  type="file"
+                  accept="application/json,.json"
+                  style="display: none"
+                />
+                <button
+                  id="ImportLinks"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-alt block emby-button"
+                >
+                  <span data-i18n="config.import_links"
+                    >Import Account Links</span
+                  >
+                </button>
+
+                <div id="LinkTransferResult"></div>
               </div>
             </div>
           </form>


### PR DESCRIPTION
# What & why

A server migration needs two files and only one of them had a button. The configuration export deliberately withholds the account-link maps (`[JsonIgnore]` on `CanonicalLinks`/`CanonicalLinkIssuers`, #157/#186), and a rebuilt user database reissues every Jellyfin user id the links are stored against, so restoring links meant calling `Config/Links/Export` and `Config/Links/Import` by hand. This gives both an admin surface next to the configuration pair they belong with.

The link pair shares the existing "Export / Import Configuration" collapse rather than adding a competing transfer widget, and carries its own heading, help text and status region so one file's outcome never overwrites the other's. The copy states the difference that matters: the configuration file is redacted, this one is not, and it carries usernames paired with the identity-provider subject identifier behind each link.

No server code changes. Both endpoints already existed and stay exactly as they were.

Closes #1131

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: unchanged, and none of it is touched here. `Config/Links/Export` and `Config/Links/Import` stay `[Authorize(Policy = Policies.RequiresElevation)]`; the import stays throttled through `SsoRateLimitClass.Link`, still validates the whole document before writing a single link inside `MutateConfiguration` (so a refusal persists nothing), and still refuses a canonical name this instance already links to a different account.
- [x] No secrets logged; secrets are redacted on config export. The link file is identity data rather than secret material, is produced only by an explicit administrator action, and the page says in its own copy that it is not redacted.
- [ ] **A security review was NOT performed by a second reader.** No second reader was available for this change. This box stays unticked rather than being answered by my own reading of my own diff. What stands in its place is the evidence below, and the residual is stated at the end of Notes.
- [ ] Review record: not produced, for the reason on the line above. No per-lens verdicts and no CONFIRMED/PLAUSIBLE counts exist for this change.
- [x] Log inputs from the IdP are sanitized inline at the log call: no log call is added or changed here.

### The one security decision in this diff, stated rather than buried

A rejected import renders the **server's own refusal text**, which `importConfig` deliberately does not do. The refusals that matter name the entry that could not be restored - an unknown username, an absent provider, a link this instance already holds for another account - and a generic message would leave an administrator holding a file they cannot fix. #1131's "Done" asks for exactly this.

Why it is safe here, and where it stops:

- The text is data the **administrator** supplied (it echoes the file they chose), returned to that same administrator on an elevation-gated page.
- It reaches the DOM through `renderTransferMessage`, which does `line.textContent = message` and never `innerHTML`, so it is inert (#221).
- The server already strips line endings from that message inline at its own emission point (`SSOController.ImportLinks`, `ex.Message?.ReplaceLineEndings(string.Empty)`).
- A rejection whose body cannot be read falls back to the generic message, so a shape this does not recognise degrades rather than showing nothing.

## Quality checklist

- [x] No duplicated logic beyond the deliberate parallel: `exportLinks`/`importLinks` mirror `exportConfig`/`importConfig` against their own endpoints and their own status region. They share `renderTransferMessage`.
- [x] The change adds no more code than the problem requires. It adds no server route, no new file, and no second reachability or download path.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. This change establishes no new structural property, so it locks in no new rule.
- [x] Docs impact considered: no README or wiki claim changes - the surface is the admin page's own copy, which is included here. The runbook that ties the two files together is #1135 and is not this issue.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror` - build succeeded, 0 warnings, 0 errors.
- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror` - build succeeded, 0 warnings, 0 errors.
- [x] Full suite green on both target frameworks:

```
net9.0    Total: 3394, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
net10.0   Total: 3395, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The 4 skips are pre-existing and unrelated: `SsoHttpTests` binds a listener off loopback, which raises the Windows firewall consent dialog and needs an administrator (#1227). They were not worked around.

- [x] Prettier is clean for the files this change touches:

```
$ npx prettier --check "SSO-Auth/Web/config.js" "SSO-Auth/Web/configPage.html" "SSO-Auth/Localization/en.json"
All matched files use Prettier code style!
```

### The localization guards were made to bite, twice

Every new string is a catalog key whose English is carried inline as the offline fallback. The suite pins the two copies equal, and I checked that it does so by breaking each one and watching it go red rather than by trusting it:

```
$ # 1. drop the ellipsis from one catalog value
$ ./SSO-Auth.Tests.exe -method "*ScriptEnglishDefaults_MatchTheCatalog*"
These inline English defaults have drifted from the catalog:
  ...Web.config.js: 'config.link_import_running' inline "Importing account links…" != catalog "Importing account links"
Total: 1, Failed: 1

$ # 2. drop one data-i18n marker from the markup
$ ./SSO-Auth.Tests.exe -method "*UiCatalogKeys_AreAllReferencedBySomeWebAsset*"
These UI catalog keys are referenced by no web asset: config.link_transfer_title
Total: 1, Failed: 1
```

Both perturbations were reverted and the full suite re-run green at the committed state.

## Notes

**What is not verified, and cannot be by anything in this repository.** This is browser JavaScript. No test in the suite executes `exportLinks` or `importLinks`, no harness drives the page, and `grep -rl "playwright\|puppeteer" test/e2e/` matches nothing. What CI does check is the localization contract (keys exist, both English copies agree, no orphan key, no marker over child markup) and Prettier. The click-through - export downloads a file, import applies it, a rejection shows the server's reason - is **not measured** here.

That normally makes the adversarial review the primary verification for a change of this shape. **No second reader was available**, so that verification did not happen either. The two are stated separately because they are different absences, and neither is answered by the other.

The one behaviour I would most want a second pair of eyes on is the rejection path: `ApiClient.fetch` rejecting with the `Response` object is read from how `linking.js` documents the same rejection ("ApiClient.fetch rejects on a non-2xx status") and not from a run, which is why the code treats `typeof e.text === "function"` as a probe rather than an assumption and falls back to the generic message when it does not hold.

**Out of scope, found while working here and reported on the issue rather than fixed:** #1131 asks that the new strings go through the catalog "like the neighbouring transfer strings (#913)". The neighbouring transfer strings are **not** localized - the `sso-config-transfer` block carries no `data-i18n` marker and `exportConfig`/`importConfig` build their status text as plain literals. The new strings are localized properly regardless. Widening this change to localize the pre-existing pair would be a second topic in one pull request.

**Pre-existing and untouched:** `npx prettier --check "**/*.{js,html,md,css,scss}"` reports 22 files on `main` with my locally-resolved Prettier 3.9.6, including files this change does not go near. CI pins `creyD/prettier_action@v4.6`, which resolves its own version, so this is a local-toolchain difference rather than a state of the branch.
