### PR TITLE
Name the five first-run steps in both empty provider states

### DIFF
--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -103,5 +103,17 @@
   "config.readiness_url_ready": "Shown on this form. Register it at your identity provider.",
   "config.readiness_toggles_row": "Insecure or sensitive options",
   "config.readiness_toggles_none": "None of the flagged options is active on this provider.",
-  "config.readiness_toggles_some": "Active: {options}"
+  "config.readiness_toggles_some": "Active: {options}",
+  "config.first_run_oidc_lead": "Adding your first provider is five steps, and this button starts them:",
+  "config.first_run_oidc_step_1": "Pick your identity provider from Start from a template, which fills the endpoint shape and the scopes for you.",
+  "config.first_run_oidc_step_2": "Paste the OpenID endpoint, the client id and the client secret from your provider.",
+  "config.first_run_oidc_step_3": "Copy the redirect URI this page computes and register it at your provider.",
+  "config.first_run_oidc_step_4": "Run Test Connection to check the endpoint answers before anyone tries to log in.",
+  "config.first_run_oidc_step_5": "Save. The provider joins the SSO providers list above, and its button appears on the sign-in page.",
+  "config.first_run_saml_lead": "Adding your first SAML provider is five steps, and this button starts them:",
+  "config.first_run_saml_step_1": "Pick your identity provider from Start from a template, or import its metadata to fill the endpoint and the signing certificate at once.",
+  "config.first_run_saml_step_2": "Check the SAML endpoint, the client id and the IdP signing certificate the import filled in.",
+  "config.first_run_saml_step_3": "Copy the reply URL and the metadata URL this page computes and register them at your provider.",
+  "config.first_run_saml_step_4": "Run Test Connection to check the certificate and the endpoint before anyone tries to log in.",
+  "config.first_run_saml_step_5": "Save. The provider joins the SAML providers list above, and its button appears on the sign-in page."
 }

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -445,6 +445,58 @@
                   >
                   to get the endpoint, client id and secret from your provider.
                 </p>
+                <!--
+                  First-run guided path (#1085). The steps NAME the controls that already exist inside the
+                  editor and put them in order; they add no second Add button, no second template picker and
+                  no control of their own, so there is nothing here that can drift out of step with the form
+                  it describes. It is advisory: the button below opens the same editor it always did, and an
+                  administrator who knows the form can ignore the list and fill it in any order. Each step is
+                  a single text node so the localization applier can replace it (#913).
+                -->
+                <p
+                  class="fieldDescription"
+                  data-i18n="config.first_run_oidc_lead"
+                >
+                  Adding your first provider is five steps, and this button
+                  starts them:
+                </p>
+                <ol class="sso-first-run-steps">
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_oidc_step_1"
+                  >
+                    Pick your identity provider from Start from a template,
+                    which fills the endpoint shape and the scopes for you.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_oidc_step_2"
+                  >
+                    Paste the OpenID endpoint, the client id and the client
+                    secret from your provider.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_oidc_step_3"
+                  >
+                    Copy the redirect URI this page computes and register it at
+                    your provider.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_oidc_step_4"
+                  >
+                    Run Test Connection to check the endpoint answers before
+                    anyone tries to log in.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_oidc_step_5"
+                  >
+                    Save. The provider joins the SSO providers list above, and
+                    its button appears on the sign-in page.
+                  </li>
+                </ol>
                 <button
                   id="AddProviderEmpty"
                   is="emby-button"
@@ -2163,6 +2215,59 @@
                   identity provider. You can import the endpoint and signing
                   certificate straight from your IdP's metadata below.
                 </p>
+                <!--
+                  First-run guided path (#1085). The steps NAME the controls that already exist inside the
+                  editor and put them in order; they add no second Add button, no second template picker and
+                  no control of their own, so there is nothing here that can drift out of step with the form
+                  it describes. It is advisory: the button below opens the same editor it always did, and an
+                  administrator who knows the form can ignore the list and fill it in any order. Each step is
+                  a single text node so the localization applier can replace it (#913).
+                -->
+                <p
+                  class="fieldDescription"
+                  data-i18n="config.first_run_saml_lead"
+                >
+                  Adding your first SAML provider is five steps, and this button
+                  starts them:
+                </p>
+                <ol class="sso-first-run-steps">
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_saml_step_1"
+                  >
+                    Pick your identity provider from Start from a template, or
+                    import its metadata to fill the endpoint and the signing
+                    certificate at once.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_saml_step_2"
+                  >
+                    Check the SAML endpoint, the client id and the IdP signing
+                    certificate the import filled in.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_saml_step_3"
+                  >
+                    Copy the reply URL and the metadata URL this page computes
+                    and register them at your provider.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_saml_step_4"
+                  >
+                    Run Test Connection to check the certificate and the
+                    endpoint before anyone tries to log in.
+                  </li>
+                  <li
+                    class="fieldDescription"
+                    data-i18n="config.first_run_saml_step_5"
+                  >
+                    Save. The provider joins the SAML providers list above, and
+                    its button appears on the sign-in page.
+                  </li>
+                </ol>
                 <button
                   id="saml-AddProviderEmpty"
                   is="emby-button"


### PR DESCRIPTION
# What & why

An administrator with no providers met a title, a wiki link and an Add button. Which of the long form's fields matter first, that the computed redirect URI has to be registered at the identity provider before a login can work, and that Test Connection exists at all, were things to be found by reading the wiki or by scrolling the form.

Both empty states now name the path in order: pick a template, paste the endpoint and credentials, copy and register the computed URL, run Test Connection, save. The SAML list opens with metadata import, because that is the cheaper start there and it fills the endpoint and the signing certificate in one action.

Closes #1085

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no server file, no route, no validation and no default is touched. The change is static markup plus twelve catalog entries.
- [x] No secrets logged; secrets are redacted on config export. Nothing here reads, writes or displays a field value.
- [ ] **A security review was NOT performed by a second reader.** None was available. The box stays unticked rather than answered by my own reading of my own diff. The residual is at the end of Notes.
- [ ] Review record: not produced, for the reason above.
- [x] Log inputs from the IdP are sanitized inline at the log call: no log call is added or changed.

### The parent's constraints, checked on the diff

`#1085` carries three constraints down from `#738`: a step must not set a toggle on the administrator's behalf, state must be in `textContent` rather than colour alone, and the path must stay advisory. The diff is markup only, which makes all three checkable at once:

```
$ git diff --stat origin/main
 SSO-Auth/Localization/en.json |   14 +-
 SSO-Auth/Web/configPage.html  |  105 +++++++++++++++
 2 files changed, 118 insertions(+), 1 deletion(-)
```

No `config.js` change, so no step can set a value, check a box, or auto-save - there is no code here to do it with. The steps are ordinary list items whose whole content is text, so there is no colour-only state. The Add button below them is the one that was already there, unchanged, and the editor it opens behaves exactly as before, so an administrator who knows the form can ignore the list entirely.

The steps deliberately **name** controls rather than duplicating them - no second Add button, no second template picker, no second reachability check. That is what keeps them from drifting out of step with the form they describe.

## Quality checklist

- [x] No duplicated logic: no logic at all is added.
- [x] The change adds no more code than the problem requires. The existing show/hide of the empty state carries the new content for free, so adding the first provider hides the steps and deleting the last one brings them back with no new handler.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. No new structural property, so no new rule.
- [x] Docs impact considered: the wiki quick-start link stays in place beside the steps, and the steps document the plugin's own controls rather than restating anything the wiki holds - so no page goes stale. `#1085`'s own done-condition is that the mechanics no longer *require* a wiki visit, not that the link goes.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror` - succeeded, 0 warnings, 0 errors.
- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror` - succeeded, 0 warnings, 0 errors.
- [x] Full suite green on both target frameworks:

```
net9.0    Total: 3394, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
net10.0   Total: 3395, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The 4 skips are pre-existing and unrelated: `SsoHttpTests` binds a listener off loopback, which raises the Windows firewall consent dialog and needs an administrator (#1227). They were not worked around.

- [x] Prettier clean on both changed files.

### The catalog guard caught a real defect before this was committed

The closing step read identically in both lists - "Save. The provider then appears in the list above…" - and the catalog refuses two keys carrying one value:

```
$ ./SSO-Auth.Tests.exe -method "*EnglishCatalog_HasNoDuplicateValues*"
duplicate English values: Save. The provider joins the SSO providers list above, and its button
appears on the sign-in page.
Total: 1, Failed: 1
```

That rule is not pedantry here: two keys with one value leave a translator no way to tell which surface they are working on, and a later reword of one surface silently reaches both. The repair is that each step now names its own provider list. The output above is from re-introducing the collision deliberately after fixing it, to check the rule bites rather than to trust it; it was reverted and the full suite re-run green at the committed state.

`#1085`'s last done-condition - new strings and markers pass `LocalizationCatalogTests` - is met: all 17 of those tests are green, including `MarkupBuiltInEnglish_MatchesTheCatalog`, `UiCatalogKeys_AreAllReferencedBySomeWebAsset` and `TextMarkers_OnlySitOnElementsWithoutChildMarkup` (each step is a single text node, which is what lets the applier replace it).

## Notes

**What is not verified.** Two of #1085's done-conditions are about a running server, not about this tree: *"following the steps end to end on a fresh install produces a saved provider that passes Test Connection"* needs an install and an identity provider, and nothing in this repository drives the page (`grep -rl "playwright\|puppeteer" test/e2e/` matches nothing). The steps' *accuracy* is argued from the controls they name, each of which exists on the same page - the template picker (#726), the computed redirect and reply URLs (#724), Test Connection, Save - and is **not measured** end to end here.

The third, *"adding one provider hides the empty state as it does today; deleting the last one restores it"*, is carried by the existing `empty.hidden = names.length !== 0` in `renderProviderCards` / `renderSamlProviderCards`, which this change does not touch; the new content sits inside the element that logic already shows and hides.

**No second reader was available**, which for a markup-only change of this shape is the verification that would normally stand in for the untestable part. Both absences are stated because they are different and neither answers the other.

**Deliberately out of scope.** The steps get no stylesheet of their own beyond an `ol.sso-first-run-steps` class and the existing `fieldDescription`, so `style.css` is untouched. If the list should be visually distinguished from an ordinary paragraph, that is a separate change with a separate reason.
