### PR TITLE
Let several providers share one named provisioning profile [#1105]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **A provisioning policy can be named once and shared by several providers
+  (#1105).** The policy written onto a brand-new account at creation used to
+  exist only as a block inside one provider, so a deployment wanting the same
+  starting permissions on two providers had to write them twice and keep the two
+  copies in step by hand. A configuration can now hold named provisioning
+  profiles, and a provider says which one its new accounts get - the `guest`
+  profile beside the default one, pointed at from as many providers as should
+  share it. Nothing changes for a provider that names no profile: it keeps its
+  own inline template, which is every provider configured before this existed,
+  and an existing configuration provisions exactly as it did. A profile is
+  judged by the same checks an inline template is, so it cannot become a second
+  route to the permissions the plugin refuses to write from configuration -
+  administrator, all-folders, Live TV and the account-disable flag are rejected
+  in a profile exactly as they are in a template. Two states are refused on
+  save rather than persisted: a provider naming a profile the configuration does
+  not define, and a provider naming a profile while still carrying an inline
+  template, which would be two account-creation policies with nothing saying
+  which one won. If a name somehow stops resolving anyway - a configuration file
+  edited around the save path - the account is created with no policy written at
+  all rather than falling back to the inline block, so a profile that was
+  replaced can never come back on the next first login. Profiles travel with a
+  configuration export and are merged back by an import, so a provider and the
+  policy it points at do not arrive separately. The plugin's settings page does
+  not yet offer a profile editor: profiles are configured through the admin API,
+  a configuration file, or an import, and a dashboard save leaves them
+  untouched.
+
 - **Counters for the sign-in path, on a metrics endpoint an operator can scrape
   (#1139).** Until now the only signal about logins was the log, and a log line
   cannot be alerted on: nobody can ask it how many sign-ins failed in the last

--- a/SSO-Auth.Tests/Config/ProvisioningProfileTests.cs
+++ b/SSO-Auth.Tests/Config/ProvisioningProfileTests.cs
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Named provisioning profiles (#1105): a provisioning template (#1099/#1100) stops being one inline block
+/// per provider and can instead live in the configuration under a name that several providers point at.
+/// <para>
+/// Two properties are what make this safe rather than merely convenient, and both are pinned here. The first
+/// is that a profile is judged by exactly the checks an inline template is - a profile naming
+/// <c>IsDisabled</c> or <c>IsAdministrator</c> is refused at save, so the new surface is not a second,
+/// unaudited route to the permissions the plugin guards hardest. The second is that the resolution is
+/// one-way: a name that resolves to nothing writes NO policy and does not fall back to the inline template,
+/// so a configuration edited by hand around the validator can never hand a brand-new account the very
+/// permission set the administrator replaced.
+/// </para>
+/// <para>
+/// The third is a compatibility one. A provider that names no profile keeps its inline template, which is
+/// every provider written before this existed, and
+/// <see cref="AConfigWrittenBeforeProfilesExisted_LoadsAndProvisionsUnchanged"/> is what would go red if
+/// that stopped being true.
+/// </para>
+/// </summary>
+public class ProvisioningProfileTests
+{
+    private static readonly Guid Created = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid CreatedB = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    [Fact]
+    public async Task AProviderNamingAProfile_ProvisionsFromThatProfile()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.EnableContentDownloading), Granted = true },
+            },
+            MaxActiveSessions = 2,
+        };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "guest" };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.True(created.HasPermission(PermissionKind.EnableContentDownloading));
+        Assert.Equal(2, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task TwoProvidersOnDifferentProfiles_EachProvisionFromItsOwn()
+    {
+        // The whole point of a named set: one policy per profile, not one per installation. If the resolution
+        // ever read the first profile in the set, or the first provider's, both accounts would come out the
+        // same and only a test with TWO of each would notice.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 5 };
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        configuration.OidConfigs["staff"] = new OidConfig { Enabled = true, ProvisioningProfile = "default" };
+        configuration.OidConfigs["visitors"] = new OidConfig { Enabled = true, ProvisioningProfile = "guest" };
+        var (service, users) = BuildFor(configuration);
+        var staff = Provisionable(users, "alice", Created);
+        var visitor = Provisionable(users, "bob", CreatedB);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "staff", "sub-1", "alice", allowExistingAccountLink: false);
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "visitors", "sub-2", "bob", allowExistingAccountLink: false);
+
+        Assert.Equal(5, staff.MaxActiveSessions);
+        Assert.Equal(1, visitor.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task AProviderNamingNoProfile_KeepsProvisioningFromItsInlineTemplate()
+    {
+        // Every installation that configured a template before profiles existed. The inline block stays
+        // authoritative for a provider that names no profile, so this change is opt-in per provider.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 7 },
+        };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(7, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task AProfileNameThatResolvesToNothing_WritesNoPolicy_AndNeverFallsBackToTheInlineTemplate()
+    {
+        // The state the validator refuses twice over (a dangling name, and a name beside an inline template),
+        // so it can only arrive in a configuration file edited by hand around the save path. The fail-closed
+        // answer is to write nothing: falling back would give the account exactly the permissions the
+        // administrator took the provider off when they pointed it at a profile.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningProfile = "deleted-profile",
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate
+            {
+                Permissions = new List<ProvisionedPermissionEntry>
+                {
+                    new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.EnableContentDownloading), Granted = true },
+                },
+                MaxActiveSessions = 9,
+            },
+        };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+        var before = (created.MaxActiveSessions, created.HasPermission(PermissionKind.EnableContentDownloading));
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(before, (created.MaxActiveSessions, created.HasPermission(PermissionKind.EnableContentDownloading)));
+    }
+
+    [Fact]
+    public async Task AProfileNamingADedicatedPermission_WritesNothingEvenWhenItReachesTheWriter()
+    {
+        // The save refuses this shape, so it can only arrive in a configuration file edited by hand. The
+        // second line of defence is the writer's own refusal (#1099, #165 Finding H1), and this proves the
+        // profile route inherits it rather than reaching the account around it: a template that could set
+        // IsDisabled would make every account a provider creates arrive disabled, and one that could grant
+        // IsAdministrator would be an unaudited second route to administrator.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.IsDisabled), Granted = true },
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.IsAdministrator), Granted = true },
+            },
+        };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "guest" };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.False(created.HasPermission(PermissionKind.IsDisabled));
+        Assert.False(created.HasPermission(PermissionKind.IsAdministrator));
+    }
+
+    [Fact]
+    public void AProviderNamingAProfileTheConfigurationDoesNotDefine_IsRefusedAtSave()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "guest" };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+
+        Assert.Contains("guest", error.Message, StringComparison.Ordinal);
+        Assert.Contains("does not define", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ASamlProviderNamingAProfileTheConfigurationDoesNotDefine_IsRefusedAtSave()
+    {
+        // Both protocols carry the field, so both save loops have to refuse it; a rule wired into one only
+        // would leave the SAML half persisting a provider that provisions nothing.
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig { Enabled = true, ProvisioningProfile = "guest" };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+
+        Assert.Contains("SAML provider 'idp'", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AProviderNamingAProfileWhileCarryingAnInlineTemplate_IsRefusedAtSave()
+    {
+        // Two account-creation policies on one provider, with nothing on the page saying which one wins. The
+        // resolution has an answer (the profile), but an administrator reading the configuration cannot see
+        // it, so the save refuses rather than picking silently.
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        incoming.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningProfile = "guest",
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 7 },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+
+        Assert.Contains("also carries its own inline provisioning template", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(PermissionKind.IsDisabled))]
+    [InlineData(nameof(PermissionKind.IsAdministrator))]
+    [InlineData("EnableNothingAtAll")]
+    public void AProfileNamingAPermissionTheInlineSurfaceRefuses_IsRefusedTheSameWay(string permission)
+    {
+        // The property that keeps this from being a bypass. The dedicated permissions and IsDisabled are
+        // refused on the inline template (#1099, #165 Finding H1); a profile is judged by the same checks, so
+        // the named surface cannot grant what the inline one may not. It is refused with no provider pointing
+        // at the profile at all, because a profile is persisted whether or not it is in use yet.
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = permission, Granted = true },
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+
+        Assert.Contains("Provisioning profile 'guest'", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AProfileWithABlankName_IsRefusedAtSave()
+    {
+        // A profile no provider could ever point at, persisted as dead configuration; refused so the
+        // administrator finds out at save rather than wondering why selecting it does nothing.
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["   "] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+
+        Assert.Contains("blank name", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheProfileSetAndTheNamePointingAtIt_SurviveTheConfigXmlRoundTrip()
+    {
+        // The plugin base persists and reloads through XmlSerializer, so a member that does not survive that
+        // trip is configured once and gone on the next restart - which for this pair would silently turn a
+        // provider on a guest policy into one that provisions nothing.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.EnableContentDownloading), Granted = true },
+            },
+            MaxActiveSessions = 2,
+            SubtitleMode = nameof(SubtitlePlaybackMode.Smart),
+        };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "guest" };
+
+        var reloaded = Deserialize<PluginConfiguration>(Serialize(configuration));
+
+        Assert.Equal("guest", reloaded.OidConfigs["kc"].ProvisioningProfile);
+        var profile = reloaded.ProvisioningProfiles["guest"];
+        Assert.Equal(2, profile.MaxActiveSessions);
+        Assert.Equal(nameof(SubtitlePlaybackMode.Smart), profile.SubtitleMode);
+        Assert.Equal(nameof(PermissionKind.EnableContentDownloading), Assert.Single(profile.Permissions!).Permission);
+    }
+
+    [Fact]
+    public async Task AConfigWrittenBeforeProfilesExisted_LoadsAndProvisionsUnchanged()
+    {
+        // The upgrade case, taken from the real serializer rather than a hand-typed literal: a stored config
+        // XML with no ProvisioningProfiles element at all must deserialize (XmlSerializer runs the
+        // parameterless constructor, so the set comes back empty rather than null) and provision exactly as
+        // it did before, from the provider's own inline template.
+        var written = new PluginConfiguration();
+        written.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 4 },
+        };
+        var legacyXml = Serialize(written)
+            .Replace("<ProvisioningProfiles />", string.Empty, StringComparison.Ordinal)
+            .Replace("<ProvisioningProfiles/>", string.Empty, StringComparison.Ordinal);
+        Assert.DoesNotContain("ProvisioningProfile", legacyXml, StringComparison.Ordinal);
+
+        var reloaded = Deserialize<PluginConfiguration>(legacyXml);
+        var (service, users) = BuildFor(reloaded);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Empty(reloaded.ProvisioningProfiles);
+        Assert.Equal(4, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public void TheProfileSet_TravelsWithAnExportAndImport()
+    {
+        // A document carrying a provider whose profile it left behind would be refused on import by the
+        // validator - fail closed, but it would make the export useless - so the set travels with it.
+        var source = new PluginConfiguration();
+        source.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        source.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            Enabled = true,
+            ProvisioningProfile = "guest",
+        };
+        var target = new PluginConfiguration();
+
+        ConfigImport.Apply(target, WireRoundTrip(ConfigExport.Build(source)));
+
+        Assert.Equal("guest", target.OidConfigs["kc"].ProvisioningProfile);
+        Assert.Equal(1, target.ProvisioningProfiles["guest"].MaxActiveSessions);
+    }
+
+    [Fact]
+    public void AnImport_LeavesAProfileOnlyTheTargetDefines_Untouched()
+    {
+        // Upsert, like the provider merge: an import is a merge, so a policy this instance defines and the
+        // document says nothing about must not disappear underneath the providers still pointing at it.
+        var source = new PluginConfiguration();
+        source.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        var target = new PluginConfiguration();
+        target.ProvisioningProfiles["staff"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+
+        ConfigImport.Apply(target, WireRoundTrip(ConfigExport.Build(source)));
+
+        Assert.Equal(9, target.ProvisioningProfiles["staff"].MaxActiveSessions);
+        Assert.Equal(1, target.ProvisioningProfiles["guest"].MaxActiveSessions);
+    }
+
+    private static ConfigExportDocument WireRoundTrip(ConfigExportDocument document) =>
+        JsonSerializer.Deserialize<ConfigExportDocument>(JsonSerializer.Serialize(document))!;
+
+    private static string Serialize<T>(T value)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, value);
+        return writer.ToString();
+    }
+
+    // Deserializes through the XmlReader overload with DTD processing prohibited (the hardened CA5369
+    // pattern), mirroring how the production config is only ever read through an XmlReader.
+    private static T Deserialize<T>(string xml)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var stringReader = new StringReader(xml);
+        using var xmlReader = XmlReader.Create(
+            stringReader,
+            new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
+        return (T)serializer.Deserialize(xmlReader)!;
+    }
+
+    private static (CanonicalLinkService Service, IUserManager Users) BuildFor(PluginConfiguration configuration)
+    {
+        var users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger()), users);
+    }
+
+    // A name nothing holds yet, so the resolver takes the create arm rather than adopting or refusing.
+    private static User Provisionable(IUserManager users, string username, Guid id)
+    {
+        var created = TestUsers.Named(username, id);
+        users.GetUserByName(username).Returns((User?)null);
+        users.CreateUserAsync(username).Returns(created);
+        users.GetUserById(id).Returns(created);
+        return created;
+    }
+}

--- a/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
@@ -38,6 +38,43 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 internal static class ProvisioningPolicy
 {
     /// <summary>
+    /// Resolves which template a provider's brand-new accounts get (#1105): the named
+    /// <see cref="PluginConfiguration.ProvisioningProfiles"/> entry when the provider names one, and
+    /// otherwise the provider's own inline <see cref="ProviderConfigBase.ProvisioningPolicyTemplate"/>.
+    /// </summary>
+    /// <remarks>
+    /// A name that resolves to nothing writes NO policy, and deliberately does not fall back to the inline
+    /// template. The save path refuses both a dangling name and a provider carrying a name AND an inline
+    /// template (<see cref="ProviderConfigValidator.ValidateProvisioningProfiles"/>), so neither state
+    /// arrives through a validated write; what is left is a configuration file edited by hand around the
+    /// validator, and there the fail-closed answer is to write nothing. Falling back would hand the new
+    /// account the very permission set the administrator replaced when they pointed the provider elsewhere.
+    /// </remarks>
+    /// <param name="configuration">The live plugin configuration, read for its profile set.</param>
+    /// <param name="provider">The provider the account is being created for; <see langword="null"/> resolves to no template.</param>
+    /// <returns>The template to apply, or <see langword="null"/> when the provider configures none.</returns>
+    internal static ProvisioningPolicyTemplate? TemplateFor(PluginConfiguration configuration, ProviderConfigBase? provider)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (provider is null)
+        {
+            return null;
+        }
+
+        var profile = provider.ProvisioningProfile;
+        if (string.IsNullOrWhiteSpace(profile))
+        {
+            return provider.ProvisioningPolicyTemplate;
+        }
+
+        return configuration.ProvisioningProfiles != null
+            && configuration.ProvisioningProfiles.TryGetValue(profile, out var named)
+                ? named
+                : null;
+    }
+
+    /// <summary>
     /// Applies the provider's template to a freshly created user, in memory. The caller persists.
     /// </summary>
     /// <param name="user">The brand-new Jellyfin account.</param>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -691,14 +691,22 @@ internal sealed class CanonicalLinkService
     // The provider's provisioning template (#1099), read under the config lock in its own short transaction
     // rather than threaded down from the caller, so the create arm reads the configuration that is live when
     // the account is actually made. A missing provider, or one stored with a null config object (#350),
-    // carries no template and writes nothing - the same fail-closed skip every other read here uses.
+    // carries no template and writes nothing - the same fail-closed skip every other read here uses. Which
+    // template a provider gets - its named profile or its own inline one (#1105) - is ProvisioningPolicy's
+    // rule, resolved inside the same transaction so the profile set and the name pointing at it are read
+    // together and a concurrent save cannot be seen half-applied.
     private ProvisioningPolicyTemplate? ProvisioningTemplateFor(ProviderMode mode, string provider) =>
-        _configStore.Read(configuration => mode switch
+        _configStore.Read(configuration => ProvisioningPolicy.TemplateFor(configuration, ProviderConfigFor(configuration, mode, provider)));
+
+    // The stored provider object the read above resolves its template from, or null when the provider is
+    // gone or was stored with a null config object (#350).
+    private static ProviderConfigBase? ProviderConfigFor(PluginConfiguration configuration, ProviderMode mode, string provider) =>
+        mode switch
         {
-            ProviderMode.Saml => configuration.SamlConfigs.TryGetValue(provider, out var saml) ? saml?.ProvisioningPolicyTemplate : null,
-            ProviderMode.Oid => configuration.OidConfigs.TryGetValue(provider, out var oid) ? oid?.ProvisioningPolicyTemplate : null,
+            ProviderMode.Saml => configuration.SamlConfigs.TryGetValue(provider, out var saml) ? saml : null,
+            ProviderMode.Oid => configuration.OidConfigs.TryGetValue(provider, out var oid) ? oid : null,
             _ => null,
-        });
+        };
 
     // The name a BRAND-NEW account is created under (#1137). Jellyfin's CreateUserAsync throws for a name
     // outside its own character set, so an IdP that emits one (the 9p4#199 shape) used to fail the login

--- a/SSO-Auth/Config/ConfigExport.cs
+++ b/SSO-Auth/Config/ConfigExport.cs
@@ -53,6 +53,13 @@ internal static class ConfigExport
         RateLimitWindowSeconds = live.RateLimitWindowSeconds,
         OidConfigs = ShallowCopy(live.OidConfigs),
         SamlConfigs = ShallowCopy(live.SamlConfigs),
+
+        // The named provisioning profiles travel with the providers that point at them (#1105): a document
+        // carrying a provider whose profile it left behind would be refused on import by the validator, which
+        // is the fail-closed direction but would make the export useless. They hold no secret - a template is
+        // permissions and playback preferences - so the redaction the provider maps rely on has nothing to do
+        // here.
+        ProvisioningProfiles = ShallowCopy(live.ProvisioningProfiles),
     };
 
     private static SerializableDictionary<string, T> ShallowCopy<T>(SerializableDictionary<string, T> source)

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -79,7 +79,19 @@ internal static class ConfigImport
         //    passed so a reserved-character name this instance already holds stays importable.
         ProviderConfigValidator.Validate(imported, live);
 
-        // 2. Only now - with the document proven valid - merge each provider. ServerManagedFields.Preserve is
+        // 2. The named provisioning profiles the imported providers point at (#1105), upserted before the
+        //    providers themselves so the target never holds, even momentarily, a provider naming a profile it
+        //    has not got. Unlike the rate-limit scalars this IS imported: a profile is admin policy that
+        //    travels with the providers referencing it, and leaving it behind would strand every imported
+        //    provider on a name that resolves to nothing - which provisions no policy at all rather than the
+        //    intended one. Upsert, like the providers: a profile the target defines and the document does not
+        //    survives untouched. A profile the document REDEFINES is replaced, and that reaches the target's
+        //    own providers pointing at that name - deliberate, since a shared name is the whole point of a
+        //    profile, and the alternative (silently keeping the target's version) would make an import that
+        //    reported success provision by a policy the administrator did not import.
+        MergeProfiles(live, imported);
+
+        // 3. Only now - with the document proven valid - merge each provider. ServerManagedFields.Preserve is
         //    the SAME re-injection the config-page save and OID/SAML Add use, so blank-means-keep for secrets
         //    and the server-managed link/issuer maps behave identically on every write path (#318). The
         //    global rate-limit settings (EnableRateLimit/RateLimitMaxAttempts/RateLimitWindowSeconds) are
@@ -132,6 +144,29 @@ internal static class ConfigImport
             }
 
             live[kvp.Key] = kvp.Value;
+        }
+    }
+
+    // Upserts the imported profile set into the target. A null or absent set carries nothing and leaves the
+    // target's profiles alone, which is every document exported before profiles existed. A null-valued entry
+    // would resolve to "no policy" at provisioning while looking like a defined profile, so it is skipped
+    // rather than stored - the same tolerance the provider merge gives a null-valued provider (#538).
+    private static void MergeProfiles(PluginConfiguration live, PluginConfiguration imported)
+    {
+        if (imported.ProvisioningProfiles is null)
+        {
+            return;
+        }
+
+        live.ProvisioningProfiles ??= new SerializableDictionary<string, ProvisioningPolicyTemplate>();
+        foreach (var kvp in imported.ProvisioningProfiles)
+        {
+            if (kvp.Value is null)
+            {
+                continue;
+            }
+
+            live.ProvisioningProfiles[kvp.Key] = kvp.Value;
         }
     }
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -25,6 +25,7 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     {
         SamlConfigs = new SerializableDictionary<string, SamlConfig>();
         OidConfigs = new SerializableDictionary<string, OidConfig>();
+        ProvisioningProfiles = new SerializableDictionary<string, ProvisioningPolicyTemplate>();
         RateLimitMaxAttempts = 30;
         RateLimitWindowSeconds = 60;
     }
@@ -40,6 +41,22 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     /// </summary>
     [XmlElement("OidConfigs")]
     public SerializableDictionary<string, OidConfig> OidConfigs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the named provisioning profiles a provider can point at (#1105). Each entry is a
+    /// provisioning template (#1099/#1100) under a name, so several providers can share one policy and a
+    /// deployment can keep more than one - the <c>guest</c> profile beside the default one. Empty on every
+    /// installation that defines none, which is every installation built before this existed.
+    /// <para>
+    /// A provider gets its profile by naming it in <see cref="ProviderConfigBase.ProvisioningProfile"/>. A
+    /// provider that names none keeps using its own inline
+    /// <see cref="ProviderConfigBase.ProvisioningPolicyTemplate"/>, so a configuration written before this
+    /// existed provisions byte-identically. Naming both is refused on save: one account-creation policy has
+    /// one authoritative source, exactly as the dedicated permissions do.
+    /// </para>
+    /// </summary>
+    [XmlElement("ProvisioningProfiles")]
+    public SerializableDictionary<string, ProvisioningPolicyTemplate> ProvisioningProfiles { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the anonymous SSO flow endpoints are rate-limited
@@ -462,6 +479,22 @@ public abstract class ProviderConfigBase
     /// </para>
     /// </summary>
     public ProvisioningPolicyTemplate? ProvisioningPolicyTemplate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the <see cref="PluginConfiguration.ProvisioningProfiles"/> entry written onto
+    /// this provider's BRAND-NEW accounts (#1105). Blank - the default - leaves the provider on its own inline
+    /// <see cref="ProvisioningPolicyTemplate"/>, so a configuration written before profiles existed provisions
+    /// unchanged.
+    /// <para>
+    /// Setting both this and the inline template is refused on save, and so is naming a profile the
+    /// configuration does not define: a provider whose policy cannot be resolved would otherwise be persisted
+    /// and then quietly provision nothing. At creation the resolution is deliberately one-way with no
+    /// fallback - a name that no longer resolves writes NO policy rather than reaching back to the inline
+    /// template, so a profile deleted behind the validator's back can never hand a new account a permission
+    /// set the administrator had replaced.
+    /// </para>
+    /// </summary>
+    public string? ProvisioningProfile { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the role-to-parental-rating mapping

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -54,6 +54,11 @@ internal static class ProviderConfigValidator
     /// <exception cref="ArgumentException">A provider fails any per-provider rule.</exception>
     internal static void Validate(PluginConfiguration incoming, PluginConfiguration live)
     {
+        // The profile set first: a provider's reference below is only as good as the profile it names, and a
+        // profile carrying a permission the plugin may not write must be refused whether or not any provider
+        // points at it yet (#1105).
+        ValidateProvisioningProfiles(incoming.ProvisioningProfiles);
+
         if (incoming.OidConfigs != null)
         {
             foreach (var kvp in incoming.OidConfigs)
@@ -65,6 +70,7 @@ internal static class ProviderConfigValidator
                 ValidateParentalRatingMappings("OpenID", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
                 ValidateGuestAccessDurations("OpenID", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("OpenID", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
+                ValidateProvisioningProfileReference("OpenID", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
                 ValidateAcrRequirement(kvp.Key, kvp.Value);
             }
         }
@@ -87,6 +93,7 @@ internal static class ProviderConfigValidator
                 ValidateParentalRatingMappings("SAML", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
                 ValidateGuestAccessDurations("SAML", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("SAML", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
+                ValidateProvisioningProfileReference("SAML", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
             }
         }
     }
@@ -358,13 +365,17 @@ internal static class ProviderConfigValidator
     /// <param name="template">The provisioning template to check.</param>
     /// <exception cref="ArgumentException">The template names an invalid or dedicated permission, or carries a negative number.</exception>
     internal static void ValidateProvisioningTemplate(string protocol, string provider, ProvisioningPolicyTemplate? template)
+        => ValidateTemplateFields($"{protocol} provider '{(provider ?? string.Empty).ReplaceLineEndings(string.Empty)}'", template);
+
+    // The template checks themselves, over whatever names the template being judged - a provider carrying an
+    // inline one, or a named profile several providers share (#1105). One implementation, so a profile cannot
+    // carry a permission the inline surface refuses.
+    private static void ValidateTemplateFields(string subject, ProvisioningPolicyTemplate? template)
     {
         if (template == null)
         {
             return;
         }
-
-        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
 
         foreach (var entry in template.Permissions ?? new System.Collections.Generic.List<ProvisionedPermissionEntry>())
         {
@@ -390,7 +401,7 @@ internal static class ProviderConfigValidator
                 _ => $"names '{echoPerm}', which is not a known Jellyfin permission",
             };
             throw new ArgumentException(
-                $"{protocol} provider '{echoName}' has an invalid provisioning template: it {reason}. Each entry's Permission must be the exact name of a Jellyfin PermissionKind (for example EnableContentDownloading) other than IsAdministrator, EnableAllFolders, EnableLiveTvAccess, EnableLiveTvManagement, or IsDisabled.",
+                $"{subject} has an invalid provisioning template: it {reason}. Each entry's Permission must be the exact name of a Jellyfin PermissionKind (for example EnableContentDownloading) other than IsAdministrator, EnableAllFolders, EnableLiveTvAccess, EnableLiveTvManagement, or IsDisabled.",
                 nameof(template));
         }
 
@@ -400,14 +411,14 @@ internal static class ProviderConfigValidator
         if (template.RemoteClientBitrateLimit < 0)
         {
             throw new ArgumentException(
-                $"{protocol} provider '{echoName}' has an invalid provisioning template: the remote-client bitrate limit must be zero or greater (zero means no limit; leave it unset to keep Jellyfin's default).",
+                $"{subject} has an invalid provisioning template: the remote-client bitrate limit must be zero or greater (zero means no limit; leave it unset to keep Jellyfin's default).",
                 nameof(template));
         }
 
         if (template.MaxActiveSessions < 0)
         {
             throw new ArgumentException(
-                $"{protocol} provider '{echoName}' has an invalid provisioning template: the maximum active sessions must be zero or greater (zero means unlimited; leave it unset to keep Jellyfin's default).",
+                $"{subject} has an invalid provisioning template: the maximum active sessions must be zero or greater (zero means unlimited; leave it unset to keep Jellyfin's default).",
                 nameof(template));
         }
 
@@ -422,8 +433,85 @@ internal static class ProviderConfigValidator
         {
             var echoMode = string.Concat(template.SubtitleMode.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
             throw new ArgumentException(
-                $"{protocol} provider '{echoName}' has an invalid provisioning template: it names subtitle mode '{echoMode}', which is not a known Jellyfin SubtitlePlaybackMode. Use the exact enum name (for example Default, Always, OnlyForced, or Smart), or leave it unset to keep Jellyfin's default.",
+                $"{subject} has an invalid provisioning template: it names subtitle mode '{echoMode}', which is not a known Jellyfin SubtitlePlaybackMode. Use the exact enum name (for example Default, Always, OnlyForced, or Smart), or leave it unset to keep Jellyfin's default.",
                 nameof(template));
+        }
+    }
+
+    /// <summary>
+    /// Rejects a named provisioning-profile set (#1105) that carries an unnamed or invalid profile. Each
+    /// profile is judged by exactly the checks an inline template gets, so a policy cannot reach through a
+    /// profile what the inline surface refuses by name - the dedicated permissions and <c>IsDisabled</c>
+    /// above all. A configuration that defines no profile configures nothing here and is tolerated.
+    /// </summary>
+    /// <param name="profiles">The profile set to check.</param>
+    /// <exception cref="ArgumentException">A profile is unnamed, or its template fails the template checks.</exception>
+    internal static void ValidateProvisioningProfiles(SerializableDictionary<string, ProvisioningPolicyTemplate>? profiles)
+    {
+        if (profiles == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in profiles)
+        {
+            if (string.IsNullOrWhiteSpace(kvp.Key))
+            {
+                throw new ArgumentException(
+                    "A provisioning profile has a blank name. Every profile needs a name, because a name is the only thing a provider can point at; an unnamed one could never be selected and would be persisted as dead configuration.",
+                    nameof(profiles));
+            }
+
+            ValidateTemplateFields(
+                $"Provisioning profile '{string.Concat(kvp.Key.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty)}'",
+                kvp.Value);
+        }
+    }
+
+    // A provider names the profile its new accounts get (#1105). Two states are refused rather than
+    // tolerated, and both would otherwise be silent: a name no profile answers to would persist and then
+    // provision NOTHING at the next first login (the resolution is fail-closed and does not fall back), and a
+    // provider carrying a name AND an inline template would have two account-creation policies with nothing
+    // saying which one won. The rule is cross-object, so it is checked here on the whole incoming
+    // configuration rather than on the provider alone - the same reason the SSO-only guard is.
+
+    /// <summary>
+    /// Rejects a provider that names a provisioning profile the configuration does not define, or that names
+    /// one while also carrying its own inline template (#1105). A provider naming no profile is untouched and
+    /// keeps its inline template, which is every provider written before profiles existed.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (control-stripped) in the rejection message.</param>
+    /// <param name="config">The provider configuration to check; <see langword="null"/> names nothing.</param>
+    /// <param name="profiles">The profile set the name must resolve in.</param>
+    /// <exception cref="ArgumentException">The named profile is undefined, or the provider also carries an inline template.</exception>
+    internal static void ValidateProvisioningProfileReference(
+        string protocol,
+        string provider,
+        ProviderConfigBase? config,
+        SerializableDictionary<string, ProvisioningPolicyTemplate>? profiles)
+    {
+        var profile = config?.ProvisioningProfile;
+        if (string.IsNullOrWhiteSpace(profile))
+        {
+            return;
+        }
+
+        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+        var echoProfile = string.Concat(profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+
+        if (config!.ProvisioningPolicyTemplate != null)
+        {
+            throw new ArgumentException(
+                $"{protocol} provider '{echoName}' names the provisioning profile '{echoProfile}' and also carries its own inline provisioning template. A provider's new accounts get exactly one policy, so keep the profile and remove the inline template, or clear the profile name.",
+                nameof(config));
+        }
+
+        if (profiles == null || !profiles.ContainsKey(profile))
+        {
+            throw new ArgumentException(
+                $"{protocol} provider '{echoName}' names the provisioning profile '{echoProfile}', which this configuration does not define. Define the profile, or clear the name - a provider pointing at a missing profile provisions nothing rather than falling back.",
+                nameof(config));
         }
     }
 


### PR DESCRIPTION
# What & why

A provisioning template (#1099/#1100) existed only as a block inside one
provider, so a deployment wanting the same starting policy on two providers
carried two copies and kept them in step by hand. This adds named provisioning
profiles to the configuration and a per-provider name that selects one, which is
the config-shape half of #1103 - #1106 resolves a profile from IdP roles on top
of the set this creates.

The shape is additive rather than a replacement, and that is the one deliberate
departure from the issue body; the reason is in Notes.

- `PluginConfiguration.ProvisioningProfiles` holds the named set.
- `ProviderConfigBase.ProvisioningProfile` names the profile a provider's
  brand-new accounts get. Blank keeps the provider on its own inline template.
- `ProvisioningPolicy.TemplateFor` is the one place the choice is made, read
  inside the same config transaction as the provider, so a save cannot be seen
  half-applied.
- `ProviderConfigValidator` refuses four states; `ConfigExport`/`ConfigImport`
  carry the set so a provider and the policy it points at cannot arrive
  separately.

Part of #1105, and deliberately NOT "Closes": two things the issue asks for are not
in this change, so the issue stays open for them. Both are named in Notes.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**The two unticked boxes are unticked because the thing they describe did not
happen.** This change touches config persistence, so the adversarial review the
repository asks for is owed, and no second reader was available for it. There is
no review record and none is implied; what stands in its place is the evidence
below, and it is evidence of guards biting rather than of a review.

**What was checked, and by what.** Each of the three new guards was removed and
the suite re-run at that state, so none of them is a rule nobody proved:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "...ProvisioningProfileTests"
   Total: 16, Errors: 0, Failed: 0
# per-provider reference check deleted from Validate:
   Total: 15, Errors: 0, Failed: 3
# profile-set check deleted from Validate:
   Total: 15, Errors: 0, Failed: 4
# dangling profile name made to fall back to the inline template:
   Total: 15, Errors: 0, Failed: 1
```

(The mutation runs predate the sixteenth test, which is why they total 15.)

**The three properties that carry the security argument:**

1. A profile is judged by the checks an inline template is judged by, one
   implementation and not two, so it is not a second route to the permissions
   configuration may not write. `AProfileNamingAPermissionTheInlineSurfaceRefuses_IsRefusedTheSameWay`
   covers `IsDisabled`, `IsAdministrator` and an unknown name, with no provider
   pointing at the profile at all.
2. The writer's own refusal still runs underneath the new surface, so a profile
   that reached it through a hand-edited file writes neither of those two:
   `AProfileNamingADedicatedPermission_WritesNothingEvenWhenItReachesTheWriter`.
3. The resolution is one-way. A name that resolves to nothing writes NO policy
   and never falls back to the inline template, so a replaced policy cannot come
   back on a first login: `AProfileNameThatResolvesToNothing_WritesNoPolicy_AndNeverFallsBackToTheInlineTemplate`.

Nothing here reads or writes a secret: a profile holds permission entries and
playback preferences, so the export redaction has nothing to do for it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the conformance line: this change establishes no new structural property. The
one rule it could have needed - that a form field id resolves to a real provider
property - is untouched, because no form field is added here.

On the docs line: the CHANGELOG entry is in this change. The wiki's
configuration reference gains a section when the profile editor lands, and that
belongs with the surface an administrator actually uses rather than ahead of it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   0 Warnung(en)  0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   0 Warnung(en)  0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    Total: 3410, Errors: 0, Failed: 0, Skipped: 4
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   Total: 3411, Errors: 0, Failed: 0, Skipped: 4
$ npx prettier --check CHANGELOG.md                       All matched files use Prettier code style!
```

The four skips are the pre-existing ones that bind a listener off loopback: on
Windows that raises the firewall consent dialog, which needs an administrator
(#1227). They are skipped rather than worked around, and they are not skips this
change introduced.

The repository-wide `npx prettier --check "**/*.{js,html,md,css,scss}"` reports
24 files in this checkout, every one of them a file this change does not touch,
which is the working copy's line endings rather than content - `git status` is
clean apart from the eight files here. `CHANGELOG.md`, the only non-`.cs` file
in the diff, is checked on its own above and passes.

## Notes

**What is not done, and why it is not half-built here.** The issue's Surfaces
list asks for a profile editor on the config page: list, add, rename, delete,
plus the per-provider selector. That is not in this change. The reason is the
save contract rather than effort: the page persists provider fields through one
flat contract keyed by element id, and a profile set is neither a provider field
nor flat, so the editor is a save-contract change plus a new workspace - and
`SSO-Auth/Web/` has no runtime in this tree to test any of it against (no
`package.json`, no DOM, no browser automation), so it ships on reading. Bundling
it here would put an untestable surface inside a change whose four Done-when
clauses are all server-side and all provable, and it would make one review of
two.

Nothing is stranded meanwhile: profiles are configurable through the admin API,
a configuration file, or an import, and a dashboard save carries the set through
because the page reads the whole configuration and writes it back.

**The one Done-when clause not met literally.** The issue asks that a config
written before this change "loads with its template as profile `default`". This
change does not hoist an inline template into the profile set, for two reasons
worth deciding rather than assuming: with several providers carrying different
inline templates, one name cannot receive all of them, so the migration needs a
naming rule nobody has chosen; and rewriting a persisted configuration at load
has no precedent in this tree, which is a destructive thing to introduce as a
side effect of a feature. What is proven instead is the behavioural half of the
clause - such a config loads and provisions identically
(`AConfigWrittenBeforeProfilesExisted_LoadsAndProvisionsUnchanged`). The written
form of this is on the issue, which stays open for it.

**A property of the config PUT worth stating.** An admin `PUT` that omits
`ProvisioningProfiles` drops the set, exactly as omitting any other
admin-edited member drops it. Where a provider points at a profile the omission
is refused fail-closed by the validator; where none does, the set is dropped
silently. That is the existing contract for every non-server-managed field
rather than something this change decides, and giving profiles a
blank-means-keep rule would make them behave unlike everything beside them.
