### PR TITLE
Name the current repository in every link a reader follows

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new
+    url: https://github.com/Flowfin/jellyfin-plugin-sso/security/advisories/new
     about: Report security vulnerabilities privately via a security advisory, never as a public issue. See SECURITY.md.
   - name: Question
-    url: https://github.com/iderex/jellyfin-plugin-sso/discussions
+    url: https://github.com/Flowfin/jellyfin-plugin-sso/discussions
     about: Please ask and answer questions here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       # builds neither ship an artifact nor hold the signing token). The bytes
       # attested here are the exact bytes the release ships (upload/download of
       # `build-artifact` preserves them), so a downloaded release zip verifies with:
-      #   gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
+      #   gh attestation verify <plugin>.zip --repo Flowfin/jellyfin-plugin-sso
       - name: Attest build provenance
         if: ${{ inputs.attest }}
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@
 # claimed the opposite until #1027. Do not restate the required set here, where
 # it drifts unnoticed; print it:
 #
-#   gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
+#   gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
 #     --jq '.[] | select(.type=="required_status_checks")
 #           | .parameters.required_status_checks[].context'
 name: CodeQL

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -2,7 +2,7 @@
 # plain workflow + one first-party github-script step - no external Danger runtime,
 # bot, or third-party review service (the merge gate is internal-only by policy;
 # see the Review-Gate wiki page:
-# https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). It complements,
+# https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate). It complements,
 # never duplicates, the build/test, Prettier,
 # CodeQL, Opengrep, zizmor, and Unicode-guard checks: those reason about the code;
 # this reasons about the *pull request* (its linkage, size, and changelog/test
@@ -16,7 +16,7 @@
 # was queried (#1199). Do not restate the required set here, where it drifts
 # unnoticed; print it:
 #
-#   gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
+#   gh api repos/Flowfin/jellyfin-plugin-sso/rules/branches/main \
 #     --jq '.[] | select(.type=="required_status_checks")
 #           | .parameters.required_status_checks[].context'
 #
@@ -41,7 +41,7 @@
 # Two acceptance-criteria items from #171 are intentionally NOT implemented here
 # (sensitive-path sign-off grep, and issue-open triage-lint); the rationale is
 # recorded in the Review-Gate wiki page
-# (https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate) so the decision
+# (https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate) so the decision
 # is auditable, not silent.
 name: PR Hygiene
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Release
 
 # A three-part stable tag push (e.g. 4.1.1-stable) is the ONLY publish trigger,
 # per the Releasing wiki page
-# (https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing) - the beta
+# (https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Releasing) - the beta
 # soak / promotion gate a stable tag clears. The
 # channel/generation is the tag SUFFIX - this is
 # the JF10.11 line, so `X.Y.Z-stable`; the JF12 line publishes from `X.Y.Z-JF12-stable`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,13 +33,13 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/README.md).
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/iderex/jellyfin-plugin-sso/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/Flowfin/jellyfin-plugin-sso/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://github.com/iderex/jellyfin-plugin-sso/issues/new).
+- Open an [Issue](https://github.com/Flowfin/jellyfin-plugin-sso/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide the relevant versions: your .NET SDK version, the Jellyfin server version, and the SSO provider type (OpenID Connect or SAML, and which identity provider).
 
@@ -75,8 +75,8 @@ Depending on how large the project is, you may want to outsource the questioning
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/iderex/jellyfin-plugin-sso/issues?q=label%3Abug).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/Flowfin/jellyfin-plugin-sso/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -93,7 +93,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/iderex/jellyfin-plugin-sso/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/Flowfin/jellyfin-plugin-sso/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -115,15 +115,15 @@ This section guides you through submitting an enhancement suggestion for Communi
 #### Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://github.com/iderex/jellyfin-plugin-sso/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Read the [documentation](https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Perform a [search](https://github.com/Flowfin/jellyfin-plugin-sso/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/iderex/jellyfin-plugin-sso/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/Flowfin/jellyfin-plugin-sso/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
@@ -144,7 +144,7 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
-**Getting oriented.** Before diving into the `SSOController` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) and [Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture) wiki pages - together they walk an OpenID and a SAML sign-in from challenge to session and map the module layout, so you can place a change onto the flow instead of reverse-engineering it.
+**Getting oriented.** Before diving into the `SSOController` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow) and [Architecture](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Architecture) wiki pages - together they walk an OpenID and a SAML sign-in from challenge to session and map the module layout, so you can place a change onto the flow instead of reverse-engineering it.
 
 **Building and testing.** CI runs these on every pull request and they must pass:
 
@@ -210,11 +210,11 @@ git grep -rniE "\.Bind\(|HttpListener|netsh|sc\.exe|runas|X509Store|dev-certs" -
 
 **Branching and pull requests.** `main` is the released line and is PR-only. Branch every change - even a one-liner - off `main` for fixes and security work, or off the feature branch for features, using a short kebab-case name with a `fix/`, `harden/`, `feature/`, `chore/`, or `refactor/` prefix. Reference the issue your change addresses (`Closes #N`) and fill in the [pull request template](.github/pull_request_template.md).
 
-This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why. The merge gate is internal-only (CI, the adversarial review, and my own sign-off); [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate) maps how those controls cover each class of issue an automated PR reviewer would catch.
+This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why. The merge gate is internal-only (CI, the adversarial review, and my own sign-off); [Review Gate](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate) maps how those controls cover each class of issue an automated PR reviewer would catch.
 
 ### Improving The Documentation
 
-We are always open to better docs! The main place documentation could be improved is the [provider setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) documentation. This file keeps track of configurations that are known to work with common SSO providers.
+We are always open to better docs! The main place documentation could be improved is the [provider setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) documentation. This file keeps track of configurations that are known to work with common SSO providers.
 
 ### Translating the UI
 
@@ -277,7 +277,7 @@ Every C# source file opens with the two-line SPDX header (a conformance test fai
 
 The project is licensed **GPL-3.0-only** (`GPL-3.0-only` is the [SPDX identifier](https://spdx.org/licenses/); see [LICENSE.txt](LICENSE.txt)).
 
-The architecture, comment/documentation, and object-oriented rules a change is held to live in one canonical place - the [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. This guide does not restate them; read that page before a non-trivial change. They are enforced by the conformance fitness functions in `SSO-Auth.Tests/ArchitectureConformanceTests.cs` and the adversarial review gate.
+The architecture, comment/documentation, and object-oriented rules a change is held to live in one canonical place - the [Coding Standards](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. This guide does not restate them; read that page before a non-trivial change. They are enforced by the conformance fitness functions in `SSO-Auth.Tests/ArchitectureConformanceTests.cs` and the adversarial review gate.
 
 ### HTML/CSS/JS/Markdown
 
@@ -287,7 +287,7 @@ Not every file under `SSO-Auth/Web` is project code. Check the provenance header
 
 ### Keeping the docs in step
 
-When a code change makes any **README section or wiki page** wrong or incomplete - a changed behaviour, a moved type the [Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture) page names, a new or renamed config option, an altered login flow - the documentation follow-up must not be lost. Either **update the docs in the same pull request**, or **open a `documentation`-labelled issue on the current-release milestone** so it ships before the next release. The PR checklist has a box for this. (The wiki has no pull-request flow - wiki edits are pushed directly to its repository - but the _tracking_ still lives as an issue in the main repository.)
+When a code change makes any **README section or wiki page** wrong or incomplete - a changed behaviour, a moved type the [Architecture](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Architecture) page names, a new or renamed config option, an altered login flow - the documentation follow-up must not be lost. Either **update the docs in the same pull request**, or **open a `documentation`-labelled issue on the current-release milestone** so it ships before the next release. The PR checklist has a box for this. (The wiki has no pull-request flow - wiki edits are pushed directly to its repository - but the _tracking_ still lives as an issue in the main repository.)
 
 <!-- omit in toc -->
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ project claims otherwise nowhere. The quality gates that stand in for a review
 team are the CI gate (build with warnings-as-errors, the full test suite,
 conformance checks, CodeQL, supply-chain checks) and the adversarial multi-lens
 security review run on every change to the login path (see the
-[Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)
+[Review Gate](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate)
 wiki page).
 
 ## Decision-making
@@ -29,7 +29,7 @@ wiki page).
   issue → branch → tests → review gates → PR → CI-green merge.
 - **Scope and releases** I decide, guided by the project's maturity ladder;
   releases follow the
-  [Releasing](https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing)
+  [Releasing](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Releasing)
   (channel/soak promotion).
 - **Security decisions outrank feature decisions.** Anything touching the login
   path passes the adversarial review gate before merge.
@@ -59,4 +59,4 @@ A one-person project carries an honest bus factor of one. Mitigations in place:
 
 Structural one-person limits (what badge levels this ceiling caps) are tracked
 openly in the maturity-map work
-([#749](https://github.com/iderex/jellyfin-plugin-sso/issues/749)).
+([#749](https://github.com/Flowfin/jellyfin-plugin-sso/issues/749)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ seriously and handled with priority over all other work.
 ## Reporting a vulnerability
 
 Please report vulnerabilities **privately** via GitHub's
-[private vulnerability reporting](https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new)
+[private vulnerability reporting](https://github.com/Flowfin/jellyfin-plugin-sso/security/advisories/new)
 ("Report a vulnerability" on the Security tab of this repository).
 
 Please do **not** open a public issue for an exploitable vulnerability. A public
@@ -38,7 +38,7 @@ consistently - they are not a contractual SLA.
   matrix). A security fix ships for **all ABI builds of the latest release**
   at the same time.
 - **When a future major line replaces 4.x** (the planned JF12-native 5.0 line -
-  [#743](https://github.com/iderex/jellyfin-plugin-sso/issues/743)), the intent
+  [#743](https://github.com/Flowfin/jellyfin-plugin-sso/issues/743)), the intent
   is to keep shipping **security fixes for the previous line for at least six
   months** after the new line's first stable release.
 - **End of support is announced**, not silent: in `CHANGELOG.md` and the
@@ -46,7 +46,7 @@ consistently - they are not a contractual SLA.
   months' notice before the final security update of a line.
 
 Release integrity, channels and the soak/promotion model are described in the
-[Releasing](https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing)
+[Releasing](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Releasing)
 wiki page.
 
 ## Verifying a release download
@@ -62,7 +62,7 @@ downloading a release zip you can verify it was produced by this repository's
 release pipeline and has not been tampered with:
 
 ```sh
-gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
+gh attestation verify <plugin>.zip --repo Flowfin/jellyfin-plugin-sso
 ```
 
 The provenance attestation complements the checksum sidecars - it does not
@@ -118,7 +118,7 @@ integrity is covered by the SLSA attestation and the checksum sidecars above.
 - **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
 
-For how these controls together cover what an automated PR reviewer would catch - and the one accepted residual - see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). The plugin's [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13660) passing level reflects the same controls. For the authentication surface mapped to OWASP ASVS 5.0 and the OAuth 2.0 Security BCP (RFC 9700) - Met / Partial / N-A with source citations and honestly-recorded residuals - see the [Security Conformance self-assessment](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Conformance).
+For how these controls together cover what an automated PR reviewer would catch - and the one accepted residual - see [Review Gate](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate). The plugin's [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13660) passing level reflects the same controls. For the authentication surface mapped to OWASP ASVS 5.0 and the OAuth 2.0 Security BCP (RFC 9700) - Met / Partial / N-A with source citations and honestly-recorded residuals - see the [Security Conformance self-assessment](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Conformance).
 
 ## Single Logout security posture
 
@@ -198,5 +198,5 @@ off, both the RP-initiated OIDC logout route and the inbound SAML
   integrates or redistributes this plugin **commercially** becomes responsible
   for the CRA manufacturer obligations for their product; this project's
   artifacts help (release provenance and checksums above, a dependency SBOM is
-  planned - [#763](https://github.com/iderex/jellyfin-plugin-sso/issues/763)
+  planned - [#763](https://github.com/Flowfin/jellyfin-plugin-sso/issues/763)
   tracks OpenVEX), but do not transfer that responsibility.

--- a/SSO-Auth.Bench/README.md
+++ b/SSO-Auth.Bench/README.md
@@ -2,7 +2,7 @@
 
 An in-process characterization of the OpenID login path: how long `OidChallenge` and `OidCallback`
 take inside the plugin, serially and under concurrent callers. It is the measuring instrument for
-[#1117](https://github.com/iderex/jellyfin-plugin-sso/issues/1117); capturing baseline numbers on a
+[#1117](https://github.com/Flowfin/jellyfin-plugin-sso/issues/1117); capturing baseline numbers on a
 controlled machine is a separate piece of work.
 
 ## Running it

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -1,7 +1,7 @@
 # Fuzzing the untrusted-input parse surface (#402)
 
 This project is the coverage-guided fuzz harness prototype for the plugin's login-path parsers, and the
-written evaluation behind [Scorecard alert #36 (Fuzzing)](https://github.com/iderex/jellyfin-plugin-sso/issues/402).
+written evaluation behind [Scorecard alert #36 (Fuzzing)](https://github.com/Flowfin/jellyfin-plugin-sso/issues/402).
 It is the concrete harness the weekly scheduled job (#174) runs.
 
 It is **out of band**: not part of `SSO-Auth.sln`, so a normal `dotnet build` / `dotnet test` never

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -603,7 +603,7 @@ internal sealed class CanonicalLinkService
             // legacy key points at - orphaned from this identity. This warning is the single
             // observable signal of that outcome; recover by linking the original account to this
             // subject via the admin endpoints. See the upgrade runbook in the Provider-Setup wiki
-            // page (https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup). Throttled
+            // page (https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup). Throttled
             // through the shared once-per-interval gate (#362) so a login loop cannot flood it; the
             // account is still provisioned on every login regardless of whether the line is emitted.
             if (_logger.IsEnabled(LogLevel.Warning))

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -58,7 +58,7 @@ internal static class SsoHttp
     /// The plugin's outbound User-Agent: product token, assembly file version, and project URL.
     /// </summary>
     internal static readonly string UserAgent =
-        $"Jellyfin-Plugin-SSO-Auth +{FileVersionInfo.GetVersionInfo(typeof(SsoHttp).Assembly.Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
+        $"Jellyfin-Plugin-SSO-Auth +{FileVersionInfo.GetVersionInfo(typeof(SsoHttp).Assembly.Location).FileVersion} (https://github.com/Flowfin/jellyfin-plugin-sso)";
 
     /// <summary>
     /// Returns an SSRF-hardened outbound client from the factory (whose primary handler is

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -19,7 +19,7 @@
               class="raised button-alt headerHelpButton"
               target="_blank"
               rel="noopener noreferrer"
-              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+              href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
               data-i18n="link.help"
               >Help</a
             >
@@ -59,7 +59,7 @@
                 See the
                 <a
                   is="emby-linkbutton"
-                  href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+                  href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
                   class="button-link"
                   >help page</a
                 >
@@ -439,7 +439,7 @@
                   your identity provider. See the
                   <a
                     is="emby-linkbutton"
-                    href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+                    href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
                     class="button-link"
                     >quick-start guide</a
                   >
@@ -1830,7 +1830,7 @@
                         account-linking runbook on the
                         <a
                           is="emby-linkbutton"
-                          href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+                          href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
                           class="button-link"
                           >wiki</a
                         >, then turn it back off. A name-matched administrator

--- a/SSO-Auth/Web/linking.html
+++ b/SSO-Auth/Web/linking.html
@@ -42,7 +42,7 @@
               class="raised button-alt headerHelpButton"
               target="_blank"
               rel="noopener noreferrer"
-              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+              href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
               data-i18n="link.help"
               >Help</a
             >
@@ -71,14 +71,14 @@
             See the
             <a
               is="emby-linkbutton"
-              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+              href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
               class="button-link"
               >homepage</a
             >
             and
             <a
               is="emby-linkbutton"
-              href="https://github.com/iderex/jellyfin-plugin-sso/issues"
+              href="https://github.com/Flowfin/jellyfin-plugin-sso/issues"
               class="button-link"
               >issue tracker
             </a>

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -27,7 +27,7 @@ description: |
   password login for every account except a designated break-glass admin.
   Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
   A security-first continuation of the archived 9p4/jellyfin-plugin-sso.
-  Documentation and provider setup guides: https://github.com/iderex/jellyfin-plugin-sso
+  Documentation and provider setup guides: https://github.com/Flowfin/jellyfin-plugin-sso
 category: "Authentication"
 # The net10 shipping closure, empirically from `dotnet publish -f net10.0` (#135). It differs from the
 # net9 list in build.yaml: on .NET 10 the SAML crypto assemblies (System.Security.Cryptography.Xml /

--- a/build.yaml
+++ b/build.yaml
@@ -19,7 +19,7 @@ description: |
   password login for every account except a designated break-glass admin.
   Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
   A security-first continuation of the archived 9p4/jellyfin-plugin-sso.
-  Documentation and provider setup guides: https://github.com/iderex/jellyfin-plugin-sso
+  Documentation and provider setup guides: https://github.com/Flowfin/jellyfin-plugin-sso
 category: "Authentication"
 artifacts:
   - "SSO-Auth.dll"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,17 @@
 # Documentation
 
 The full documentation for this plugin lives in the project
-**[Wiki](https://github.com/iderex/jellyfin-plugin-sso/wiki)**. It is maintained
+**[Wiki](https://github.com/Flowfin/jellyfin-plugin-sso/wiki)**. It is maintained
 as a separate Git repository, so it is not mirrored into this folder.
 
 Start there for:
 
-- **[Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation)**
-- **[Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)** -
+- **[Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation)**
+- **[Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup)** -
   OpenID Connect and SAML
-- **[Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow)**
-- **[Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model)**
-- **[Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)**
+- **[Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow)**
+- **[Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model)**
+- **[Troubleshooting](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Troubleshooting)**
 
 Three pages in this folder are published here rather than in the Wiki, because
 each is written for somebody reading the source alongside it:
@@ -28,6 +28,6 @@ each is written for somebody reading the source alongside it:
 
 The [README](../README.md) has the overview and quick start; the Wiki is the
 reference documentation. The contributor architecture reference lives in the
-Wiki **[Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture)**
+Wiki **[Architecture](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Architecture)**
 page - the module structure, the enforced dependency graph, and the contract
 every change follows.

--- a/docs/SECURITY-REMEDIATION-POLICY.md
+++ b/docs/SECURITY-REMEDIATION-POLICY.md
@@ -66,7 +66,7 @@ ever drift, the policy is corrected or the gate is fixed, never papered over.
   or a note in the PR) - silent dismissal is not an option. False positives in
   the Opengrep ruleset are fixed in the ruleset itself, never waived ad hoc.
 - **Accepted residuals** are documented where they live: the
-  [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)
+  [Review Gate](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Review-Gate)
   wiki page records the known accepted residual(s) of the overall gate stack.
   A dependency advisory triaged as not-exploitable is not a residual of this
   kind - it is a published statement in `security/vex/openvex.json`, under

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -1,9 +1,9 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://github.com/iderex/jellyfin-plugin-sso/security/vex/openvex.json",
+  "@id": "https://github.com/Flowfin/jellyfin-plugin-sso/security/vex/openvex.json",
   "author": "iderex",
   "role": "Maintainer",
-  "timestamp": "2026-08-05T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-08-26T00:00:00Z",
+  "version": 2,
   "statements": []
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -18,7 +18,7 @@ the PR run already validated it). Additional self-hostable identity providers ge
 (`test/e2e/zitadel/`, OIDC), **Pocket ID** (`test/e2e/pocket-id/`, OIDC) and **Kanidm**
 (`test/e2e/kanidm/`, OIDC) are all implemented - every self-hostable provider in the README table now has
 one. The programme is tracked in
-[#919](https://github.com/iderex/jellyfin-plugin-sso/issues/919). The **full provider matrix runs at a
+[#919](https://github.com/Flowfin/jellyfin-plugin-sso/issues/919). The **full provider matrix runs at a
 release and a beta-release** - never on a routine merge, so the cross-provider pass is release-gate
 evidence, not a per-commit cost - **and on a manual dispatch with `providers: all`**, which is how a newly
 added harness is proven green before a release rather than on release day. A provider joins that matrix by


### PR DESCRIPTION
# What & why

Closes #1430.

59 references across 21 tracked files still named the pre-transfer path
`iderex/jellyfin-plugin-sso`. Every one of them worked, and worked only because
GitHub serves the old path through a rename redirect, which is not a property of
this tree and is maintained by nothing here:

```
$ gh api repos/iderex/jellyfin-plugin-sso --jq '.full_name'
Flowfin/jellyfin-plugin-sso
```

That redirect stops the moment a repository is created under the old name, and at
that point the links do not 404 - they point at somebody else's repository. A 404
is visible; a wrong destination is not.

The two that mattered most were the security-report routes. The issue template's
contact link and `SECURITY.md` both sent a private vulnerability report at the old
path's advisory form, which is the one message whose misdelivery nobody would
notice.

## The three sites that are not links a person clicks

Called out because they were decided rather than swept, which is what #1430's
Done-when asks for.

**The outbound User-Agent.** `SsoHttp.UserAgent` carries the project URL and
leaves the machine on every OpenID discovery, token and JWKS request, so it is
how an identity-provider operator finds this project. No test pinned that string:

```
$ git grep -rn "Jellyfin-Plugin-SSO-Auth +" SSO-Auth.Tests/ ; echo "exit=$?"
exit=1
```

The build covers it and nothing asserts its content. Whether it deserves an
assertion is not decided here.

**`gh attestation verify --repo` in SECURITY.md.** An attestation is recorded
against the repository whose workflow produced it, and `.github/workflows/build.yml`
runs in this repository with `attestations: write`. So the old value would be
correct only for artifacts built before the transfer. **I did not run
`gh attestation verify`**: that needs a downloaded release zip and I downloaded
none, so this line is reasoned from where the workflow runs rather than measured
against an artifact.

**The VEX document's `@id`.** That is an identifier rather than a route, so the
document says it changed rather than being edited silently: `version` goes to 2
and the timestamp to the day of the change. It carries no statements, so nothing
downstream holds a claim keyed to the previous identity.

```
$ git show HEAD:security/vex/openvex.json
{
  "@context": "https://openvex.dev/ns/v0.2.0",
  "@id": "https://github.com/Flowfin/jellyfin-plugin-sso/security/vex/openvex.json",
  "author": "iderex",
  "timestamp": "2026-08-26T00:00:00Z",
  "version": 2,
  "statements": []
}
```

`author` is unchanged: it names a person, not a path. The `role` line is elided
above; nothing else is.

## What is deliberately left

`CHANGELOG.md` keeps its three references. Each entry records what was true when
it was written, and rewriting a landed entry's URL edits the record rather than
fixing a link. That is #1430's third Done-when clause, answered here rather than
left silent.

```
$ git grep -c "iderex/jellyfin-plugin-sso" HEAD
HEAD:CHANGELOG.md:3
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches the security-report routing, one value on the outbound login path,
and two files the release pipeline reads, so the boxes are answered rather than
skipped.

- [x] Fail-closed preserved: no branch, guard, validation or default changed.
      Every changed line is replaced one for one and none is added or removed:
      `git diff origin/main...HEAD --numstat` totals +56 -56, of which 53 carry the
      55 path replacements outside the VEX file and 3 are the VEX file (its `@id`,
      which is the 56th replacement, plus the version and timestamp beside it).
- [x] No secrets logged; secrets are redacted on config export. Untouched.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **Not performed, and not
      claimed.** No validation, persistence or pipeline LOGIC is in the diff; what
      the pipeline files carry is a description string in `build.yaml` /
      `build-jf12.yaml` and comments in four workflows. `Package (JPRM) / Build
      package` exercises both manifests on this head.
- [ ] Review record. **No lens was run and no second reader looked at this**, on
      either count. There is none available on this board tonight.
- [x] Log inputs from the IdP are sanitized inline at the log call. Untouched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. No logic added.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting.
- [x] Architecture-conformance tests pass (they run in the suite below); no
      structural property changed, so none is added.
- [x] Docs impact considered: this change **is** largely the documentation
      update. The wiki was not audited for the same residue and is named as out of
      scope on #1430.

## Verification

Run in this worktree at the committed head, both target frameworks:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgeführt.
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgeführt.
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3410, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3411, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

**The four skips are disclosed rather than counted as passes.** They are the
pre-existing `SsoHttpTests` cases that bind a listener off loopback, which raises
a Windows firewall consent dialog needing an administrator (#1227). They skip on
`main` too and were not worked around.

On Prettier: every formattable file this touches was **already** reported by local
Prettier before the change, so this introduces nothing. Measured by checking the
same file list with the change stashed:

```
$ git stash && npx prettier --check <the ten touched formattable files>
Code style issues found in 10 files.
$ git stash pop && npx prettier --check <the same ten>
Code style issues found in 10 files.
```

Local Prettier is 3.9.6 and the `prettier` job installs its own through
`creyD/prettier_action`, which is why that count is non-zero here and green in CI.
The CI job is the authority on this head.

## Notes

**No second reader looked at this change**, and no security lens was run on it.

Out of scope and named so it is not read as covered: the wiki was not checked for
the same residue - it is a different repository and is not readable from this
tree - and no assertion was added that would refuse the next stale path. #1430's
last Done-when clause offers `.github/workflows/opengrep.yml` as the home for such
a refusal; this change does not add one, so the class is repaired but not yet
refused. That is filed as #1432, together with the reason it could not be done
here: the rule's bite has to be shown on a runner, because the ruleset's local
run is a container invocation and there is no container engine on this machine.
