### PR TITLE
Refuse the pre-transfer repository path in the invariant gate [#1432]

### DIFF
--- a/PROBE-1432.md
+++ b/PROBE-1432.md
@@ -1,8 +1,0 @@
-# Deliberate regression probe (#1432)
-
-This file exists to prove that `no-pre-transfer-repo-path` fires, and it is
-removed by the next commit on this branch. The line below is the regression: a
-reference naming the pre-transfer repository path, in ordinary tracked prose,
-outside the two paths the rule exempts.
-
-See the [security model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model).

--- a/PROBE-1432.md
+++ b/PROBE-1432.md
@@ -1,0 +1,8 @@
+# Deliberate regression probe (#1432)
+
+This file exists to prove that `no-pre-transfer-repo-path` fires, and it is
+removed by the next commit on this branch. The line below is the regression: a
+reference naming the pre-transfer repository path, in ordinary tracked prose,
+outside the two paths the rule exempts.
+
+See the [security model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model).

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -1,9 +1,11 @@
 # Opengrep (open-source Semgrep fork) rules that enforce this repo's greppable
 # security invariants as lint rules - one rule per invariant, added as each is
 # discovered (rule-per-regression). Deliberately narrow and low-false-positive:
-# these are `generic`-mode token patterns, NOT semantic C# analysis, so they do
-# not depend on the C# language parser (whose modern-C#/.NET 9 support is still
-# maturing) and cannot silently mis-parse a file into a false negative. Every
+# these run in `generic` mode - token patterns, or a regex where the subject is
+# an exact byte sequence rather than code - and NOT semantic C# analysis, so they
+# do not depend on the C# language parser (whose modern-C#/.NET 9 support is
+# still maturing) and cannot silently mis-parse a file into a false negative. A
+# rule that departs from the token-pattern shape says why at the rule. Every
 # rule is verified to produce zero findings on the current clean tree; a rule
 # fires only when an invariant regresses.
 #
@@ -146,3 +148,46 @@ rules:
     paths:
       include:
         - "SSO-Auth/**/*.cs"
+
+  # Invariant (links / identity, #1430): every reference a reader or a machine
+  # follows names the CURRENT repository path. The pre-transfer path
+  # `iderex/jellyfin-plugin-sso` resolves only through GitHub's rename redirect,
+  # which is not a property of this tree and is maintained by nothing here: it
+  # stops the moment any account creates a repository under the old name, and
+  # from then on those references do not 404 - they point at somebody else's
+  # repository. A 404 is visible; a wrong destination is not, and two of the
+  # references #1430 repaired were the private vulnerability-report routes.
+  # #1285 fixed one instance of this class and closed; the class came back
+  # across 21 files anyway, which is what rule-per-regression is for (#1432).
+  #
+  # `iderex` ALONE IS NOT THE SUBJECT and must keep passing: it is the author
+  # field in security/vex/openvex.json and the account named in several
+  # documents. The subject is the repository path and nothing narrower.
+  #
+  # This is the one rule here written as a regex rather than a generic-mode
+  # token pattern, and the reason is the sentence above. Generic mode matches a
+  # token sequence across intervening whitespace and newlines, so `iderex` on
+  # one JSON line and `jellyfin-plugin-sso` on another could satisfy a token
+  # pattern that no reader would call an occurrence of the path. The subject is
+  # an exact byte sequence in prose, so the means that matches bytes is the one
+  # that states it.
+  - id: no-pre-transfer-repo-path
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not name the pre-transfer repository path `iderex/jellyfin-plugin-sso`.
+      Name the current one, `Flowfin/jellyfin-plugin-sso`: the old path resolves
+      only through GitHub's rename redirect, and the moment a repository exists
+      under that name these references point at it instead of 404ing (#1430).
+    patterns:
+      - pattern-regex: iderex/jellyfin-plugin-sso
+    paths:
+      exclude:
+        # CHANGELOG.md keeps its references deliberately (#1430): each entry
+        # records what was true when it was written, and rewriting a landed
+        # entry's URL edits the record rather than repairing a link. A rule
+        # that refused them would refuse honest text and would be turned off.
+        - "CHANGELOG.md"
+        # This rule file necessarily contains the banned string as its own
+        # pattern and in the prose above - do not scan it against itself.
+        - "tools/opengrep/**"


### PR DESCRIPTION
# What & why

Closes #1432.

#1430 repaired 59 references across 21 tracked files that named the pre-transfer
path `iderex/jellyfin-plugin-sso`, and nothing refused the next one. #1285 had
already fixed a single instance of the same class and closed; the class came
back anyway. A class that recurs after a targeted fix is what the invariant gate
is for, and this adds the rule plus the evidence that it bites.

What the old path costs is not a broken link. It resolves only through GitHub's
rename redirect, which is not a property of this tree and is maintained by
nothing here. The moment any account creates a repository under that name, those
references stop redirecting and start pointing at it. A 404 is visible and a
wrong destination is not, and two of the references #1430 repaired were the
private vulnerability-report routes.

## The proof that it bites

This is the half #1432 says it is really about, and it is two runs on this pull
request rather than a claim. It had to be produced on a runner: the ruleset
documents its local invocation as a container and no container engine is
reachable on the machine the rule was written on.

**It fires.** Commit `d3febe7` carries the rule and one deliberate regression in
ordinary tracked prose (`PROBE-1432.md`). The gate refused it and the job exited
non-zero:

https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33008966904/job/98309957854

```
    PROBE-1432.md
   ❯❯❱ tools.opengrep.no-pre-transfer-repo-path
Ran 7 rules on 532 files: 1 finding.
##[error]Process completed with exit code 1.
```

**It refuses nothing else.** That same line is the false-positive measurement,
and it is the reason the red run is worth more than a red run usually is: the
scan covered 532 files and returned ONE finding. `security/vex/openvex.json`,
whose `author` field is `iderex`, was among them and passed. #1432 names that
exact false positive as the thing the rule has to get right, and this is it
measured rather than argued.

**The clean tree is at zero.** Commit `7efdb2c` removes the probe and changes
nothing else:

https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33009066015/job/98310295440

```
Ran 7 rules on 531 files: 0 findings.
```

531 against 532 is the probe and nothing else, so the two runs differ by exactly
the subject under test. That is the pair #1432 asked for: a rule that has been
seen to bite, on the tree that actually merges.

## Scope and exemptions

`CHANGELOG.md` is exempt, with the reason written at the rule: its entries record
what was true when each was written, so a rule refusing them would refuse honest
text and be turned off. Read on the merge base:

```
$ git grep -c "iderex/jellyfin-plugin-sso" 78b283d
78b283d:CHANGELOG.md:3
```

Three references, all in `CHANGELOG.md`, so the clean tree is at zero once that
file is exempt. `tools/opengrep/**` is exempt because the rule file necessarily
contains the string as its own pattern.

The rule scans the tree rather than an extension list. The residue #1430
repaired spanned six extensions:

```
$ git diff --name-only 78b283d^1 78b283d | sed 's/.*\.//' | sort | uniq -c | sort -rn
      8 md
      5 yml
      2 yaml
      2 html
      2 cs
      1 json
```

An include list built from those six would have to be extended the first time
the class appears in a seventh, which is the drift the exemption-by-name shape
avoids.

## The means, and why it fits

This is the one rule in the file written as a regex rather than a generic-mode
token pattern, and it says so at the rule. Generic mode matches a token sequence
across intervening whitespace, so `iderex` on one line of
`security/vex/openvex.json` and `jellyfin-plugin-sso` on another could satisfy a
token pattern while being no occurrence of the path at all. #1432 names that
false positive explicitly: `iderex` alone is legitimate and has to keep passing.
The subject is an exact byte sequence in prose, so the means that matches bytes
is the one that states it. The file header carried a blanket claim that every
rule is a token pattern; it now says a departing rule argues itself at the rule.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This change adds a lint rule and touches no login path, no
crypto, no config persistence and no release pipeline. No `.cs` file changes.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update.

The conformance line is ticked on the ground that it is unaffected rather than
re-run here: no `.cs` file changes, so the structural properties that suite
reads are untouched. The `dotnet` job on this pull request is what actually
runs it.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The two build boxes are left unticked deliberately rather than ticked by
inference. Neither was run on this machine, because this change compiles
nothing; the `dotnet` job on this pull request is the reading that counts, and
it is visible in the checks below.

```
$ npx --yes prettier --check PROBE-1432.md
Checking formatting...
All matched files use Prettier code style!
```

That command was run while the probe existed. The probe is removed by the second
commit, and the ruleset is a `.yml`, which is outside the prettier job's glob
(`**/*.{js,html,md,css,scss}`).

## Notes

`PROBE-1432.md` is added by the first commit and removed by the second. It exists
only to be refused, and the merged tree does not carry it.

Out of scope, from #1432's own closing section: whether other pre-transfer
identifiers deserve the same treatment. This is scoped to the one path #1430
measured.

No second reader looked at this change.
