### PR TITLE
Fix self-service account link falling through to a login POST

### DIFF
--- a/SSO-Auth/Api/Flows/WebResponse.cs
+++ b/SSO-Auth/Api/Flows/WebResponse.cs
@@ -297,12 +297,9 @@ function showReturnLink() {
 const ssoBaseUrl = " + JsonSerializer.Serialize(punycodeBaseUrl) + @";
 const ssoProvider = " + JsonSerializer.Serialize(provider) + @";
 const ssoMode = " + JsonSerializer.Serialize(mode) + @";
-async function link(request) {
-    const jfCredentialsString = localStorage.getItem(""jellyfin_credentials"");
+async function link(jfCredentials, request) {
+    if (jfCredentials == null) return;
 
-    if (jfCredentialsString == null) return;
-
-    const jfCredentials = JSON.parse(jfCredentialsString);
     const jfUser = jfCredentials['Servers'][0]['UserId'];
     const jfToken = jfCredentials['Servers'][0]['AccessToken'];
 
@@ -333,24 +330,36 @@ async function link(request) {
 }
 
 async function main() {
-    localStorage.removeItem('jellyfin_credentials');
-    document.getElementById('iframe-main').src = ssoBaseUrl + '/web/index.html';
+    // #self-link-credential-race: capture the CURRENT tab's session BEFORE anything below touches
+    // localStorage. The link leg authenticates as the user who is already signed in (that's how they
+    // reached /SSOViews/linking), so it needs THIS session's token. Wiping credentials first - as the
+    // login leg does below, to force a clean iframe bootstrap for a brand-new session - destroys the
+    // one thing the link leg needs, and the iframe-reload race that follows may or may not repopulate
+    // an authenticated (non-anonymous) session before the wait loop moves on, silently sending the
+    // request down the wrong leg (Auth instead of Link) when it doesn't.
+    var preLinkCredentials = null;
+    if (" + (isLinking ? "true" : "false") + @") {
+        var preLinkCredentialsString = localStorage.getItem(""jellyfin_credentials"");
+        if (preLinkCredentialsString != null) {
+            preLinkCredentials = JSON.parse(preLinkCredentialsString);
+        }
+    }
 
     var data = " + JsonSerializer.Serialize(data) + @";
-    while (localStorage.getItem(""_deviceId2"") == null ||
-        localStorage.getItem(""jellyfin_credentials"") == null ||
-        JSON.parse(localStorage.getItem(""jellyfin_credentials""))['Servers'][0]['Id'] == null) {
-        // If localStorage isn't initialized yet, try again.
-        await sleep(100);
-    }
-    var deviceId = localStorage.getItem(""_deviceId2"");
-    var appName = ""Jellyfin Web"";
-    var appVersion = ""10.8.0"";
-    var deviceName = getDeviceName();
 
-    var request = {deviceId, appName, appVersion, deviceName, data};
+    if (preLinkCredentials != null && preLinkCredentials['Servers']?.[0]?.['UserId'] != null) {
+        // Fast path: a live session for the account being linked is already in hand, so skip the
+        // wipe-and-reload dance below entirely - it exists to bootstrap a FRESH session for the login
+        // leg, which is not what linking needs and only risks losing the session linking depends on.
+        while (localStorage.getItem(""_deviceId2"") == null) {
+            await sleep(100);
+        }
+        var linkDeviceId = localStorage.getItem(""_deviceId2"");
+        var linkAppName = ""Jellyfin Web"";
+        var linkAppVersion = ""10.8.0"";
+        var linkDeviceName = getDeviceName();
+        var linkRequest = {deviceId: linkDeviceId, appName: linkAppName, appVersion: linkAppVersion, deviceName: linkDeviceName, data};
 
-    if (" + (isLinking ? "true" : "false") + @") {
         // Linking is NOT a login round-trip, so a DEFINITIVE link outcome is terminal here - the page does
         // NOT go on to post to .../Auth (#614). The Link leg one-time-consumes the assertion / state token,
         // so the old unconditional follow-on Auth post could never redeem it: it fail-closed at the mint leg
@@ -359,9 +368,9 @@ async function main() {
         //   - A 2xx is a completed link: show success and stop (do not attempt a login).
         //   - A non-2xx is a rejected link (#344): the provider is disabled (#343), the caller is not
         //     allowed, or the request is throttled - surface it and stop, never fall through to a login.
-        //   - A missing status (undefined: no stored credentials, or a network error) keeps the prior
-        //     behavior of proceeding to the auth leg, since that outcome cannot be told apart from success.
-        var linkStatus = await link(request);
+        //   - A missing status (undefined: a network error) keeps the prior behavior of proceeding to the
+        //     auth leg, since that outcome cannot be told apart from success.
+        var linkStatus = await link(preLinkCredentials, linkRequest);
         if (linkStatus !== undefined) {
             const linked = linkStatus >= 200 && linkStatus < 300;
             document.querySelector('p').textContent =
@@ -376,6 +385,22 @@ async function main() {
             return;
         }
     }
+
+    localStorage.removeItem('jellyfin_credentials');
+    document.getElementById('iframe-main').src = ssoBaseUrl + '/web/index.html';
+
+    while (localStorage.getItem(""_deviceId2"") == null ||
+        localStorage.getItem(""jellyfin_credentials"") == null ||
+        JSON.parse(localStorage.getItem(""jellyfin_credentials""))['Servers'][0]['Id'] == null) {
+        // If localStorage isn't initialized yet, try again.
+        await sleep(100);
+    }
+    var deviceId = localStorage.getItem(""_deviceId2"");
+    var appName = ""Jellyfin Web"";
+    var appVersion = ""10.8.0"";
+    var deviceName = getDeviceName();
+
+    var request = {deviceId, appName, appVersion, deviceName, data};
 
     var url = ssoBaseUrl + '/sso/' + ssoMode + '/Auth/' + encodeURIComponent(ssoProvider);
 


### PR DESCRIPTION
# What & why

`WebResponse.Generator`'s auth page unconditionally wipes `localStorage`'s
`jellyfin_credentials` and reloads an iframe to re-bootstrap them before
reading `jfUser`/`jfToken` for the `/Link/` POST. For the linking leg this is
counterproductive: the currently signed-in user's session (needed to make the
authenticated Link call) is destroyed first, and the iframe reload may not
repopulate an authenticated (non-anonymous) session before the wait loop
moves on. When it doesn't, `link()` sees `jfUser == null`, resolves to
`undefined`, and the page falls through to the ordinary `/Auth/` login POST
instead - which can then be refused for reasons that only make sense for a
first-time login (e.g. `AllowExistingAccountLink` being off), even though the
user was already authenticated and only trying to link.

Capture `jellyfin_credentials` from `localStorage` before the wipe when this
is a linking request, and use those captured credentials for the `/Link/`
POST directly - skipping the wipe-and-reload dance entirely, since it exists
to bootstrap a fresh session for the login leg and linking already has a live
one. Falls back to the original wipe-and-reload login path only when no
usable session was actually held to begin with.

Found this debugging a real deployment: a signed-in administrator's
self-service link at `/SSOViews/linking` was silently landing on the
name-adoption refusal (`AllowExistingAccountLink` off, admin accounts never
name-adopted) instead of ever reaching `/Link/`. No issue filed yet - happy
to open one and cross-reference if that's preferred over a bare PR.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No signature/time-bound/audience
      check is touched - every server-side gate on `/Link` and `/Auth`
      (rate limiting, `AllowExistingAccountLink`, the admin no-name-adoption
      rule) is unchanged. This only changes which client-side request the
      auth page sends and with which already-held credentials.
- [x] No secrets logged; secrets are redacted on config export. No logging
      added or changed; `jfToken` flows through the same `Authorization`
      header construction as before, never printed.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Not performed - flagging
      rather than claiming it. The change doesn't touch SAML/OIDC token
      validation, config persistence, or the release pipeline, only which
      leg of the *already-reviewed* `/Link` vs `/Auth` endpoints the page
      posts to and with what credentials - but I'd rather a maintainer's eyes
      confirm that scoping than assert it myself.
- [ ] Review record: per lens, its verdict and its findings... Not performed
      (see above) - no CONFIRMED/PLAUSIBLE record to report honestly.
- [x] Log inputs from the IdP are sanitized inline at the log call. N/A - no
      logging touched by this change.

## Quality checklist

- [ ] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. Partially - the fast path re-derives
      `deviceId`/`appName`/`appVersion`/`deviceName` under `link*`-prefixed
      names rather than sharing the assembly with the fallback login path's
      identical block further down. Kept it a straight duplication rather
      than refactoring the shared shape into a helper, to keep the diff
      minimal and the literal strings the existing test suite asserts on
      (`if (true) {` / `if (false) {`, `if (linkStatus !== undefined) {`,
      the `return`-before-`/Auth/` ordering) untouched. Open to extracting a
      shared helper if that's preferred - said more in Notes.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments
      explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass (confirmed locally, see
      Verification) - this fix doesn't establish a new structural property,
      so no new `ArchitectureConformanceTests` rule was added.
- [x] Docs impact considered: no README/wiki update needed - this restores
      the behavior the Login-Flow wiki page already documents for
      self-service linking; it was never accurately describing what the code
      did.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. Verified for
      **net9.0 only** (`-p:TargetFrameworks=net9.0 --no-restore
      --warnaserror`): 0 warnings, 0 errors. I don't have the .NET 10 SDK
      available locally, so I could not run the unmodified multi-target
      command or verify the net10.0 leg - deferring that to CI.
- [ ] `dotnet test` is green. Couldn't get `dotnet test` (the CLI wrapper) to
      report results in my local environment - it builds successfully but
      reports no discovered/run tests, on both a fresh run and
      `--no-build --verbosity normal`, which looks like a local
      Microsoft.Testing.Platform/`dotnet test` integration quirk with SDK
      9.0.317 rather than anything about the change. Ran the built xUnit v3
      test host directly instead (`SSO-Auth.Tests` binary), which does
      report results: **3405/3410 passed**. The 5 failures are all
      pre-existing `SamlResponseTests`/`SamlSecondaryCertificateTests`/
      `SamlLogoutRequestTests` SHA-1-signature cases, unrelated to this
      change - they fail locally because Fedora's OpenSSL build refuses to
      even *produce* a SHA-1 signature for the test fixture
      (`digital envelope routines::invalid digest`), not because the
      plugin's rejection logic is wrong. All 19 `WebResponseTests` pass,
      including the two most relevant to this change
      (`Generator_EmitsIsLinkingAsJsBooleanLiteral`,
      `Generator_SuccessfulLink_IsTerminal_...`).
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. N/A -
      only `SSO-Auth/Api/Flows/WebResponse.cs` changed (the JS lives inline
      as a C# raw string literal there); no standalone `.js`/`.html`/`.md`/
      `.css` file was touched.

## Notes

- Rebased onto current `main` after forking (picked up the `iderex` →
  `Flowfin` URL-string cleanup commits; no conflicts, nothing near this
  file).
- Open to extracting the duplicated device-info assembly (fast path vs.
  fallback login path) into a shared helper if that's the preferred shape -
  kept it inline for this PR to minimize the diff against the existing
  literal-string test assertions and make the review surface small.
- Found and reproduced against a live deployment (Authelia as OIDC
  provider), where a signed-in administrator's self-service link at
  `/SSOViews/linking` was reproducibly falling through to `/Auth/` and
  getting refused. Confirmed end-to-end after deploying this exact build:
  the same administrator's self-service link now reaches `/Link/` and
  completes successfully.
