### PR TITLE
Answer readiness for every configured provider in one action [#1084]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **One action checks every configured provider at once (#1084).** The settings
+  page could say whether the provider currently open in the editor looks
+  complete, and nothing could say it about the others: an administrator with six
+  providers had to open six forms to find the one that would refuse a login.
+  A "Configuration check" section above the provider lists now answers for all
+  of them in one press - every OpenID and SAML provider, whether a login against
+  it would get past the configuration, and what is wrong where it would not. The
+  answer comes from the server rather than from the form, which is what lets it
+  cover providers nobody has opened, and it is the same judgement a save is
+  refused by: the reason a row gives is the message the save path itself would
+  produce, so the check and the settings page cannot disagree about one
+  provider. Required settings that are still empty are named through the form's
+  own labels, so the report speaks the page's language. Advisory in both
+  directions - it never blocks a save and it changes nothing, so running it
+  leaves every provider's stored values and toggles exactly as they were. A
+  provider that is switched off is reported as switched off rather than as
+  broken. What the check does NOT do is contact any identity provider, and it
+  says so on every run: reachability is what Test Connection in a provider's own
+  editor is for, and fanning out probes here would empty the throttle budget
+  those routes share and report working providers as unreachable.
 - **A provisioning policy can be named once and shared by several providers
   (#1105).** The policy written onto a brand-new account at creation used to
   exist only as a block inside one provider, so a deployment wanting the same

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rules for the aggregate configuration check (#1084). The evaluation is executed by
+/// <see cref="ProviderCheckTests"/>; what these rules cover is everything BETWEEN the server and the page,
+/// which no suite here can run - the button, the route string, the member names and the field ids all live
+/// in a browser. A drift in any of them is otherwise found by an administrator pressing Check and reading a
+/// list that is silently wrong rather than one that is missing.
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    [Fact]
+    public void ConfigPage_RunsTheCheck_AgainstTheRouteTheServerServes()
+    {
+        // The route is a string on both sides and nothing compiles the pair together. Spelled wrong, the
+        // fetch rejects and the page reports "could not run the check" forever - a feature that looks broken
+        // rather than one that is absent. Read off the attribute rather than pasted, so renaming the route
+        // reddens this instead of half-renaming the feature.
+        var route = typeof(Jellyfin.Plugin.SSO_Auth.Api.Http.SSOController)
+            .GetMethod(nameof(Jellyfin.Plugin.SSO_Auth.Api.Http.SSOController.CheckProviders), BindingFlags.Public | BindingFlags.Instance)!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Mvc.HttpGetAttribute), false)
+            .Cast<Microsoft.AspNetCore.Mvc.HttpGetAttribute>()
+            .Single()
+            .Template;
+
+        Assert.Equal("Config/Check", route);
+        Assert.Contains("\"sso/" + route + "\"", ConfigJs(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigPage_ReadsExactlyTheMembersTheCheckReportDeclares()
+    {
+        // A member read under the wrong spelling is undefined in a browser rather than an error, and every
+        // one of these decides what a row SAYS: a misread Ready flags every provider, a misread MissingFields
+        // reports a broken provider as fine. So each declared member has to be named by the page.
+        var declared = typeof(ProviderCheckResult)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            new[] { "Enabled", "MissingFields", "Problem", "Protocol", "Provider", "Ready" },
+            declared);
+
+        var js = ConfigJs();
+        foreach (var member in declared)
+        {
+            Assert.Contains("row." + member, js, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("report.Providers", js, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryRequiredFieldTheCheckCanReport_IsAFieldTheFormCarries()
+    {
+        // The drift guard the aggregate check owes, and it is the one #1104 could not have: this report DOES
+        // name fields. Each name is a property on the provider type AND the id of that field on the settings
+        // page, which is what lets the page resolve a reported name to the form's own localized label instead
+        // of carrying a second copy of every label. A name that resolves to no element renders as the bare id
+        // in front of an administrator - readable, but the wrong word - and a renamed form field is exactly
+        // how that happens. Derived from the source on both sides, so neither can move alone.
+        var html = ConfigPageHtml();
+
+        foreach (var field in ProviderCheck.OidRequiredFields)
+        {
+            Assert.Contains("id=\"" + field + "\"", html, StringComparison.Ordinal);
+        }
+
+        foreach (var field in ProviderCheck.SamlRequiredFields)
+        {
+            Assert.Contains("id=\"saml-" + field + "\"", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void TheReportedRequiredFields_AreTheOnesThePerProviderPanelCallsRequired()
+    {
+        // Two answers to one question have to agree. The per-provider readiness panel (#1083) reads its own
+        // required list out of the DOM; this check reads the configuration. An administrator who sees a
+        // provider called ready in the editor and flagged in the aggregate list has no way to tell which one
+        // is lying, so the two lists are pinned to each other here rather than kept in step by hand.
+        //
+        // The panel's list carries the provider-name field as well, which the server cannot report on: the
+        // name is the dictionary KEY rather than a property, so a provider with no name does not exist to be
+        // reported. That one id is subtracted rather than the comparison being loosened.
+        var js = ConfigJs();
+
+        Assert.Equal(
+            ProviderCheck.OidRequiredFields.OrderBy(f => f, StringComparer.Ordinal),
+            RequiredIds(js, "oid:").Where(id => id != "OidProviderName").OrderBy(f => f, StringComparer.Ordinal));
+
+        Assert.Equal(
+            ProviderCheck.SamlRequiredFields.Select(f => "saml-" + f).OrderBy(f => f, StringComparer.Ordinal),
+            RequiredIds(js, "saml:").Where(id => id != "saml-provider-name").OrderBy(f => f, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void TheCheckAction_IsBoundAndPaintsIntoElementsThatExist()
+    {
+        // config.js addresses the button and the result list by id. An id no element carries is not an error
+        // in a browser: querySelector answers null, and either the binding throws during page setup - taking
+        // every later binding on the page with it - or the handler silently paints nowhere.
+        var js = ConfigJs();
+        var html = ConfigPageHtml();
+
+        foreach (var id in new[] { "CheckAllProviders", "sso-config-check-result" })
+        {
+            Assert.Contains("\"#" + id + "\"", js, StringComparison.Ordinal);
+            Assert.Contains("id=\"" + id + "\"", html, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void TheCheckHandler_WritesNoProviderFieldAndNoToggle()
+    {
+        // The acceptance clause that a run leaves every provider's form values and toggles byte-identical,
+        // held where it can actually be broken. The server side cannot break it - the route is a pure read -
+        // but the handler runs inside the page that owns every field, so a later "fix it for me" convenience
+        // would break it here and nowhere else. Anything that assigns `.value`, `.checked` or `.disabled`
+        // inside this handler is refused; reading them is untouched.
+        var js = ConfigJs();
+        var start = js.IndexOf("  checkAllProviders: (page) => {", StringComparison.Ordinal);
+        Assert.True(start >= 0, "config.js no longer declares checkAllProviders.");
+        var end = js.IndexOf("\n  renderTestMessage:", start, StringComparison.Ordinal);
+        Assert.True(end > start, "checkAllProviders is no longer followed by renderTestMessage; re-anchor this rule.");
+
+        var body = js.Substring(start, end - start);
+        foreach (var write in new[] { ".value =", ".checked =", ".disabled =" })
+        {
+            Assert.DoesNotContain(write, body, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void TheCheckAlwaysDisclosesThatReachabilityWasNotChecked()
+    {
+        // A negative disclosure that is easy to drop and expensive to lose. This check makes no request to
+        // any identity provider, so a list with nothing flagged says the CONFIGURATION is complete and
+        // nothing at all about whether the provider answers. Without the sentence, an administrator reads
+        // silence as reachability - the one wrong conclusion this action can produce - and the fix is not to
+        // start probing: both Test routes share one throttle bucket, so a fan-out over many providers empties
+        // it and reports working providers as broken.
+        var js = ConfigJs();
+        var start = js.IndexOf("  checkAllProviders: (page) => {", StringComparison.Ordinal);
+        Assert.True(start >= 0, "config.js no longer declares checkAllProviders.");
+        var end = js.IndexOf("\n  renderTestMessage:", start, StringComparison.Ordinal);
+        var body = js.Substring(start, end - start);
+
+        Assert.Contains("\"config.check_reachability\"", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("sso/OID/Test/", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("sso/SAML/Test/", body, StringComparison.Ordinal);
+
+        using var catalog = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Localization", "en.json")));
+
+        Assert.True(
+            catalog.RootElement.TryGetProperty("config.check_reachability", out var value),
+            "SSO-Auth/Localization/en.json carries no config.check_reachability entry.");
+        Assert.False(string.IsNullOrWhiteSpace(value.GetString()));
+    }
+
+    // The ids one readiness spec (#1083) calls required, read out of config.js rather than restated. The
+    // spec is a literal object, so its `requiredIds: [...]` array is located from the protocol key above it.
+    private static string[] RequiredIds(string js, string specKey)
+    {
+        var spec = js.IndexOf("    " + specKey, StringComparison.Ordinal);
+        Assert.True(spec >= 0, "config.js no longer declares a readiness spec for " + specKey);
+        var start = js.IndexOf("requiredIds: [", spec, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The " + specKey + " readiness spec no longer declares requiredIds.");
+        var end = js.IndexOf(']', start);
+
+        return js.Substring(start, end - start)
+            .Split('"')
+            .Where((_, index) => index % 2 == 1)
+            .ToArray();
+    }
+}

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -83,6 +83,12 @@ public partial class ArchitectureConformanceTests
         // writes nothing. It answers with NAMES the elevation-gated Config/Export already lists in full,
         // so repeating it discloses nothing that route does not, and it takes no caller-supplied id.
         "Config/Managed",
+        // Elevated read-only aggregate configuration check (#1084): it evaluates the configuration already
+        // in memory against the same rules the save path uses, makes NO outbound request of its own, writes
+        // nothing and takes no caller-supplied id. Its whole design point is that it does not fan out to the
+        // provider Test routes - those are throttled, share one bucket, and a fan-out would empty it - so
+        // throttling this one would guard a surface that spends nothing.
+        "Config/Check",
         // Elevated read-only counter exposition (#1139): in-memory tallies rendered to text, no outbound
         // fetch and no write. Exempt for a reason the neighbours above do not have - a scraper is SUPPOSED to
         // poll this route, every fifteen seconds forever, so a throttle here would break the one caller it

--- a/SSO-Auth.Tests/Config/ProviderCheckTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderCheckTests.cs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The aggregate configuration check (#1084) against the three things its acceptance asks of it: it names
+/// exactly the provider that would fail and why, it answers an empty configuration as a report rather than
+/// as an error, and it changes nothing while doing either.
+/// </summary>
+/// <remarks>
+/// These run against <see cref="ProviderCheck"/> directly rather than through a browser, which is where the
+/// button lives. That is deliberate: the evaluation was put on the server precisely so it could be executed
+/// by a test, and the alternative shape - reading each provider's readiness out of the settings page's own
+/// DOM - is unreachable from any suite here and would have left every clause below unproven.
+/// </remarks>
+public class ProviderCheckTests
+{
+    private static PluginConfiguration TwoProviders()
+    {
+        var config = new PluginConfiguration();
+        config.OidConfigs["complete"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-1",
+        };
+        config.OidConfigs["half-filled"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+        };
+        return config;
+    }
+
+    private static ProviderCheckResult Row(ProviderCheckDocument report, string provider)
+        => Assert.Single(report.Providers, r => r.Provider == provider);
+
+    [Fact]
+    public void OneCompleteAndOneIncompleteProvider_NamesExactlyTheIncompleteOneAndTheReason()
+    {
+        // The first acceptance clause. "Exactly" is the load-bearing word: a check that flagged the complete
+        // provider too would be as useless as one that flagged neither, because an administrator learns to
+        // ignore a list that is always half red.
+        var report = ProviderCheck.Build(TwoProviders());
+
+        Assert.Equal(new[] { "complete", "half-filled" }, report.Providers.Select(r => r.Provider));
+        Assert.True(Row(report, "complete").Ready);
+
+        var incomplete = Row(report, "half-filled");
+        Assert.False(incomplete.Ready);
+        Assert.Equal(new[] { "OidClientId" }, incomplete.MissingFields);
+        Assert.Null(incomplete.Problem);
+    }
+
+    [Fact]
+    public void NoProvidersConfigured_ReportsAnEmptyList_RatherThanFailing()
+    {
+        // The second clause, and the state of every fresh installation. An exception here would make the
+        // action look broken on the one page an administrator opens before they have configured anything.
+        var report = ProviderCheck.Build(new PluginConfiguration());
+
+        Assert.Empty(report.Providers);
+    }
+
+    [Fact]
+    public void RunningTheCheck_LeavesEveryProviderFieldUnchanged()
+    {
+        // The third clause, at the only layer that can hold it: the check is a pure read, so nothing it does
+        // could reach a stored value. Pinning it here means a later version that "repaired" a provider while
+        // reporting on it - the obvious next feature - reddens instead of quietly editing configuration from
+        // a button labelled Check. Compared through the export document because that is the whole
+        // configuration rendered as bytes, so a change to any provider field shows up rather than only the
+        // ones a hand-written assertion thought to name.
+        var config = TwoProviders();
+        config.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = false,
+            SamlEndpoint = "https://adfs.example.invalid/sso",
+            SamlClientId = "sp-1",
+            SamlCertificate = "not-a-certificate",
+        };
+        var before = JsonSerializer.Serialize(ConfigExport.Build(config));
+
+        ProviderCheck.Build(config);
+
+        Assert.Equal(before, JsonSerializer.Serialize(ConfigExport.Build(config)));
+    }
+
+    [Fact]
+    public void AnInvalidValue_IsReportedWithTheMessageTheSavePathWouldRefuseItWith()
+    {
+        // The reason text is TAKEN from the save gate rather than composed here, so the report and the
+        // rejected save cannot say different things about one provider. Pinned against the gate's own output
+        // rather than against a literal, so a reworded refusal moves both together.
+        var config = new PluginConfiguration();
+        config.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            BaseUrlOverride = "not-a-url",
+        };
+
+        var expected = Assert.Throws<ArgumentException>(
+            () => ProviderConfigValidator.ValidateBaseUrlOverride("OpenID", "kc", "not-a-url"));
+
+        var row = Row(ProviderCheck.Build(config), "kc");
+        Assert.False(row.Ready);
+
+        // Byte-identical, tail and all. Trimming the message here - the "(Parameter 'baseUrlOverride')" the
+        // runtime appends is the obvious candidate - would make the check and the refused save say different
+        // things about one provider, which is the disagreement this report exists to prevent.
+        Assert.Equal(expected.Message, row.Problem);
+    }
+
+    [Fact]
+    public void ADisabledButCompleteProvider_IsReportedAsReady_AndAsSwitchedOff()
+    {
+        // A provider an administrator turned off is not misconfigured. Reporting it as needing attention
+        // would put a permanent false alarm on every deployment that keeps a provider parked, which is the
+        // fastest way to make the whole list unread. The state is still REPORTED, so the page can say it.
+        var config = new PluginConfiguration();
+        config.SamlConfigs["parked"] = new SamlConfig
+        {
+            Enabled = false,
+            SamlEndpoint = "https://adfs.example.invalid/sso",
+            SamlClientId = "sp-1",
+            SamlCertificate = SamlTestFactory.Create().CertificateBase64,
+        };
+
+        var row = Row(ProviderCheck.Build(config), "parked");
+
+        Assert.True(row.Ready);
+        Assert.False(row.Enabled);
+    }
+
+    [Fact]
+    public void ASamlProviderMissingItsCertificate_NamesTheCertificate_NotTheEndpoint()
+    {
+        // The SAML required set is its own; a check that reported the OpenID one against a SAML provider
+        // would name fields that provider does not have.
+        var config = new PluginConfiguration();
+        config.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlEndpoint = "https://adfs.example.invalid/sso",
+            SamlClientId = "sp-1",
+        };
+
+        var row = Row(ProviderCheck.Build(config), "adfs");
+
+        Assert.False(row.Ready);
+        Assert.Equal(new[] { "SamlCertificate" }, row.MissingFields);
+    }
+
+    [Fact]
+    public void AProviderNamingAnUndefinedProfile_IsReported_AndItsNeighbourIsNot()
+    {
+        // The check asks the whole-config validator about a snapshot holding ONE provider, which is what lets
+        // a per-provider rule be reported per provider at all. Widen that snapshot to the whole configuration
+        // and every provider inherits its neighbour's refusal, so the second assertion here is the one that
+        // fails if the isolation is lost.
+        var config = new PluginConfiguration();
+        config.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            ProvisioningProfile = "no-such-profile",
+        };
+        config.OidConfigs["clean"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-2",
+        };
+
+        var report = ProviderCheck.Build(config);
+
+        Assert.False(Row(report, "kc").Ready);
+        Assert.Contains("no-such-profile", Row(report, "kc").Problem!, StringComparison.Ordinal);
+        Assert.True(Row(report, "clean").Ready);
+    }
+
+    [Fact]
+    public void EveryDeclaredRequiredField_ResolvesToAStringSettingOnItsProviderType()
+    {
+        // The required-field lists are read by reflection, so a name that resolves to nothing would throw at
+        // the moment an administrator pressed the button - the one place a report about broken configuration
+        // must not itself break. Misspell a name and this reddens instead.
+        foreach (var field in ProviderCheck.OidRequiredFields)
+        {
+            var property = typeof(OidConfig).GetProperty(field);
+            Assert.True(property is not null, "OidConfig declares no '" + field + "' property.");
+            Assert.Equal(typeof(string), property!.PropertyType);
+        }
+
+        foreach (var field in ProviderCheck.SamlRequiredFields)
+        {
+            var property = typeof(SamlConfig).GetProperty(field);
+            Assert.True(property is not null, "SamlConfig declares no '" + field + "' property.");
+            Assert.Equal(typeof(string), property!.PropertyType);
+        }
+    }
+}

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -44,6 +44,10 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         "OidRedirectUri",
         "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
         "ExportConfig", "ImportConfig", "ManagedProviders", "Unregister", "ExportLinks", "ExportUserLinks",
+        // The aggregate configuration check (#1084): read-only, and elevation-gated because it names every
+        // configured provider and what is wrong with it, which is an inventory an unauthenticated caller has
+        // no business reading.
+        "CheckProviders",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",
         // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for

--- a/SSO-Auth.Tests/Http/SSOControllerProviderCheckTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerProviderCheckTests.cs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of <c>GET sso/Config/Check</c> (#1084) through <see cref="SsoControllerHarness"/>, so
+/// the report the settings page consumes is read off the real store rather than a stand-in. What is pinned
+/// here is the contract a browser depends on: the route answers over the live configuration, both protocols
+/// appear in one list, and no field value rides along with the verdict.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerProviderCheckTests
+{
+    private static ProviderCheckDocument Reported(SsoControllerHarness harness) =>
+        Assert.IsType<ProviderCheckDocument>(Assert.IsType<OkObjectResult>(harness.Controller.CheckProviders().Result).Value);
+
+    [Fact]
+    public void TheRoute_AnswersOverBothProtocols_InOneList()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+                OidClientId = "client-1",
+            };
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                SamlEndpoint = "https://adfs.example.invalid/sso",
+                SamlClientId = "sp-1",
+            };
+        });
+
+        var reported = Reported(harness);
+
+        Assert.Equal(new[] { "keycloak", "adfs" }, reported.Providers.Select(r => r.Provider));
+        Assert.Equal(new[] { "OpenID", "SAML" }, reported.Providers.Select(r => r.Protocol));
+        Assert.True(reported.Providers.Single(r => r.Provider == "keycloak").Ready);
+        Assert.False(reported.Providers.Single(r => r.Provider == "adfs").Ready);
+    }
+
+    [Fact]
+    public void AnInstallationWithNoProviders_GetsAnEmptyReport_NotAnError()
+    {
+        var harness = new SsoControllerHarness(_ => { });
+
+        Assert.Empty(Reported(harness).Providers);
+    }
+
+    [Fact]
+    public void TheSerializedReport_CarriesNoProviderSecretOrEndpointValue()
+    {
+        // The report exists to describe a provider, not to reveal it. A row carries the provider's name,
+        // which of its required settings are EMPTY by property name, and the refusal the save path would
+        // give - none of which is a stored value. A secret arriving here would be a disclosure through the
+        // one route on this page an administrator is most likely to run and then paste into a bug report.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.invalid/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            OidSecret = "PLAINTEXT-OIDC-SECRET",
+        });
+
+        var json = JsonSerializer.Serialize(Reported(harness));
+
+        Assert.Contains("keycloak", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("PLAINTEXT-OIDC-SECRET", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("client-1", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("idp.example.invalid", json, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1424,6 +1424,28 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Answers, for every configured OpenID and SAML provider at once, whether a login against it would get
+    /// past the configuration and why not (#1084) - the aggregate "Configuration check" the redesigned
+    /// settings page dropped. Requires administrator privileges, like the other config endpoints. Read-only:
+    /// it evaluates the configuration already in memory and writes nothing, so running it leaves every
+    /// provider's stored values byte-identical.
+    /// </summary>
+    /// <remarks>
+    /// ADVISORY, and it makes no outbound request. Whether an identity provider ANSWERS is what the
+    /// per-provider Test routes are for; probing them all from here would spend one shared throttle budget
+    /// (both pass <see cref="SsoRateLimitClass.Test"/>) and the 429s that followed would name working
+    /// providers as broken. So the report says what it checked and leaves reachability to the consumer to
+    /// disclose as unchecked.
+    /// </remarks>
+    /// <returns>One row per configured provider; an empty list where none is configured.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Config/Check")]
+    public ActionResult<ProviderCheckDocument> CheckProviders()
+    {
+        return Ok(SSOPlugin.Instance.ReadConfiguration(ProviderCheck.Build));
+    }
+
+    /// <summary>
     /// Publishes the auth-path counters as Prometheus text exposition (#1139), so an operator can alert on a
     /// rate of failed logins, provisioning or provider-fetch errors instead of grepping the Jellyfin log.
     /// Requires administrator privileges. Read-only - it changes nothing.

--- a/SSO-Auth/Config/ProviderCheck.cs
+++ b/SSO-Auth/Config/ProviderCheck.cs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Answers, for every configured provider at once, whether a login against it would get past the
+/// configuration (#1084). Restores the aggregate "Configuration check" the redesigned settings page dropped,
+/// and does it on the server so the answer is the same one the save path would give.
+/// </summary>
+/// <remarks>
+/// <para>
+/// REUSES THE SAVE GATE RATHER THAN RESTATING IT. The invalid-value half of a row is
+/// <see cref="ProviderConfigValidator.Validate"/> run over a snapshot holding that one provider, so a rule
+/// added to the save path is reported here on the same commit and a rule this file does not know about is
+/// still caught. Nothing here re-implements a predicate.
+/// </para>
+/// <para>
+/// One message per provider, because that is all the save gate produces: it refuses on the first invalid
+/// rule it meets. A row saying "and three more" would be claiming a completeness the refusal does not have.
+/// </para>
+/// <para>
+/// THE PROFILE SET IS CONFIGURATION-WIDE AND IS REPORTED ON EVERY PROVIDER. The snapshot carries the real
+/// <see cref="PluginConfiguration.ProvisioningProfiles"/>, both because a provider naming a profile is only
+/// valid if that profile exists, and because a broken profile set refuses every provider's save until it is
+/// fixed. Reporting it once per provider is that state stated rather than softened.
+/// </para>
+/// <para>
+/// The empty-required-field half is not the save gate's, because the save gate does not have one: a
+/// half-filled provider persists fine and fails at login instead. That is exactly the failure this check
+/// exists to surface before a user meets it.
+/// </para>
+/// </remarks>
+internal static class ProviderCheck
+{
+    /// <summary>
+    /// The OpenID settings without which a login cannot start, by property name. Each name is ALSO the id
+    /// the settings page gives that field, which is what lets the page resolve a reported name to its own
+    /// localized label; <c>ArchitectureConformanceTests</c> pins both halves of that agreement.
+    /// </summary>
+    internal static readonly string[] OidRequiredFields = { "OidEndpoint", "OidClientId" };
+
+    /// <summary>
+    /// The SAML settings without which a login cannot start or its response be verified. The settings page
+    /// prefixes each of these ids with <c>saml-</c>; that prefix is the page's, not the property's.
+    /// </summary>
+    internal static readonly string[] SamlRequiredFields = { "SamlEndpoint", "SamlClientId", "SamlCertificate" };
+
+    /// <summary>
+    /// Builds the aggregate report over a configuration snapshot.
+    /// </summary>
+    /// <param name="config">The configuration to evaluate; never modified.</param>
+    /// <returns>One row per configured provider, OpenID first, in configuration order.</returns>
+    internal static ProviderCheckDocument Build(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var rows = new List<ProviderCheckResult>();
+
+        foreach (var kvp in config.OidConfigs ?? new SerializableDictionary<string, OidConfig>())
+        {
+            rows.Add(Row("OpenID", kvp.Key, kvp.Value, OidRequiredFields, Snapshot(config, oid: kvp)));
+        }
+
+        foreach (var kvp in config.SamlConfigs ?? new SerializableDictionary<string, SamlConfig>())
+        {
+            rows.Add(Row("SAML", kvp.Key, kvp.Value, SamlRequiredFields, Snapshot(config, saml: kvp)));
+        }
+
+        return new ProviderCheckDocument { Providers = rows };
+    }
+
+    // A configuration carrying exactly one provider plus the shared profile set, so the whole-config
+    // validator can be asked about that provider alone. It is passed as its own `live` argument on purpose:
+    // that makes every provider here an EXISTING one, which is what it is, so the new-name rule stays off a
+    // name the identity provider already has registered - the same exemption a real save gets.
+    private static PluginConfiguration Snapshot(
+        PluginConfiguration config,
+        KeyValuePair<string, OidConfig>? oid = null,
+        KeyValuePair<string, SamlConfig>? saml = null)
+    {
+        var snapshot = new PluginConfiguration { ProvisioningProfiles = config.ProvisioningProfiles };
+        if (oid is { } o)
+        {
+            snapshot.OidConfigs[o.Key] = o.Value;
+        }
+
+        if (saml is { } s)
+        {
+            snapshot.SamlConfigs[s.Key] = s.Value;
+        }
+
+        return snapshot;
+    }
+
+    private static ProviderCheckResult Row(
+        string protocol,
+        string provider,
+        ProviderConfigBase? config,
+        string[] requiredFields,
+        PluginConfiguration snapshot)
+    {
+        var missing = config is null
+            ? requiredFields.ToList()
+            : requiredFields.Where(field => string.IsNullOrWhiteSpace(Read(config, field))).ToList();
+        var problem = Refusal(snapshot);
+
+        return new ProviderCheckResult
+        {
+            Protocol = protocol,
+            Provider = provider,
+            Enabled = config?.Enabled == true,
+            MissingFields = missing,
+            Problem = problem,
+            Ready = missing.Count == 0 && problem is null,
+        };
+    }
+
+    // The value of a required setting, read by the name the list above declares. Reflection rather than a
+    // switch: the declared names are what the page resolves to labels and what the conformance test compares
+    // against the form, so a name nobody reads through would be free to be wrong. A name that resolves to no
+    // string property throws here rather than silently reporting the field as filled in - fail closed, and
+    // pinned by a test so the throw is never met at runtime.
+    private static string? Read(ProviderConfigBase config, string field)
+    {
+        var property = config.GetType().GetProperty(field, BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{config.GetType().Name} declares no '{field}' property.");
+        return property.PropertyType == typeof(string)
+            ? property.GetValue(config) as string
+            : throw new InvalidOperationException($"{config.GetType().Name}.{field} is not a string setting.");
+    }
+
+    // What the save path would say about this provider, or null where it would say nothing.
+    //
+    // The message is taken WHOLE and unedited, tail included. ArgumentException.Message appends
+    // "(Parameter 'x')" wherever a parameter name was given, which is not pretty in front of an
+    // administrator - and the admin write paths already answer a refused save with exactly that string
+    // (SSOController's BadRequest(ex.Message) arms). Tidying it here would make the check and the save
+    // disagree about one provider in the one respect this report exists to get right, so the tidying, if it
+    // is wanted, belongs at the message rather than at one of its two readers.
+    private static string? Refusal(PluginConfiguration snapshot)
+    {
+        try
+        {
+            ProviderConfigValidator.Validate(snapshot, snapshot);
+            return null;
+        }
+        catch (ArgumentException ex)
+        {
+            return ex.Message;
+        }
+    }
+}

--- a/SSO-Auth/Config/ProviderCheckDocument.cs
+++ b/SSO-Auth/Config/ProviderCheckDocument.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// What one aggregate configuration check answers (#1084): every configured OpenID and SAML provider, and
+/// for each of them whether a login against it would fail today and why.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ADVISORY ONLY. Building this report reads the configuration and writes nothing: no provider field, no
+/// toggle, no persisted byte. Nothing here blocks a save, and an administrator who disagrees with a row can
+/// save the provider anyway - the save path keeps its own fail-closed refusal, which is where a bad value is
+/// actually stopped.
+/// </para>
+/// <para>
+/// NO FIELD VALUE ON THE WIRE. A row carries the provider's name, which of its REQUIRED settings are empty
+/// by property name, and the refusal message the save path itself would produce. The refusal messages are
+/// the admin-facing ones <see cref="ProviderConfigValidator"/> already shows on a rejected save, so nothing
+/// reaches this report that an administrator does not already read on the settings page, and no secret is
+/// among them.
+/// </para>
+/// <para>
+/// REACHABILITY IS NOT PART OF THIS ANSWER, and the consumer must say so rather than leaving it out. Probing
+/// every provider from here would spend one shared throttle budget - both Test routes pass
+/// <c>SsoRateLimitClass.Test</c>, so a fan-out over many providers empties the bucket and the 429s that
+/// follow would name working providers as broken, worst on exactly the installations with the most providers
+/// to check. So a row says whether the configuration is complete and valid; whether the identity provider
+/// answers is what the per-provider Test Connection is for.
+/// </para>
+/// </remarks>
+public class ProviderCheckDocument
+{
+    /// <summary>
+    /// Gets one row per configured provider, OpenID first and SAML after it, each in the order the
+    /// configuration holds them. An installation with no provider configured gets an empty list, which is a
+    /// report rather than an error.
+    /// </summary>
+    public IReadOnlyList<ProviderCheckResult> Providers { get; init; } = new List<ProviderCheckResult>();
+}
+
+/// <summary>
+/// One provider's row in <see cref="ProviderCheckDocument"/>.
+/// </summary>
+public class ProviderCheckResult
+{
+    /// <summary>
+    /// Gets the protocol label, "OpenID" or "SAML", spelled as
+    /// <see cref="ProviderConfigValidator"/> spells it in the refusal messages so a row and its reason
+    /// cannot disagree about which provider they are describing.
+    /// </summary>
+    public string Protocol { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the provider name, keyed as it is in <see cref="PluginConfiguration.OidConfigs"/> or
+    /// <see cref="PluginConfiguration.SamlConfigs"/> so a consumer can match a row to a card without a
+    /// second lookup.
+    /// </summary>
+    public string Provider { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether a login against this provider would get past the configuration:
+    /// every required setting filled in, and nothing the save path would refuse.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately independent of <see cref="Enabled"/>. A provider an administrator turned off is not
+    /// misconfigured, and reporting it as needing attention would train them to ignore the report.
+    /// </remarks>
+    public bool Ready { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the provider is switched on and therefore offered at the login page.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the required settings that are empty, by PROPERTY name - which is also the id the settings page
+    /// gives that field, so a consumer resolves each one to the form's own localized label instead of
+    /// carrying a second copy of every label to drift against.
+    /// </summary>
+    public IReadOnlyList<string> MissingFields { get; init; } = new List<string>();
+
+    /// <summary>
+    /// Gets the message the save path would refuse this provider with, or null where it would refuse
+    /// nothing. One message rather than a list: the save is refused on the first invalid rule found, so a
+    /// second one here would claim a completeness the refusal itself does not have.
+    /// </summary>
+    public string? Problem { get; init; }
+}

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -115,5 +115,13 @@
   "config.first_run_saml_step_2": "Check the SAML endpoint, the client id and the IdP signing certificate the import filled in.",
   "config.first_run_saml_step_3": "Copy the reply URL and the metadata URL this page computes and register them at your provider.",
   "config.first_run_saml_step_4": "Run Test Connection to check the certificate and the endpoint before anyone tries to log in.",
-  "config.first_run_saml_step_5": "Save. The provider joins the SAML providers list above, and its button appears on the sign-in page."
+  "config.first_run_saml_step_5": "Save. The provider joins the SAML providers list above, and its button appears on the sign-in page.",
+  "config.check_lead": "Checks every configured OpenID and SAML provider against the same rules a save is refused by, and lists the ones a login would fail on. It changes nothing and never blocks a save. Whether an identity provider answers is not part of this check: use Test Connection in a provider's own editor for that.",
+  "config.check_all_providers": "Check all providers",
+  "config.check_running": "Checking every configured provider…",
+  "config.check_none": "No provider is configured yet, so there is nothing to check.",
+  "config.check_ready_detail": "Nothing in this provider's configuration would refuse a login.",
+  "config.check_disabled": "It is switched off, so no button for it appears on the sign-in page.",
+  "config.check_reachability": "Reachability was not checked. Use Test Connection in a provider's own editor to see whether it answers.",
+  "config.check_failed": "Could not run the check. Make sure you are signed in as an administrator, then try again."
 }

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -1593,6 +1593,143 @@ const ssoConfigurationPage = {
           }),
     );
   },
+  // ---- Aggregate configuration check (#1084) ----
+  // ONE action over every configured provider, answered by the server at `sso/Config/Check`. The evaluation
+  // is NOT the per-provider panel above: that one reads the form in front of the administrator, and there is
+  // exactly one form, so it can only ever answer about the provider currently loaded. Loading each provider
+  // into the editor in turn to read the panel would end with the last one loaded, which this issue's own
+  // acceptance forbids - a run must leave every provider's form values and toggles byte-identical. So the
+  // aggregate is asked of the configuration rather than of the DOM.
+  //
+  // What IS reused is the naming: a missing setting is reported by the id the form gives that field, and the
+  // label is read off the form through readinessFieldName, so the check speaks the page's language and a
+  // relabelled field cannot drift against it.
+  //
+  // ADVISORY. This writes into its own list and nowhere else: no provider field, no toggle, no request that
+  // changes anything. A failure leaves the page exactly as it was.
+  renderCheckRow: (list, ok, label, detail) => {
+    const item = document.createElement("li");
+    item.classList.add("fieldDescription");
+    const state = ok
+      ? tr("config.readiness_ready", "Ready")
+      : tr("config.readiness_attention", "Needs attention");
+    // textContent: a provider name and a server refusal message both reach this line, and neither may
+    // arrive as markup (#221).
+    item.textContent = state + " - " + label + " - " + detail;
+    list.appendChild(item);
+  },
+  renderCheckNote: (list, message) => {
+    const item = document.createElement("li");
+    item.classList.add("fieldDescription");
+    item.textContent = message;
+    list.appendChild(item);
+  },
+  // One row's detail sentence, in the order an administrator acts on it: what is empty, then what the save
+  // path would refuse, then whether the provider is switched on at all. A provider an administrator turned
+  // off is NOT reported as needing attention - it is a deliberate state, and flagging it would train them to
+  // ignore the list - so the sentence says so and the row's own verdict is left alone.
+  checkRowDetail: (page, row) => {
+    const parts = [];
+    const missing = Array.isArray(row.MissingFields) ? row.MissingFields : [];
+    if (missing.length > 0) {
+      const prefix = row.Protocol === "SAML" ? "saml-" : "";
+      parts.push(
+        tr("config.readiness_required_missing", "Still empty: {fields}", {
+          fields: missing
+            .map((field) =>
+              ssoConfigurationPage.readinessFieldName(page, prefix + field),
+            )
+            .join(", "),
+        }),
+      );
+    }
+
+    if (row.Problem) {
+      parts.push(String(row.Problem));
+    }
+
+    if (parts.length === 0) {
+      parts.push(
+        tr(
+          "config.check_ready_detail",
+          "Nothing in this provider's configuration would refuse a login.",
+        ),
+      );
+    }
+
+    if (!row.Enabled) {
+      parts.push(
+        tr(
+          "config.check_disabled",
+          "It is switched off, so no button for it appears on the sign-in page.",
+        ),
+      );
+    }
+
+    return parts.join(" ");
+  },
+  checkAllProviders: (page) => {
+    const list = page.querySelector("#sso-config-check-result");
+    if (!list) {
+      return Promise.resolve();
+    }
+
+    list.replaceChildren();
+    ssoConfigurationPage.renderCheckNote(
+      list,
+      tr("config.check_running", "Checking every configured provider…"),
+    );
+
+    return ApiClient.getJSON(ApiClient.getUrl("sso/Config/Check")).then(
+      (report) => {
+        const rows =
+          report && Array.isArray(report.Providers) ? report.Providers : [];
+        list.replaceChildren();
+
+        if (rows.length === 0) {
+          ssoConfigurationPage.renderCheckNote(
+            list,
+            tr(
+              "config.check_none",
+              "No provider is configured yet, so there is nothing to check.",
+            ),
+          );
+          return;
+        }
+
+        rows.forEach((row) => {
+          ssoConfigurationPage.renderCheckRow(
+            list,
+            row.Ready === true,
+            String(row.Protocol || "") + " " + String(row.Provider || ""),
+            ssoConfigurationPage.checkRowDetail(page, row),
+          );
+        });
+
+        // Stated on every run rather than left out. The check makes no request to any identity provider, so
+        // a list with no "needs attention" row does not mean every provider answers - and an administrator
+        // reading silence as reachability is the one wrong conclusion this action could produce.
+        ssoConfigurationPage.renderCheckNote(
+          list,
+          tr(
+            "config.check_reachability",
+            "Reachability was not checked. Use Test Connection in a provider's own editor to see whether it answers.",
+          ),
+        );
+      },
+      // Generic and input-independent, like the neighbouring admin actions: it never reflects a server value.
+      () => {
+        list.replaceChildren();
+        ssoConfigurationPage.renderCheckNote(
+          list,
+          tr(
+            "config.check_failed",
+            "Could not run the check. Make sure you are signed in as an administrator, then try again.",
+          ),
+        );
+      },
+    );
+  },
   renderTestMessage: (container, message) => {
     container.replaceChildren();
     const line = document.createElement("p");
@@ -2932,6 +3069,13 @@ export default function initSsoConfigurationPage(view) {
 
   view.querySelector("#SaveSingleLogout").addEventListener("click", (e) => {
     ssoConfigurationPage.saveSingleLogout(view);
+    e.preventDefault();
+    return false;
+  });
+
+  // The aggregate configuration check (#1084). Read-only: it fetches a report and paints its own list.
+  view.querySelector("#CheckAllProviders").addEventListener("click", (e) => {
+    ssoConfigurationPage.checkAllProviders(view);
     e.preventDefault();
     return false;
   });

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -399,6 +399,55 @@
           </form>
 
           <!--
+            Configuration check (#1084): ONE action across every configured OpenID and SAML provider,
+            restoring the aggregate check the #365 redesign dropped. It sits above both workspaces because it
+            answers about both; the per-provider readiness panel (#1083) inside each editor answers about the
+            form in front of you, and the two do not overlap.
+
+            ADVISORY. The button is outside both provider forms and carries no sso-* marker class, so it is
+            not a provider field and the save contract does not see it. The handler reads a report and writes
+            into the list below; it assigns no field and no toggle, which is what keeps a run from changing
+            what a subsequent Save would persist. Every row is rendered with textContent and states its
+            outcome in words rather than in colour alone (#221).
+          -->
+          <form id="sso-config-check" class="esqConfigurationForm">
+            <div
+              class="verticalSection"
+              is="emby-collapse"
+              title="Configuration check"
+            >
+              <div class="collapseContent">
+                <div class="fieldDescription" data-i18n="config.check_lead">
+                  Checks every configured OpenID and SAML provider against the
+                  same rules a save is refused by, and lists the ones a login
+                  would fail on. It changes nothing and never blocks a save.
+                  Whether an identity provider answers is not part of this
+                  check: use Test Connection in a provider's own editor for
+                  that.
+                </div>
+
+                <button
+                  id="CheckAllProviders"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span data-i18n="config.check_all_providers"
+                    >Check all providers</span
+                  >
+                </button>
+
+                <ul
+                  class="sso-readiness-list"
+                  id="sso-config-check-result"
+                  role="status"
+                  aria-live="polite"
+                ></ul>
+              </div>
+            </div>
+          </form>
+
+          <!--
             Provider workspace (#365 UI redesign). The provider LIST replaces the old select -> Load flow:
             each saved OpenID provider is a card (name + type badge + enabled/disabled pill); clicking a card
             loads it into the editor below. The hidden <select id="selectProvider"> is retained as the state


### PR DESCRIPTION
# What & why

An administrator with six providers had to open six forms to find the one that
would refuse a login: the settings page can report on the provider currently in
the editor and on nothing else. This restores the aggregate "Configuration
check" the #365 redesign dropped, as one section above both provider lists that
answers for every configured OpenID and SAML provider at once - ready or not,
and why not.

Closes #1084

## The route this took, and why

The issue's Scope says the action reuses the per-provider readiness evaluation
from #1083 rather than duplicating it, and that evaluation cannot be reused as
worded: every entry point it shipped takes the page and reads the DOM of
whichever provider is loaded.

```
$ git show origin/main:SSO-Auth/Web/config.js | grep -nE "readiness[A-Za-z]*: \("
1420:  readinessFieldName: (page, id) => {
1446:  readinessFieldStates: (page, spec) => {
1461:  readinessActiveToggles: (page, key) => {
```

Two routes were open: lift those rules off the DOM into a function taking a
provider object, or answer on the server behind a new aggregate route over
`ProviderConfigValidator`, which the Scope names as the alternative. This takes
the server route, for three reasons rather than a preference:

1. **The third acceptance clause decides it.** Running the action must leave
   every provider's form values and toggles byte-identical. There is one editor,
   so any route that evaluates a provider by loading it ends with the last one
   loaded.
2. **It reaches the population the action is about.** The DOM can only answer
   about providers somebody has opened; the point of "check all" is the ones
   nobody has.
3. **It puts the judgement where a test can execute it.** None of this page runs
   in a browser in CI. A browser-only version would have left all three Done-when
   clauses unproven; on the server they are three executed tests.

What IS reused is the naming half: a missing setting is reported by the id the
form gives that field, and the label is read off the form through
`readinessFieldName`, so the report speaks the page's language and a relabelled
field cannot drift against it.

## The means check

The means is C# on the existing plugin assembly plus the page's own vanilla JS,
adding no language, runtime or dependency the tree does not already carry. It
fits the standpoint on the point that decided the route above: in this means the
claims the action makes are refusable by the suites that already exist - the
evaluator is executed by unit tests, and the parts that live between the server
and the browser are pinned by `ArchitectureConformanceTests` rules that were each
proven to bite. The rejected means (the same feature written entirely in the
page) is the one in which none of that is testable here.

## Two rows the aggregate deliberately does not produce

- **Reachability.** The check makes no outbound request, and every run says so.
  Probing every provider would come out of the one throttle budget both Test
  routes share (`SsoRateLimitClass.Test`, keyed `test:<client>`), so a fan-out
  empties the bucket and the 429s that follow name working providers as broken -
  worst on exactly the installations with the most providers to check. The
  disclosure is pinned by a rule so it cannot quietly be dropped.
- **Field warnings.** The panel's warning row reads the inline validation boxes,
  which exist per form and carry a message only after a validator has run against
  typed input. A stored provider has no such box, so there is nothing honest to
  report and nothing is claimed.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

This touches none of the four. It adds one elevation-gated **read** route that
evaluates the configuration already in memory, and a page handler that renders
what it answers. Nothing on the login path, no crypto, and nothing persists.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. **Untouched** - no validation decision
      moved, and the save gate this reads through is called, not changed.
- [x] No secrets logged; secrets are redacted on config export. The report
      carries provider names, empty-field names and the save path's own refusal
      messages; a test asserts on the SERIALIZED form that no secret, no client
      id and no endpoint value reaches it.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **Not run**, and the box
      stays unticked: no lens looked at this change. The classification above is
      mine, and a reader who disagrees with it should read the route before
      trusting the rest of this section.
- [ ] Review record: per lens, its verdict and its findings. **None** - see
      above. No lens ran, so there are no CONFIRMED or PLAUSIBLE counts to
      report, and this line is not a zero-findings result.
- [x] Log inputs from the IdP are sanitized inline at the log call. **Not
      applicable, and nothing was added**: this change writes no log line.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The invalid-value judgement is `ProviderConfigValidator.Validate`
      called over a one-provider snapshot rather than a second copy of any
      predicate, so a rule added to the save path is reported here on the same
      commit.
- [x] The change adds no more code than the problem requires. The one thing that
      is not the save gate is the empty-required-field check, because the save
      gate has none: a half-filled provider persists fine and fails at login,
      which is the failure this action exists to surface first.
- [x] The code is self-documenting and matches the target architecture. The new
      types sit in `Config/` beside the validator and the managed-set document
      they are shaped after; the controller action is four lines.
- [x] Architecture-conformance tests pass, and the new structural properties are
      locked in as rules: the route string on both sides, every report member the
      page reads, the button and result-list ids against the markup, every
      reportable required field against the form, the agreement between the
      server's required set and #1083's panel, the handler writing no field or
      toggle, and the reachability disclosure.
- [ ] Docs impact considered. This adds an admin-page surface the wiki's
      configuration page describes, so a `documentation` issue is filed rather
      than the wiki being edited here - see Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Built on both target
      frameworks, 0 warnings:
      `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror`
      and the same for `net10.0`.
- [x] `dotnet test` is green. Full suite on both frameworks:
      net9.0 `Total: 3428, Failed: 0, Skipped: 4`, net10.0
      `Total: 3429, Failed: 0, Skipped: 4`. The four skips are the ones the suite
      already skips on this host - they bind a listener off loopback, which needs
      an administrator (#1227). They were not worked around.
- [x] Prettier is clean for the `.js` / `.html` / `.md` change. Checked against
      the bytes git stores (this checkout is CRLF, which the local run trips on
      for files this change does not touch as well).

## How the guards were checked

Each was deleted or broken and the suite watched.

- Dropping a required field from the server list reddens both the agreement with
  #1083's panel and the "names exactly the incomplete one" case.
- Renaming the route, misspelling a report member in the page, renaming the
  result list in the markup, renaming a form field id, and removing the
  reachability sentence each redden exactly the rule that covers them.
- Widening the one-provider snapshot to the whole configuration makes a provider
  inherit its neighbour's refusal, and reddens the isolation case.
- Making the evaluator "repair" a provider while reporting on it - the obvious
  next feature - reddens the no-mutation case.

One of these first appeared not to bite and did: the member-name break was made
with a `sed` without `/g`, so one of the two occurrences on the line survived.
Replacing both reddens it.

## Notes

- **Not verified in a browser.** Nothing here was opened in Jellyfin. The
  server half is executed by tests; the page half is judged by source rules,
  which can tell that the button, the ids, the route and the member names agree
  with the server, and cannot tell what the section looks like or that the list
  renders. That is the residual and it is not softened by the rules above.
- **A documentation issue follows**, for the wiki's configuration page: the new
  section, what it does and does not check, and why reachability is separate.
  Filed as #1436.
- **Out of scope, deliberately:** no fan-out of live probes (the throttle
  measurement above), no provider-card badge in the lists (only the section
  reports), and no repair action - the check reports and never edits.