### PR TITLE
Cite names instead of line numbers in the migration runbook

### DIFF
--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -11,30 +11,46 @@ somebody calling the endpoints from a tool. The refusal rules of the link
 restore live on that page and are not repeated here; this page carries the
 order and the omissions, and links there for everything else.
 
+Each claim below cites a file and a **name** inside it, a route template, a
+method, a constant, or the literal string the plugin returns, so a reader can
+check the claim by grepping for that name rather than trusting the sentence.
+
+The names are cited instead of line numbers on purpose, which is the answer
+[Account-management API](ACCOUNT-MANAGEMENT-API.md) took on #1424 and this page
+takes on #1429. This page carried line numbers for one day after it landed, and
+four of them already pointed at unrelated code: a citation that names the wrong
+line is worse than none, because it teaches the reader to stop checking. A name
+moves with the code it names; a number does not. So there is no number on this
+page meant to be exact, because there are none, and a citation that stops
+resolving is a defect worth reporting.
+
 **Not walked end to end yet.** Everything below is read out of the source files
-cited beside each claim, at the commit this page landed on. The procedure has
-not been followed against a scratch server rebuild, and the failure messages are
-quoted from the code rather than from a run. Issue #1135 stays open for exactly
-that, and until it is closed this page is derived rather than tested.
+cited beside each claim, at the commit this page last changed on. The procedure
+has not been followed against a scratch server rebuild, and the failure messages
+are quoted from the code rather than from a run. Issue #1135 stays open for
+exactly that, and until it is closed this page is derived rather than tested.
 
 ## The two files, and why there are two
 
 A migration needs two downloads, not one, and neither is a substitute for the
 other.
 
-| File          | Endpoint                                                             | What it is                                                                    |
-| ------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Configuration | `GET /sso/Config/Export` (`SSO-Auth/Api/Http/SSOController.cs:1396`) | Every provider's settings, redacted: no secret and no link map                |
-| Account links | `GET /sso/Config/Links/Export` (`SSOController.cs:1470`)             | One entry per account link, keyed by Jellyfin username rather than by user id |
+| File          | Endpoint                                                                          | What it is                                                                    |
+| ------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Configuration | `GET /sso/Config/Export` (`ExportConfig` in `SSO-Auth/Api/Http/SSOController.cs`) | Every provider's settings, redacted: no secret and no link map                |
+| Account links | `GET /sso/Config/Links/Export` (`ExportLinks`, same file)                         | One entry per account link, keyed by Jellyfin username rather than by user id |
 
 Both are also reachable from the plugin's settings page, from the two blocks of
-the transfer section (`SSO-Auth/Web/configPage.html:185` for the configuration
-pair, `:239` for the account-link pair).
+the transfer section in `SSO-Auth/Web/configPage.html`: the
+`Export / Import Configuration` block inside the `sso-config-transfer` form for
+the configuration pair, and the `Export / Import Account Links` block
+(`config.link_transfer_title`) for the account-link pair.
 
 The split is deliberate. The configuration export drops the canonical-link maps
-under `[JsonIgnore]` (`SSO-Auth/Config/PluginConfiguration.cs:526`, `:747`) and
-is documented as carrying no link map, so an administrator has to ask for the
-link document separately rather than receiving identity data as a side effect of
+under `[JsonIgnore]` - the attribute sits on `CanonicalLinks` and on
+`CanonicalLinkIssuers` in `SSO-Auth/Config/PluginConfiguration.cs` - and is
+documented as carrying no link map, so an administrator has to ask for the link
+document separately rather than receiving identity data as a side effect of
 exporting provider settings (`SSO-Auth/Config/LinkExportDocument.cs`, the
 remarks on the class).
 
@@ -43,7 +59,7 @@ identity provider's subject identifier for each of them. It is not redacted, it
 cannot be, and it should be stored and transported the way any other file naming
 your users is. It is also not the per-subject export a single user would ask
 for; the per-account read is `GET /sso/Links/Export/{jellyfinUserId}`
-(`SSOController.cs:1523`), described under
+(`ExportUserLinks`), described under
 [Export one account's links](ACCOUNT-MANAGEMENT-API.md#export-one-accounts-links).
 
 ## The order
@@ -53,52 +69,60 @@ rules of the link restore decide that order rather than a convention doing it.
 
 1. **Bring the Jellyfin accounts back under the same usernames.** The link
    import resolves each entry's username against the user database and refuses
-   the whole document when an account it names does not exist
-   (`SSO-Auth/Config/LinkImport.cs:132`). It never creates an account, so a
-   backup file cannot bring a principal into existence.
+   the whole document when an account it names does not exist, as
+   `no Jellyfin account is named ... on this instance` from
+   `LinkImport.Resolve` (`SSO-Auth/Config/LinkImport.cs`). It never creates an
+   account, so a backup file cannot bring a principal into existence.
 2. **Import the configuration export** (`POST /sso/Config/Import`,
-   `SSOController.cs:1560`). This is a merge, not a replace: a provider that
-   exists only on the target is left alone, and a provider new to the target is
-   added with an empty link map and a blank secret
-   (`SSO-Auth/Config/ConfigImport.cs:98`).
+   `ImportConfig`). This is a merge, not a replace: a provider that exists only
+   on the target is left alone, and a provider new to the target is added with
+   an empty link map and a blank secret (`ConfigImport.MergeProviders`,
+   `SSO-Auth/Config/ConfigImport.cs`).
 3. **Re-enter every provider secret and save.** The export carries none, so a
    provider that arrived from it has a blank one and fails its logins closed
    until an administrator supplies it. On a provider the target already held, a
    blank incoming secret keeps the stored one rather than wiping it
-   (`ConfigImport.cs:18`).
+   (`ServerManagedFields.Preserve`, called from `ConfigImport.MergeProviders`
+   and stated in the summary on `ConfigImport`).
 4. **Import the account links last** (`POST /sso/Config/Links/Import`,
-   `SSOController.cs:1674`). The import refuses a protocol and provider pair
-   this instance does not hold (`LinkImport.cs:111`), which is why it cannot run
-   before step 2.
+   `ImportLinks`). The import refuses a protocol and provider pair this instance
+   does not hold, as
+   `no provider of that name is configured for that protocol on this instance`
+   from `LinkImport.TryResolveProvider`, which is why it cannot run before
+   step 2.
 
 No step half-applies. Both imports resolve the whole document before they write
-anything, and a single unrestorable entry throws with every refusal collected
-(`LinkImport.cs:83-84` and `:174-182`; `ConfigImport.cs:80` and `:91-92`). The
-controller runs each inside `MutateConfiguration`, which persists nothing when
-the mutation throws (`SSOController.cs:1596`, `:1714`), so a step run too early
-leaves the instance exactly as it was and is simply re-run once the step before
-it is done.
+anything, and a single unrestorable entry throws with every refusal collected:
+`LinkImport.Resolve` fills a `refusals` list and throws
+`The link import was rejected and nothing was restored.` before
+`LinkImport.Write` runs, and `ConfigImport.Apply` puts the whole incoming set
+through `ProviderConfigValidator.Validate` before it reaches `MergeProviders`.
+The controller runs each inside `MutateConfiguration`, which persists nothing
+when the mutation throws - the remarks on `ImportConfig` and `ImportLinks` say
+so - so a step run too early leaves the instance exactly as it was and is simply
+re-run once the step before it is done.
 
 Re-running the link import after a partial migration is safe: re-importing a
-mapping this instance already holds is not a repoint and succeeds
-(`LinkImport.cs:147`).
+mapping this instance already holds is not a repoint and succeeds, because the
+refusal in `LinkImport.Resolve` fires only when the stored link resolves to a
+different account.
 
 ## What is deliberately never restored
 
 Each of these survives neither file, and each omission is a decision with a
 reason rather than a gap.
 
-| Not restored                                                                            | Where the decision is                       | Why                                                                                                                                                         |
-| --------------------------------------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Provider secrets and SAML signing keys                                                  | `ConfigExport.cs`, the summary on the class | Withheld at the JSON boundary by `WriteOnlySecretConverter`, so the document carries no plaintext secret and no `ssoenc:` envelope                          |
-| The at-rest data key `sso-secret.key`                                                   | `SSO-Auth/SSOPlugin.cs:66`                  | It lives in its own file beside the configuration and is never part of the configuration object at all                                                      |
-| Rate-limit tuning (`EnableRateLimit`, `RateLimitMaxAttempts`, `RateLimitWindowSeconds`) | `ConfigImport.cs:85-90`                     | Instance-local operational tuning, and a scalar has no blank-means-keep signal, so importing it would let a partial document silently disable a DoS control |
-| The SSO-only globals (`DisablePasswordLogin`, `BreakGlassAdminUsername`)                | `ConfigImport.cs:63-73`                     | Validated fail-closed on import but never applied; the mode is turned on through its own elevated, audited endpoints, which also run the per-user sweep     |
-| `SsoOnlyRepointedUserIds`                                                               | `PluginConfiguration.cs:127`                | Bookkeeping about accounts this instance took a password door away from; it describes this user database, not the next one                                  |
-| `LogoutSessions`                                                                        | `PluginConfiguration.cs:147`                | Per-session single-logout state written at login and removed at logout; nothing on a rebuilt server has a session to log out                                |
-| `CanonicalLinkDeadlines`                                                                | `PluginConfiguration.cs:557`                | The role-mapped access deadlines are not fields of the link backup document (`LinkExportDocument.cs`), so a time-limited link comes back without its expiry |
-| `CanonicalLinkLastLogins`                                                               | `SSO-Auth/Config/LinkExport.cs:111-116`     | A login instant is an observation, not restorable state: writing it back would assert a login that never happened on the new server                         |
-| A provider's `NewPath`                                                                  | `ConfigImport.cs:131`                       | Runtime state recording which redirect-path spelling the last challenge used; meaningless across instances, so the target keeps its own                     |
+| Not restored                                                                            | Where the decision is                                                 | Why                                                                                                                                                         |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Provider secrets and SAML signing keys                                                  | `ConfigExport.cs`, the summary on the class                           | Withheld at the JSON boundary by `WriteOnlySecretConverter`, so the document carries no plaintext secret and no `ssoenc:` envelope                          |
+| The at-rest data key `sso-secret.key`                                                   | `SSOPlugin`, where the `SecretStore` over `sso-secret.key` is built   | It lives in its own file beside the configuration and is never part of the configuration object at all                                                      |
+| Rate-limit tuning (`EnableRateLimit`, `RateLimitMaxAttempts`, `RateLimitWindowSeconds`) | `ConfigImport.Apply`, the comment on the `MergeProviders` step        | Instance-local operational tuning, and a scalar has no blank-means-keep signal, so importing it would let a partial document silently disable a DoS control |
+| The SSO-only globals (`DisablePasswordLogin`, `BreakGlassAdminUsername`)                | `ConfigImport.Apply`, the `SsoOnlyLoginGuard.AssertCanActivate` guard | Validated fail-closed on import but never applied; the mode is turned on through its own elevated, audited endpoints, which also run the per-user sweep     |
+| `SsoOnlyRepointedUserIds`                                                               | `PluginConfiguration.SsoOnlyRepointedUserIds`                         | Bookkeeping about accounts this instance took a password door away from; it describes this user database, not the next one                                  |
+| `LogoutSessions`                                                                        | `PluginConfiguration.LogoutSessions`                                  | Per-session single-logout state written at login and removed at logout; nothing on a rebuilt server has a session to log out                                |
+| `CanonicalLinkDeadlines`                                                                | `PluginConfiguration.CanonicalLinkDeadlines`                          | The role-mapped access deadlines are not fields of the link backup document (`LinkExportDocument.cs`), so a time-limited link comes back without its expiry |
+| `CanonicalLinkLastLogins`                                                               | `LinkExport.Build`, the comment on the entry it writes                | A login instant is an observation, not restorable state: writing it back would assert a login that never happened on the new server                         |
+| A provider's `NewPath`                                                                  | `ConfigImport.MergeProviders`                                         | Runtime state recording which redirect-path spelling the last challenge used; meaningless across instances, so the target keeps its own                     |
 
 Two of those are worth planning around rather than only knowing about.
 **Re-enter the secrets** as step 3, or every provider that arrived from the file
@@ -107,9 +131,10 @@ one**, so a deployment using role-mapped access durations has to check those
 accounts after the restore instead of assuming the expiry travelled.
 
 One thing is dropped at export rather than at import: a link pointing at a
-Jellyfin account that no longer exists is left out of the document entirely
-(`LinkExport.cs:103-109`), so a dangling link does not travel and the restore
-cannot differ from the file it claims to apply.
+Jellyfin account that no longer exists is left out of the document entirely -
+`LinkExport.Build` skips a row whose user id resolves to no username - so a
+dangling link does not travel and the restore cannot differ from the file it
+claims to apply.
 
 ## The failure modes an operator actually hits
 
@@ -120,24 +145,29 @@ refusal table, with a code line beside each row, is
 these are the three a migration runs into.
 
 - **A renamed user.** The entry names a username no account on this instance
-  holds (`LinkImport.cs:132`). Rename the account back, or change that entry's
-  `Username` field to the new name before importing. The canonical name is the
-  identity; the username is only how the document finds the account.
+  holds: `no Jellyfin account is named ... on this instance`. Rename the account
+  back, or change that entry's `Username` field to the new name before
+  importing. The canonical name is the identity; the username is only how the
+  document finds the account.
 - **A provider missing on the target.** The entry names a protocol and provider
-  pair this instance does not hold (`LinkImport.cs:111`). Either step 2 was
-  skipped, or the provider's name differs: provider names are matched exactly
-  and ordinally, while the protocol is matched case-insensitively
-  (`LinkImport.cs:212-245`).
+  pair this instance does not hold:
+  `no provider of that name is configured for that protocol on this instance`.
+  Either step 2 was skipped, or the provider's name differs: provider names are
+  matched exactly and ordinally, while the protocol is matched
+  case-insensitively (`LinkImport.TryResolveProvider` and
+  `LinkImport.TryGetConfig`).
 - **An existing conflicting link.** This instance already links that canonical
-  name to a different account (`LinkImport.cs:149`), or already binds that link
-  to a different OpenID issuer (`:166`). Both refusals exist so a backup file
-  cannot silently remap an identity-provider subject onto another account.
-  Unlink the existing link first, then re-import.
+  name to a different account -
+  `this instance already links that identity to a different account; unlink it first` -
+  or already binds that link to a different OpenID issuer -
+  `this instance already binds that link to a different issuer; unlink it first`.
+  Both refusals exist so a backup file cannot silently remap an
+  identity-provider subject onto another account. Unlink the existing link
+  first, then re-import.
 
 An import that succeeds is audited with the total and the per-provider counts,
-and with no canonical name in the line
-(`SSO-Auth/Api/Audit/SsoAudit.cs:306`). Those counts are what say whether what
-came back matches the file that was applied.
+and with no canonical name in the line (`SsoAudit.LinksImported`). Those counts
+are what say whether what came back matches the file that was applied.
 
 ## Rolling back
 


### PR DESCRIPTION
# What & why

`docs/SERVER-MIGRATION.md` cited source line numbers on 28 of its lines. One day
after the page landed, four of them already resolved to unrelated code, which is
what #1429 measured. I re-read every citation at `2df7d8d` before choosing
between the two answers that issue named, and the drift is wider than the four:
every citation into `SSO-Auth/Api/Http/SSOController.cs` except the first has
moved since the issue was written, because that file has kept growing.

```
$ git show 2df7d8d:SSO-Auth/Api/Http/SSOController.cs | sed -n '1396p;1470p;1523p;1560p;1596p;1674p;1714p'
    [HttpGet("Config/Export")]
    [Produces(MediaTypeNames.Text.Plain)]
        // cannot tear against a concurrent login writing a link.
        }
        // would be told it succeeded and would have no way to see which providers did not arrive. Refusing
    /// Restores an account-link backup (<c>Config/Links/Export</c>) onto this instance (#1129), rebinding
            return BadRequest("The link import document is missing or is not valid JSON.");
$ git grep -nE '\[Http(Get|Post)\("(Config/Links/Export|Links/Export/\{jellyfinUserId\}|Config/Import|Config/Links/Import)"\)\]' 2df7d8d -- SSO-Auth/Api/Http/SSOController.cs
2df7d8d:SSO-Auth/Api/Http/SSOController.cs:1492:    [HttpGet("Config/Links/Export")]
2df7d8d:SSO-Auth/Api/Http/SSOController.cs:1545:    [HttpGet("Links/Export/{jellyfinUserId}")]
2df7d8d:SSO-Auth/Api/Http/SSOController.cs:1582:    [HttpPost("Config/Import")]
2df7d8d:SSO-Auth/Api/Http/SSOController.cs:1696:    [HttpPost("Config/Links/Import")]
```

Only `:1396` still lands on what the page says it lands on. So the page was
losing citations faster than the four the issue counted, and re-pointing the
numbers would reset the clock on a class that measurably runs down in a day.

This takes the answer #1424 took on `docs/ACCOUNT-MANAGEMENT-API.md` instead:
every citation now names a route template, a method, a field, or the literal
refusal string the plugin returns, and the page says in its own opening which of
the two answers it took and why. The failure-mode section gains the refusal text
an operator actually sees, which is both the anchor and the thing that makes
that section usable at the moment it is read.

Closes #1429

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, and the boxes are left unticked rather than ticked as passed:
the diff is one Markdown file and touches no login path, no crypto, no config
persistence and no release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No second reader.** Nothing in this change was read by anybody other than its
author before it was opened. What stands in place of one is the anchor
verification below: every name the page now cites was re-extracted from the tree
at the commit this lands on, and no claim on the page rests on a number any more.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The architecture line is ticked as unaffected rather than as run: no `.cs` file
is in the diff, so no structural property moves and no new rule is owed. The
docs line is the change itself. The page's own links are unchanged, and the two
places that point at it keep pointing at the same path:

```
$ git grep -ril 'server.migration' HEAD -- docs/ README.md
HEAD:README.md
HEAD:docs/ACCOUNT-MANAGEMENT-API.md
HEAD:docs/README.md
HEAD:docs/SERVER-MIGRATION.md
$ git diff --name-only origin/main...HEAD
docs/SERVER-MIGRATION.md
```

## Verification

Every anchor the page now names, re-extracted at the head this pull request
carries. The counts are of the names in the file the page cites them in, so a
zero anywhere would be a citation that does not resolve:

```
$ git grep -cE 'ExportConfig|ExportLinks|ExportUserLinks|ImportConfig|ImportLinks|MutateConfiguration' HEAD -- SSO-Auth/Api/Http/SSOController.cs
HEAD:SSO-Auth/Api/Http/SSOController.cs:24
$ git grep -cE 'sso-config-transfer|Export / Import Configuration|Export / Import Account Links|config\.link_transfer_title' HEAD -- SSO-Auth/Web/configPage.html
HEAD:SSO-Auth/Web/configPage.html:4
$ git grep -cE 'CanonicalLinks|CanonicalLinkIssuers|CanonicalLinkDeadlines|SsoOnlyRepointedUserIds|LogoutSessions' HEAD -- SSO-Auth/Config/PluginConfiguration.cs
HEAD:SSO-Auth/Config/PluginConfiguration.cs:20
$ git grep -cE 'Resolve|Write|TryResolveProvider|TryGetConfig|refusals' HEAD -- SSO-Auth/Config/LinkImport.cs
HEAD:SSO-Auth/Config/LinkImport.cs:26
$ git grep -cE 'ProviderConfigValidator\.Validate|SsoOnlyLoginGuard\.AssertCanActivate|ServerManagedFields\.Preserve|MergeProviders|NewPath' HEAD -- SSO-Auth/Config/ConfigImport.cs
HEAD:SSO-Auth/Config/ConfigImport.cs:10
$ git grep -c -F 'new SecretStore(Path.Combine(DataFolderPath, "sso-secret.key"))' HEAD -- SSO-Auth/SSOPlugin.cs
HEAD:SSO-Auth/SSOPlugin.cs:1
$ git grep -c -w 'LinksImported' HEAD -- SSO-Auth/Api/Audit/SsoAudit.cs
HEAD:SSO-Auth/Api/Audit/SsoAudit.cs:1
$ git grep -c -w 'WriteOnlySecretConverter' HEAD -- SSO-Auth/Config/ConfigExport.cs
HEAD:SSO-Auth/Config/ConfigExport.cs:1
$ git grep -c -w 'Build' HEAD -- SSO-Auth/Config/LinkExport.cs
HEAD:SSO-Auth/Config/LinkExport.cs:1
```

The five refusal strings the failure-mode section now quotes, each read back out
of the file that produces it:

```
$ for s in "no Jellyfin account is named" \
           "no provider of that name is configured for that protocol on this instance" \
           "The link import was rejected and nothing was restored." \
           "this instance already links that identity to a different account; unlink it first" \
           "this instance already binds that link to a different issuer; unlink it first"; do
    printf '%s  %s\n' "$(git grep -c -F "$s" HEAD -- SSO-Auth/Config/LinkImport.cs | sed 's/.*://')" "$s"
  done
1  no Jellyfin account is named
1  no provider of that name is configured for that protocol on this instance
1  The link import was rejected and nothing was restored.
1  this instance already links that identity to a different account; unlink it first
1  this instance already binds that link to a different issuer; unlink it first
```

And the defect class is gone from the page, leaving one page in the tree that
still carries it:

```
$ git grep -cE '[A-Za-z0-9_/.-]+\.(cs|js|html|json|csproj|yml)(`)?:[0-9]+' HEAD -- docs/SERVER-MIGRATION.md ; echo "exit=$?"
exit=1
$ for f in $(git ls-tree -r HEAD --name-only -- docs | grep '\.md$'); do n=$(git show "HEAD:$f" | grep -cE '[A-Za-z0-9_/.-]+\.(cs|js|html|json|csproj|yml)(`)?:[0-9]+'); [ "$n" -gt 0 ] && echo "$n $f"; done
7 docs/THREAT-MODEL-TRUSTED-HEADER.md
```

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ npx prettier --check docs/SERVER-MIGRATION.md
Checking formatting...
All matched files use Prettier code style!
```

**The build and the test suite were not run for this change.** The diff is one
Markdown file, as `git diff --name-only origin/main...HEAD` shows above, so no
compiled file moves and a local run would prove nothing about the change. The
workflow's own `build` and `dotnet test` on this head are what stand behind
those two boxes, and they are left unticked here rather than ticked off a run
that did not happen.

## Notes

The page's "Not walked end to end yet" disclosure survives this edit and stays
negative: the procedure still has not been run against a scratch server rebuild,
and #1135 stays open for exactly that. One phrase moves, "the commit this page
landed on" to "the commit this page last changed on", because the reading behind
every claim was redone at this commit.

**Correcting this section after the merge.** It said
`docs/THREAT-MODEL-TRUSTED-HEADER.md` still carries seven line citations and is
not audited here, which is what #1429's own "Not covered here" says and what the
last command above appears to show. Both are wrong, and the seven are false
positives of the detector rather than citations. It was found by opening the page
to scope the sweep the sentence asks for: every one of the seven is a line of
`git grep -c` output pasted inside a fenced block, from two commands the page
runs as its evidence.

```
$ git show origin/main:docs/THREAT-MODEL-TRUSTED-HEADER.md | grep -nE '^\$ git grep -c'
38:$ git grep -c 'Headers.AcceptLanguage' origin/main -- SSO-Auth/
49:$ git grep -c 'RemoteIpAddress' origin/main -- SSO-Auth/
$ git show origin/main:docs/THREAT-MODEL-TRUSTED-HEADER.md | awk '/^```/{f=!f;next} !f' | grep -cE '[A-Za-z0-9_/.-]+\.(cs|js|html|json|csproj|yml)(`)?:[0-9]+'
0
```

A `path:count` line and a `path:line` citation are the same shape, so the
detector cannot separate them, and the page has no citation to repair. Read
outside fenced blocks, `docs/` carries none anywhere at
`ca23560911bed31c371e8015b2a00a05980c308d`, so the class this change was about is
gone from the tree rather than one page short of it. The measurement is written
into #1429 as well, so a later sweep does not go looking for seven citations that
are not there.
