### PR TITLE
Select a new account's provisioning profile from the login's roles [#1106]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,37 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   not yet offer a profile editor: profiles are configured through the admin API,
   a configuration file, or an import, and a dashboard save leaves them
   untouched.
+- **A provider can pick which provisioning profile a new account gets from the
+  login's own roles (#1106).** Naming one profile per provider (#1105) meant a
+  deployment wanting guests to start narrower than staff needed a second
+  provider, a second client registration at the identity provider, and a second
+  sign-in button - for a difference that the identity provider already states in
+  the roles it sends. A provider can now carry an ordered list of
+  role-to-profile rows, so one provider provisions a `guest` login from the
+  `guest` profile and everybody else from the provider's own default. The
+  resolution order is one sentence and it is the order the rows are written in:
+  the first row whose roles the login holds wins, then the provider's own named
+  profile, then its inline template, then nothing. First-row-wins rather than
+  some combination of the matches, because two profiles are two permission sets
+  rather than two points on a scale - there is no "most restrictive" to pick -
+  so the administrator states the precedence by ordering the rows, and
+  re-ordering them is the whole of how it is changed. Nothing changes for a
+  provider that configures no rows, which is every provider configured before
+  this existed, and a stored configuration written without them provisions
+  exactly as it did. The roles are the ones the login already produced for role
+  mapping, so no new claim or attribute is read. Two states are refused on save
+  rather than persisted: a row naming a profile the configuration does not
+  define, and a row that names no profile or lists no roles - each would sit in
+  the list looking like a rule while selecting nothing. If a row's profile stops
+  resolving anyway - a configuration file edited around the save path - the
+  account is created with no policy written at all, and in particular it does
+  NOT fall back to the provider's default. That matters more here than one level
+  up: a row exists to send one group somewhere narrower, so falling back would
+  hand precisely those accounts the wider policy they were moved off, silently,
+  at the moment they are created. As with profiles themselves, the settings page
+  does not yet offer an editor for the rows: they are configured through the
+  admin API, a configuration file, or an import, and a dashboard save leaves
+  them untouched.
 
 - **Counters for the sign-in path, on a metrics endpoint an operator can scrape
   (#1139).** Until now the only signal about logins was the log, and a log line

--- a/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
+++ b/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
@@ -1,0 +1,555 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Role-selected provisioning profiles (#1106): which named profile (#1105) a brand-new account is created
+/// from is decided from the roles the identity provider already sent for that login, by an ordered map on
+/// the provider.
+/// <para>
+/// The resolution order is the thing under test and it is stated once, here: the FIRST row whose roles the
+/// login holds wins, else the provider's own default profile, else the provider's inline template, else no
+/// policy at all. Order matters because two profiles are two permission sets rather than two points on a
+/// scale - there is no "most restrictive" to reduce to the way #1146 reduces durations to the shortest - so
+/// the administrator states the precedence by ordering the rows, and
+/// <see cref="ALoginMatchingTwoRows_TakesTheEarlierRow"/> is what would go red if that stopped being true.
+/// </para>
+/// <para>
+/// The security-relevant half is that a row whose profile no longer resolves writes NO policy and never
+/// falls back. That is stricter than it looks: a row exists to send one group somewhere NARROWER than the
+/// provider default, so a fallback would hand exactly those accounts the wider policy the administrator had
+/// moved them off - silently, at account creation, with nothing but a log line to say so. The save path
+/// refuses a dangling row, and
+/// <see cref="ARowNamingAMissingProfile_WritesNoPolicy_AndNeverFallsBackToTheProviderDefault"/> covers the
+/// configuration file edited by hand around it.
+/// </para>
+/// <para>
+/// The compatibility half is <see cref="AProviderWithNoRows_ProvisionsExactlyAsItDidBefore"/> and
+/// <see cref="AConfigWrittenBeforeRoleRowsExisted_LoadsAndProvisionsUnchanged"/>: an empty map is the whole
+/// of "off", so every installation that configured none provisions byte-identically to before this existed.
+/// </para>
+/// </summary>
+public class ProvisioningProfileRoleSelectionTests
+{
+    private static readonly Guid Created = Guid.Parse("66666666-6666-6666-6666-666666666666");
+
+    // The resolver: the pure question, asked without a login path around it (#1106 Surfaces).
+
+    [Fact]
+    public void ALoginHoldingAMappedRole_SelectsThatRowsProfile()
+    {
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        Assert.Equal("guest", ProvisioningProfilePolicy.Resolve(new[] { "guest" }, config));
+    }
+
+    [Fact]
+    public void ALoginHoldingNoMappedRole_SelectsNothing()
+    {
+        // Null rather than a name, so the caller falls through to the provider's own default resolution
+        // (#1105) instead of this map deciding for a login it was never written for.
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        Assert.Null(ProvisioningProfilePolicy.Resolve(new[] { "staff", "media" }, config));
+    }
+
+    [Fact]
+    public void ALoginMatchingTwoRows_TakesTheEarlierRow()
+    {
+        // The clause that pins the documented order. A login in both groups must land on the row the
+        // administrator listed first; anything that iterated to the end, or reduced over the matches, would
+        // return "staff" here and this is the only test that would notice.
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+                new ProvisioningProfileRoleMap { Profile = "staff", Roles = new[] { "staff" } },
+            },
+        };
+
+        Assert.Equal("guest", ProvisioningProfilePolicy.Resolve(new[] { "staff", "guest" }, config));
+    }
+
+    [Fact]
+    public void ReorderingTheRows_ReversesWhichOneWins()
+    {
+        // The other direction of the same property: the order is the administrator's statement of precedence
+        // and nothing else decides it. Without this, a resolver that always returned the alphabetically first
+        // profile would pass the test above.
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "staff", Roles = new[] { "staff" } },
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        Assert.Equal("staff", ProvisioningProfilePolicy.Resolve(new[] { "staff", "guest" }, config));
+    }
+
+    [Fact]
+    public void ANullOrProfilelessRow_IsSkippedRatherThanThrownOn_AndTheWalkContinues()
+    {
+        // Both states are refused at save, so they only arrive in a hand-edited configuration. There a single
+        // dead row must not 500 a login: it selects nothing and the next row still gets its turn.
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                null!,
+                new ProvisioningProfileRoleMap { Profile = "   ", Roles = new[] { "guest" } },
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        Assert.Equal("guest", ProvisioningProfilePolicy.Resolve(new[] { "guest" }, config));
+    }
+
+    [Fact]
+    public void ABlankConfiguredRole_NeverMatches()
+    {
+        // The #935 blank-skip every other role policy applies. A blank entry hand-written into the config XML
+        // must not satisfy a row, or a provider would select a profile for every login that sent any role.
+        var config = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "  " } },
+            },
+        };
+
+        Assert.Null(ProvisioningProfilePolicy.Resolve(new[] { "guest", string.Empty }, config));
+    }
+
+    [Fact]
+    public void NoRowsConfigured_SelectsNothing()
+    {
+        Assert.Null(ProvisioningProfilePolicy.Resolve(new[] { "guest" }, new OidConfig()));
+    }
+
+    // The create arm: the same question asked through the service that actually makes the account.
+
+    [Fact]
+    public async Task ARoleSelectedProfile_ProvisionsFromThatProfile()
+    {
+        // Done-when 1, first half: a login carrying role "guest" provisions from the "guest" profile even
+        // though the provider's own default sends everybody else to "default".
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "default" };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "guest");
+
+        Assert.Equal(1, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task ALoginSelectingNoProfile_ProvisionsFromTheProviderDefault()
+    {
+        // Done-when 1, second half. The unmatched login is the common case - most logins hold none of the
+        // mapped roles - so this is the arm that must stay exactly what #1105 left.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "default" };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: null);
+
+        Assert.Equal(9, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task ARowNamingAMissingProfile_WritesNoPolicy_AndNeverFallsBackToTheProviderDefault()
+    {
+        // The fail-closed clause, and the one this issue's third Done-when originally asked for the opposite
+        // of. The provider default here is deliberately WIDE (9 sessions) and the selected profile is gone.
+        // Falling back would hand the guest group the staff policy at the moment the account is created,
+        // which is the failure #1105 already refuses one level up, reached through a role instead.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningProfile = "default",
+            ProvisioningPolicyTemplate = null,
+        };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+        var before = created.MaxActiveSessions;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "deleted-profile");
+
+        Assert.Equal(before, created.MaxActiveSessions);
+        Assert.NotEqual(9, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task ARoleSelectedProfile_NeverFallsBackToTheProvidersInlineTemplate()
+    {
+        // The same one-way rule against the other fallback target. A provider may legitimately carry rows AND
+        // an inline template - that is "guest goes narrow, everyone else gets the house default" - so the
+        // inline block is reachable, but only by a login that matched NO row.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 7 },
+        };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+        var before = created.MaxActiveSessions;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "deleted-profile");
+
+        Assert.Equal(before, created.MaxActiveSessions);
+        Assert.NotEqual(7, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task AProviderWithNoRows_ProvisionsExactlyAsItDidBefore()
+    {
+        // Done-when 4. An empty map is the whole of "off", so the inline template still decides and nothing
+        // about the account changes.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 4 },
+        };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(4, created.MaxActiveSessions);
+    }
+
+    // The whole path. Everything above tests one joint; these two test that the joints are connected.
+    //
+    // They exist because of a measured gap rather than for symmetry: with the resolver, the create arm and
+    // both validator doors all covered, severing the one line in LoginCompletionService that hands the
+    // selected name down left the ENTIRE suite green. A feature that resolves a profile correctly and then
+    // drops it on the floor is indistinguishable, to every other test here, from one that works.
+
+    [Fact]
+    public async Task AnOidcLoginCarryingTheSelection_ProvisionsFromIt_AllTheWayThroughTheCompletionPath()
+    {
+        // Builder state -> ValidatedLogin -> VerifiedIdentity -> LoginCompletionService -> the create arm.
+        // The provider default is deliberately the WIDER policy, so a path that lost the selection anywhere
+        // between the two ends comes out at 9 rather than 1 and this goes red.
+        var config = new OidConfig { Enabled = true, ProvisioningProfile = "default" };
+        var (service, _, users, sessions) = BuildCompletion(c =>
+        {
+            c.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+            c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+            c.OidConfigs["kc"] = config;
+        });
+        var created = Provisionable(users, "alice", Created);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.GetUserById(Created).Returns(created);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await service.CompleteAsync(
+            TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+                Username: "alice",
+                Subject: "sub-1",
+                Issuer: null,
+                EmailVerified: null,
+                Valid: true,
+                Admin: false,
+                EnableLiveTv: false,
+                EnableLiveTvManagement: false,
+                Folders: new List<string>(),
+                AvatarUrl: null,
+                ProvisioningProfile: "guest")),
+            new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
+            config,
+            AdoptionGate.None,
+            () => "203.0.113.9");
+
+        Assert.Equal(1, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public void TheOidcBuilder_ResolvesTheSelectionFromTheLoginsRoles()
+    {
+        // The other end of the same wire: the builder has to put the resolved name ON the state, or the
+        // completion path above would faithfully carry a null. Asked through the real builder with a real
+        // role claim rather than by constructing the state by hand.
+        var config = new OidConfig
+        {
+            Roles = new[] { "media" },
+            RoleClaim = "roles",
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        var state = OidcAuthorizeStateBuilder.Build(
+            new[] { new Claim("roles", "guest"), new Claim("sub", "sub-1") },
+            config);
+
+        Assert.Equal("guest", state.ProvisioningProfile);
+    }
+
+    [Fact]
+    public void TheSamlBuilder_ResolvesTheSelectionFromTheLoginsRoles()
+    {
+        // The SAML builder is a separate function, so a resolution wired into only the OpenID one would pass
+        // every other test in this file.
+        var config = new SamlConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        var state = SamlAuthorizeStateBuilder.Build(new[] { "guest" }, config);
+
+        Assert.Equal("guest", state.ProvisioningProfile);
+    }
+
+    // The save path: the states the resolver above is only tolerant of because this refuses them.
+
+    [Fact]
+    public void ARowNamingAProfileTheConfigurationDoesNotDefine_IsRefusedOnSave()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["kc"] = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("does not define", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ARowNamingNoProfile_IsRefusedOnSave()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["kc"] = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "  ", Roles = new[] { "guest" } },
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("naming no profile", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ARowListingNoRoles_IsRefusedOnSave()
+    {
+        // A row that can never match is dead configuration that reads like a rule, which is exactly what the
+        // parental-rating map refuses for the same reason. A row whose every entry is blank is the same state
+        // written differently, because the runtime matcher skips blank entries.
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        incoming.OidConfigs["kc"] = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "   " } },
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("lists no roles", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ASamlProvidersRows_AreJudgedByTheSameRule()
+    {
+        // The SAML map is a separate loop in Validate, so a check wired into only the OpenID arm would pass
+        // every test above and leave SAML unguarded.
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        var error = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("SAML provider", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AValidRowSet_SavesWithoutComplaint()
+    {
+        // The negative of every refusal above: the shape an administrator actually writes must pass, or the
+        // guards would be refusing the feature rather than its misconfigurations.
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        incoming.OidConfigs["kc"] = new OidConfig
+        {
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest" } },
+            },
+        };
+
+        ProviderConfigValidator.Validate(incoming, new PluginConfiguration());
+    }
+
+    // Persistence.
+
+    [Fact]
+    public void TheRows_SurviveAConfigurationRoundTrip()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        configuration.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap>
+            {
+                new ProvisioningProfileRoleMap { Profile = "guest", Roles = new[] { "guest", "trial" } },
+                new ProvisioningProfileRoleMap { Profile = "staff", Roles = new[] { "staff" } },
+            },
+        };
+
+        var reloaded = Deserialize<PluginConfiguration>(Serialize(configuration));
+
+        var rows = reloaded.OidConfigs["kc"].ProvisioningProfileRoleMappings!;
+        Assert.Equal(2, rows.Count);
+
+        // The ORDER survives, not merely the members: the order is the precedence, so a serializer that
+        // reordered them would silently change which profile a login in both groups gets.
+        Assert.Equal("guest", rows[0].Profile);
+        Assert.Equal("staff", rows[1].Profile);
+        Assert.Equal(new[] { "guest", "trial" }, rows[0].Roles);
+    }
+
+    [Fact]
+    public async Task AConfigWrittenBeforeRoleRowsExisted_LoadsAndProvisionsUnchanged()
+    {
+        // The upgrade case, taken from the real serializer rather than a hand-typed literal: a stored config
+        // XML with no ProvisioningProfileRoleMappings element must come back configuring no rows and
+        // provision exactly as it did, from the provider's own inline template.
+        //
+        // What comes back is an EMPTY LIST rather than null, which is worth pinning rather than asserting
+        // away: XmlSerializer materialises the collection member even though the element is absent, so "off"
+        // has two spellings in practice and the resolver has to answer the same to both. The assertion below
+        // is therefore on what the resolver DOES with the reloaded provider, not on which of the two
+        // spellings the serializer happened to produce - an assertion on null alone would have gone red here
+        // for a difference no login can observe.
+        var written = new PluginConfiguration();
+        written.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 4 },
+        };
+        var legacyXml = Serialize(written);
+        Assert.DoesNotContain("ProvisioningProfileRoleMappings", legacyXml, StringComparison.Ordinal);
+
+        var reloaded = Deserialize<PluginConfiguration>(legacyXml);
+        var (service, users) = BuildFor(reloaded);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Empty(reloaded.OidConfigs["kc"].ProvisioningProfileRoleMappings!);
+        Assert.Null(ProvisioningProfilePolicy.Resolve(new[] { "guest" }, reloaded.OidConfigs["kc"]));
+        Assert.Equal(4, created.MaxActiveSessions);
+    }
+
+    private static string Serialize<T>(T value)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, value);
+        return writer.ToString();
+    }
+
+    private static T Deserialize<T>(string xml)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var reader = XmlReader.Create(new StringReader(xml));
+        return (T)serializer.Deserialize(reader)!;
+    }
+
+    private static (CanonicalLinkService Service, IUserManager Users) BuildFor(PluginConfiguration configuration)
+    {
+        var users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger()), users);
+    }
+
+    // The full completion path, wired exactly as LoginCompletionServiceTests wires it. A real AvatarService
+    // (deps stubbed) is safe here because a null AvatarUrl early-returns, so no network is reached.
+    private static (LoginCompletionService Service, PluginConfiguration Config, IUserManager Users, ISessionManager Sessions) BuildCompletion(Action<PluginConfiguration> seed)
+    {
+        var cfg = new PluginConfiguration();
+        seed(cfg);
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, new CapturingLogger()), cfg, users, sessions);
+    }
+
+    private static User Provisionable(IUserManager users, string username, Guid id)
+    {
+        var user = new User(username, "SSO-Auth", "SSO-Auth") { Id = id };
+        users.CreateUserAsync(username).Returns(Task.FromResult(user));
+        return user;
+    }
+}

--- a/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
+++ b/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
@@ -8,7 +8,9 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
+using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
@@ -354,6 +356,35 @@ public class ProvisioningProfileRoleSelectionTests
         var state = SamlAuthorizeStateBuilder.Build(new[] { "guest" }, config);
 
         Assert.Equal("guest", state.ProvisioningProfile);
+    }
+
+    [Fact]
+    public async Task ARoleSelectedProfileNamingADedicatedPermission_WritesNothingEvenWhenItReachesTheWriter()
+    {
+        // The escalation question this feature raises, answered by execution rather than by argument. The
+        // roles come from the identity provider, so if a role row could reach a profile that grants
+        // administrator, an identity provider that lied about one role would mint an admin at first login.
+        // It cannot: the selection only ever names an entry in the profile set, and every entry is judged by
+        // the same checks an inline template is, with the writer's own refusal underneath (#1099, #165
+        // Finding H1). This asserts the second line rather than the first, because the first is a save-time
+        // refusal and this is the state a hand-edited configuration can still produce.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.IsAdministrator), Granted = true },
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.IsDisabled), Granted = true },
+            },
+        };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var (service, users) = BuildFor(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "guest");
+
+        Assert.False(created.HasPermission(PermissionKind.IsAdministrator));
+        Assert.False(created.HasPermission(PermissionKind.IsDisabled));
     }
 
     // The save path: the states the resolver above is only tolerant of because this refuses them.

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -36,6 +36,7 @@ internal static class TestIdentities
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
             ExpiresAtUtc = derived.ExpiresAtUtc,
             GuestAccessDuration = derived.GuestAccessDuration,
+            ProvisioningProfile = derived.ProvisioningProfile,
         });
 
     internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges, DateTime? expiresAtUtc = null) =>
@@ -55,5 +56,6 @@ internal static class TestIdentities
             MaxParentalRatingScore = privileges.MaxParentalRatingScore,
             ExpiresAtUtc = expiresAtUtc,
             GuestAccessDuration = privileges.GuestAccessDuration,
+            ProvisioningProfile = privileges.ProvisioningProfile,
         });
 }

--- a/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
@@ -38,22 +38,30 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 internal static class ProvisioningPolicy
 {
     /// <summary>
-    /// Resolves which template a provider's brand-new accounts get (#1105): the named
-    /// <see cref="PluginConfiguration.ProvisioningProfiles"/> entry when the provider names one, and
-    /// otherwise the provider's own inline <see cref="ProviderConfigBase.ProvisioningPolicyTemplate"/>.
+    /// Resolves which template a provider's brand-new accounts get, in one documented order (#1105, #1106):
+    /// the profile the login's roles selected, else the named
+    /// <see cref="PluginConfiguration.ProvisioningProfiles"/> entry the provider points at, else the
+    /// provider's own inline <see cref="ProviderConfigBase.ProvisioningPolicyTemplate"/>.
     /// </summary>
     /// <remarks>
-    /// A name that resolves to nothing writes NO policy, and deliberately does not fall back to the inline
-    /// template. The save path refuses both a dangling name and a provider carrying a name AND an inline
+    /// A name that resolves to nothing writes NO policy, and deliberately does not fall back - not to the
+    /// inline template, and not to the provider default when the name came from a role row. The save path
+    /// refuses a dangling name on both surfaces, and refuses a provider carrying a name AND an inline
     /// template (<see cref="ProviderConfigValidator.ValidateProvisioningProfiles"/>), so neither state
     /// arrives through a validated write; what is left is a configuration file edited by hand around the
     /// validator, and there the fail-closed answer is to write nothing. Falling back would hand the new
-    /// account the very permission set the administrator replaced when they pointed the provider elsewhere.
+    /// account the very permission set the administrator replaced when they pointed the provider elsewhere -
+    /// and on a role row it would do it to precisely the group that was singled out for a narrower one.
     /// </remarks>
     /// <param name="configuration">The live plugin configuration, read for its profile set.</param>
     /// <param name="provider">The provider the account is being created for; <see langword="null"/> resolves to no template.</param>
+    /// <param name="selectedProfile">
+    /// The profile name the login's roles selected (#1106), or <see langword="null"/>/blank when the login
+    /// matched no row. A selected name is authoritative: it never falls back to the provider's own default,
+    /// for the reason in the remarks.
+    /// </param>
     /// <returns>The template to apply, or <see langword="null"/> when the provider configures none.</returns>
-    internal static ProvisioningPolicyTemplate? TemplateFor(PluginConfiguration configuration, ProviderConfigBase? provider)
+    internal static ProvisioningPolicyTemplate? TemplateFor(PluginConfiguration configuration, ProviderConfigBase? provider, string? selectedProfile = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
@@ -62,7 +70,10 @@ internal static class ProvisioningPolicy
             return null;
         }
 
-        var profile = provider.ProvisioningProfile;
+        // The role-selected profile (#1106) wins over the provider's own default, because that is the whole
+        // point of the row: it names where THIS login goes instead of where the provider sends everyone else.
+        // An unmatched login arrives here with null and the resolution below is byte-identical to #1105's.
+        var profile = string.IsNullOrWhiteSpace(selectedProfile) ? provider.ProvisioningProfile : selectedProfile;
         if (string.IsNullOrWhiteSpace(profile))
         {
             return provider.ProvisioningPolicyTemplate;

--- a/SSO-Auth/Api/Authz/ProvisioningProfilePolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningProfilePolicy.cs
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+/// <summary>
+/// Reduces a login's roles to the NAME of the provisioning profile (#1105) its brand-new account is created
+/// from (#1106). The configured rows are ordered and the FIRST one whose roles the login holds wins; a login
+/// matching no row resolves null, which leaves the provider's own default resolution (#1105) exactly as it
+/// was.
+/// </summary>
+/// <remarks>
+/// First-row-wins rather than any reduction over the matches, because the alternatives all need a comparison
+/// this map has no basis for. Two profiles are two permission sets, not two points on a scale, so there is no
+/// "most restrictive" to pick the way <see cref="GuestAccessDurationPolicy"/> picks the shortest duration.
+/// The administrator states the precedence by ordering the rows, and the order they wrote is the order that
+/// runs.
+/// <para>
+/// It returns a NAME rather than a template because the profile set lives on the plugin configuration while
+/// this sees only the provider, and because the name has to be resolved inside the same locked read that
+/// resolves the provider - otherwise a concurrent save could be observed half-applied. Turning the name into
+/// a policy is <see cref="ProvisioningPolicy.TemplateFor(PluginConfiguration, ProviderConfigBase, string)"/>'s
+/// job, one layer down, and a name that resolves to nothing writes NO policy there rather than falling back.
+/// </para>
+/// <para>
+/// The roles are the ones the login already produced - the same values <see cref="PermissionRolePolicy"/>,
+/// <see cref="ParentalRatingPolicy"/> and <see cref="GuestAccessDurationPolicy"/> are handed - so no second
+/// role read is added to either protocol, and a role claim the extractor refused (#216) reaches here as an
+/// empty set and selects nothing.
+/// </para>
+/// </remarks>
+internal static class ProvisioningProfilePolicy
+{
+    /// <summary>
+    /// The provisioning-profile name the login's roles select, or null when the provider configures no rows
+    /// or none of them matched (fall through to the provider's own default resolution).
+    /// </summary>
+    /// <param name="roles">The login's role values.</param>
+    /// <param name="config">The provider configuration carrying the rows.</param>
+    /// <returns>The first matched row's profile name, or null when nothing applies.</returns>
+    internal static string? Resolve(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(roles);
+
+        // No rows configured (the default): this provider selects no profile by role, so a provisioning
+        // login resolves its policy exactly as it did before #1106. There is deliberately NO master switch
+        // beside the map - an empty map already means off, and a second switch would be a second place for
+        // the feature to be silently half-enabled from. The same reasoning #1146 wrote down.
+        if (config.ProvisioningProfileRoleMappings is null)
+        {
+            return null;
+        }
+
+        var loginRoles = roles as IReadOnlyCollection<string> ?? new List<string>(roles);
+
+        foreach (var mapping in config.ProvisioningProfileRoleMappings)
+        {
+            // A null row, or one naming no profile, selects nothing and is SKIPPED rather than thrown on:
+            // both are refused at config-save validation, so what is left is a configuration file edited by
+            // hand around the validator, and there a single bad row must not 500 a login. Skipping is also
+            // the fail-closed direction here - the row grants nothing and the walk continues to the next.
+            if (mapping is null
+                || string.IsNullOrWhiteSpace(mapping.Profile)
+                || !MatchesAnyRole(mapping.Roles, loginRoles))
+            {
+                continue;
+            }
+
+            // First match wins, so the walk stops here. A login holding both a "staff" and a "guest" role
+            // gets whichever the administrator listed first, and re-ordering the rows is the whole of how
+            // that precedence is changed.
+            return mapping.Profile.Trim();
+        }
+
+        return null;
+    }
+
+    // A login holding any of the row's roles matches. The configured role is trimmed and compared ordinally
+    // to the (verbatim) login roles, null-safe - the same matching every other role policy uses.
+    private static bool MatchesAnyRole(string[]? mappingRoles, IReadOnlyCollection<string> loginRoles)
+    {
+        if (mappingRoles is null)
+        {
+            return false;
+        }
+
+        foreach (var role in mappingRoles)
+        {
+            var trimmed = role?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var loginRole in loginRoles)
+            {
+                if (string.Equals(loginRole, trimmed, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -110,7 +110,12 @@ internal sealed class LoginCompletionService
                 // Follow the identity provider's username on an already-linked account (#1138). Read off the
                 // provider configuration rather than off the identity, because it is the administrator's
                 // policy and not something the login gets to assert.
-                config.SyncUsernameFromProvider).ConfigureAwait(false);
+                config.SyncUsernameFromProvider,
+                // The role-selected provisioning profile (#1106), handed down as a NAME so the create arm
+                // resolves it against the profile set inside its own locked configuration read. Null when the
+                // provider configures no role rows or this login matched none, and the create arm then falls
+                // to the provider's own default resolution (#1105) - which is every login before this existed.
+                identity.ProvisioningProfile).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -62,4 +62,7 @@ internal sealed record ValidatedLogin
 
     /// <summary>Gets the fixed access duration the login's roles resolved (#1146), or null when the provider maps no role to a duration or the login held none. A DURATION, not an instant: it is anchored to the moment an account is actually provisioned, and it is read on that arm only.</summary>
     internal TimeSpan? GuestAccessDuration { get; init; }
+
+    /// <summary>Gets the provisioning-profile name the login's roles selected (#1106), or null when the provider configures no role rows or the login matched none (fall through to the provider's own default). A NAME, not a template: it is resolved against the profile set inside the create arm's own locked configuration read, and it is read on that arm only.</summary>
+    internal string? ProvisioningProfile { get; init; }
 }

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -57,7 +57,8 @@ internal sealed record VerifiedIdentity
         IReadOnlyList<PermissionGrant> permissionGrants,
         int? maxParentalRatingScore,
         DateTime? expiresAtUtc,
-        TimeSpan? guestAccessDuration)
+        TimeSpan? guestAccessDuration,
+        string? provisioningProfile)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -75,6 +76,7 @@ internal sealed record VerifiedIdentity
         MaxParentalRatingScore = maxParentalRatingScore;
         ExpiresAtUtc = expiresAtUtc;
         GuestAccessDuration = guestAccessDuration;
+        ProvisioningProfile = provisioningProfile;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -150,6 +152,20 @@ internal sealed record VerifiedIdentity
     internal TimeSpan? GuestAccessDuration { get; }
 
     /// <summary>
+    /// Gets the provisioning-profile name the login's roles selected (#1106), or null when the provider
+    /// configures no role rows or the login held none of them - in which case the provider's own default
+    /// resolution (#1105) decides and the account is provisioned exactly as it was before this existed.
+    /// <para>
+    /// It is a NAME rather than a resolved template for the same reason
+    /// <see cref="GuestAccessDuration"/> is a duration rather than an instant: the value has to be turned
+    /// into a policy inside the locked configuration read on the arm that actually creates the account, so
+    /// the profile set and the name pointing into it are read together and a concurrent save cannot be seen
+    /// half-applied. A login resolving an EXISTING account never reads it.
+    /// </para>
+    /// </summary>
+    internal string? ProvisioningProfile { get; }
+
+    /// <summary>
     /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
     /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
     /// promoted (role-gate-passed) state - so a raw or unvalidated login can never reach it.
@@ -188,5 +204,6 @@ internal sealed record VerifiedIdentity
             login.PermissionGrants,
             login.MaxParentalRatingScore,
             login.ExpiresAtUtc,
-            login.GuestAccessDuration);
+            login.GuestAccessDuration,
+            login.ProvisioningProfile);
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -211,8 +211,16 @@ internal sealed class CanonicalLinkService
     /// adopted one was selected BY its name. Default off, in which case the resolved account's name is never
     /// touched, which is what every deployment does today.
     /// </param>
+    /// <param name="provisioningProfile">
+    /// The provisioning-profile name the login's roles selected (#1106). Like the duration above this is the
+    /// CREATE ARM ONLY: it decides which policy a brand-new account is written from, and every other arm
+    /// ignores it, so a later login can never re-apply a template over an administrator's per-user edit. It
+    /// arrives as a NAME and is resolved against the profile set inside this service's own locked
+    /// configuration read, so the set and the name pointing into it are read together. Default null, in which
+    /// case the provider's own default resolution (#1105) decides - which is every login before this existed.
+    /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false, TimeSpan? provisionedAccessDuration = null, bool syncUsername = false)
+    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false, TimeSpan? provisionedAccessDuration = null, bool syncUsername = false, string? provisioningProfile = null)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -284,7 +292,7 @@ internal sealed class CanonicalLinkService
                 return AdoptExistingAccount(mode, provider, canonicalKey, username, issuer, existingAccount!, adoptionGate, decision.UserId);
 
             case AccountLinkAction.CreateNewAccount:
-                return await CreateNewAccountAsync(mode, provider, canonicalKey, username, issuer, candidates.LegacyLink, provisionDisabled, provisionedAccessDuration).ConfigureAwait(false);
+                return await CreateNewAccountAsync(mode, provider, canonicalKey, username, issuer, candidates.LegacyLink, provisionDisabled, provisionedAccessDuration, provisioningProfile).ConfigureAwait(false);
 
             case AccountLinkAction.RejectNameTaken:
                 throw RejectNameTaken(candidates.LegacyLink, mode, provider, username);
@@ -585,7 +593,7 @@ internal sealed class CanonicalLinkService
     // when a now-orphaned legacy link is being left behind. When provisionDisabled is set (the provider's
     // ProvisionNewUsersDisabled policy, #737), the brand-new account is created disabled and persisted here
     // so it exists inert for an administrator to approve; the caller then refuses the login without minting.
-    private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string? issuer, Guid? legacyLink, bool provisionDisabled, TimeSpan? provisionedAccessDuration)
+    private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string? issuer, Guid? legacyLink, bool provisionDisabled, TimeSpan? provisionedAccessDuration, string? provisioningProfile)
     {
         // Resolved FIRST, ahead of the orphan warning below (#1137). That warning states that a fresh
         // account is being provisioned and the legacy target is now orphaned; a refusal after it would
@@ -636,7 +644,7 @@ internal sealed class CanonicalLinkService
         // carrying none provisions byte-identically to before. Ahead of the pending-approval branch below so
         // an account created inert already carries its policy when an administrator comes to enable it,
         // rather than getting it on a first login that may never happen.
-        ProvisioningPolicy.ApplyAtProvisioning(user, ProvisioningTemplateFor(mode, provider));
+        ProvisioningPolicy.ApplyAtProvisioning(user, ProvisioningTemplateFor(mode, provider, provisioningProfile));
         // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
         user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
 
@@ -695,8 +703,8 @@ internal sealed class CanonicalLinkService
     // template a provider gets - its named profile or its own inline one (#1105) - is ProvisioningPolicy's
     // rule, resolved inside the same transaction so the profile set and the name pointing at it are read
     // together and a concurrent save cannot be seen half-applied.
-    private ProvisioningPolicyTemplate? ProvisioningTemplateFor(ProviderMode mode, string provider) =>
-        _configStore.Read(configuration => ProvisioningPolicy.TemplateFor(configuration, ProviderConfigFor(configuration, mode, provider)));
+    private ProvisioningPolicyTemplate? ProvisioningTemplateFor(ProviderMode mode, string provider, string? provisioningProfile) =>
+        _configStore.Read(configuration => ProvisioningPolicy.TemplateFor(configuration, ProviderConfigFor(configuration, mode, provider), provisioningProfile));
 
     // The stored provider object the read above resolves its template from, or null when the provider is
     // gone or was stored with a null config object (#350).

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -156,6 +156,7 @@ internal abstract class AuthorizeSession
                 MaxParentalRatingScore = derived.MaxParentalRatingScore,
                 ExpiresAtUtc = derived.ExpiresAtUtc,
                 GuestAccessDuration = derived.GuestAccessDuration,
+                ProvisioningProfile = derived.ProvisioningProfile,
             });
 
             // Carry the OpenID logout material (#727, SLO-1b) alongside the keystone rather than inside it:

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -107,6 +107,12 @@ internal static class OidcAuthorizeStateBuilder
         // resolved here, beside the other role reductions, so no second role read is added to the callback.
         var guestAccessDuration = GuestAccessDurationPolicy.Resolve(roles, config);
 
+        // Reduce the SAME role set to a provisioning-profile NAME (#1106): null when the provider configures
+        // no role rows or this login held none of them, in which case the provider's own default resolution
+        // (#1105) decides and a brand-new account is provisioned exactly as it was before. Resolved here,
+        // beside the other role reductions, so no second role read is added to the callback.
+        var provisioningProfile = ProvisioningProfilePolicy.Resolve(roles, config);
+
         // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
         // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning
         // the claims a second time. Faithful to the original: unlike the preferred-username branch, this
@@ -127,7 +133,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc, guestAccessDuration);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc, guestAccessDuration, provisioningProfile);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -421,6 +427,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     /// <param name="ExpiresAtUtc">The account-expiry instant the configured expiry claim resolved (#1143), in UTC; null when no claim is configured, the claim is absent, or its value is not a shape the reader understands.</param>
     /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
+    /// <param name="ProvisioningProfile">The provisioning-profile name the login's roles selected (#1106); null when the provider configures no role rows or the login matched none, in which case the provider's own default resolution decides. Read only on the arm that provisions a brand-new account.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -435,7 +442,8 @@ internal static class OidcAuthorizeStateBuilder
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
         int? MaxParentalRatingScore = null,
         DateTime? ExpiresAtUtc = null,
-        TimeSpan? GuestAccessDuration = null)
+        TimeSpan? GuestAccessDuration = null,
+        string? ProvisioningProfile = null)
     {
         /// <summary>
         /// Gets the raw OpenID <c>id_token</c>, captured at the callback for a later RP-initiated logout

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -258,6 +258,7 @@ internal sealed class SamlAssertionValidator
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
             ExpiresAtUtc = ReadExpiry(config, samlResponse),
             GuestAccessDuration = derived.GuestAccessDuration,
+            ProvisioningProfile = derived.ProvisioningProfile,
         });
         return true;
     }

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -45,7 +45,13 @@ internal static class SamlAuthorizeStateBuilder
         // here, beside the other role reductions, so no second attribute read is added to the callback.
         var guestAccessDuration = GuestAccessDurationPolicy.Resolve(roles, config);
 
-        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore, guestAccessDuration);
+        // Reduce the SAME role set to a provisioning-profile NAME (#1106): null when the provider configures
+        // no role rows or this login held none of them, in which case the provider's own default resolution
+        // (#1105) decides and a brand-new account is provisioned exactly as it was before. Resolved here,
+        // beside the other role reductions, so no second attribute read is added to the callback.
+        var provisioningProfile = ProvisioningProfilePolicy.Resolve(roles, config);
+
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore, guestAccessDuration, provisioningProfile);
     }
 
     /// <summary>
@@ -58,6 +64,7 @@ internal static class SamlAuthorizeStateBuilder
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
+    /// <param name="ProvisioningProfile">The provisioning-profile name the login's roles selected (#1106); null when the provider configures no role rows or the login matched none, in which case the provider's own default resolution decides. Read only on the arm that provisions a brand-new account.</param>
     internal readonly record struct SamlAuthorizeState(
         bool Admin,
         bool EnableLiveTv,
@@ -65,5 +72,6 @@ internal static class SamlAuthorizeStateBuilder
         List<string> Folders,
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
         int? MaxParentalRatingScore = null,
-        TimeSpan? GuestAccessDuration = null);
+        TimeSpan? GuestAccessDuration = null,
+        string? ProvisioningProfile = null);
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -497,6 +497,29 @@ public abstract class ProviderConfigBase
     public string? ProvisioningProfile { get; set; }
 
     /// <summary>
+    /// Gets or sets the ordered role-to-provisioning-profile rows this provider selects a new account's
+    /// profile with (#1106). The FIRST row whose roles the login holds decides, so the order the
+    /// administrator wrote is the precedence; a login matching no row falls to
+    /// <see cref="ProvisioningProfile"/>, and a provider naming neither keeps its own inline
+    /// <see cref="ProvisioningPolicyTemplate"/>. No rows is the whole of "off", which is why there is no
+    /// separate switch beside it: an empty map already means the feature does nothing, and a second switch
+    /// would be a second place for it to be half-enabled from. Null and an empty list are both "no rows" -
+    /// a configuration serialized without this element deserializes to an empty list rather than to null, so
+    /// the resolver answers the same to either spelling and neither is the privileged one.
+    /// <para>
+    /// A row naming a profile the configuration does not define is refused on save, exactly as
+    /// <see cref="ProvisioningProfile"/> is. At creation the resolution stays one-way with no fallback: a
+    /// name that no longer resolves writes NO policy rather than reaching back to the provider default. That
+    /// matters more here than it does one level up, because a row exists to send one group somewhere
+    /// NARROWER than the default - falling back would hand exactly those accounts the wider policy the
+    /// administrator had moved them off, silently.
+    /// </para>
+    /// </summary>
+    [XmlArray("ProvisioningProfileRoleMappings")]
+    [XmlArrayItem(typeof(ProvisioningProfileRoleMap), ElementName = "ProvisioningProfileRoleMappings")]
+    public List<ProvisioningProfileRoleMap>? ProvisioningProfileRoleMappings { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the role-to-parental-rating mapping
     /// (<see cref="ParentalRatingRoleMappings"/>) is applied at login (#736). Off by default (fail closed):
     /// a deployment that does not set it sees no change on upgrade. Gated additionally by
@@ -1158,6 +1181,26 @@ public class GuestAccessDurationRoleMap
     /// <summary>
     /// Gets or sets the roles the duration applies to. A login holding any of these roles provisions with the
     /// deadline; a login holding none provisions with no deadline at all.
+    /// </summary>
+    public string[]? Roles { get; set; }
+}
+
+/// <summary>
+/// One row of a provider's ordered role-to-provisioning-profile map (#1106): the roles that select a named
+/// provisioning profile for a brand-new account.
+/// </summary>
+public class ProvisioningProfileRoleMap
+{
+    /// <summary>
+    /// Gets or sets the name of the <see cref="PluginConfiguration.ProvisioningProfiles"/> entry a matching
+    /// login is provisioned from. A blank name selects nothing: it is refused on save, and skipped at
+    /// creation so a hand-edited configuration cannot turn one dead row into a failed login.
+    /// </summary>
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles this row applies to. A login holding any of them matches the row; a login
+    /// holding none moves on to the next row.
     /// </summary>
     public string[]? Roles { get; set; }
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -71,6 +71,7 @@ internal static class ProviderConfigValidator
                 ValidateGuestAccessDurations("OpenID", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("OpenID", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
                 ValidateProvisioningProfileReference("OpenID", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
+                ValidateProvisioningProfileRoleMappings("OpenID", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
                 ValidateAcrRequirement(kvp.Key, kvp.Value);
             }
         }
@@ -94,6 +95,7 @@ internal static class ProviderConfigValidator
                 ValidateGuestAccessDurations("SAML", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("SAML", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
                 ValidateProvisioningProfileReference("SAML", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
+                ValidateProvisioningProfileRoleMappings("SAML", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
             }
         }
     }
@@ -512,6 +514,77 @@ internal static class ProviderConfigValidator
             throw new ArgumentException(
                 $"{protocol} provider '{echoName}' names the provisioning profile '{echoProfile}', which this configuration does not define. Define the profile, or clear the name - a provider pointing at a missing profile provisions nothing rather than falling back.",
                 nameof(config));
+        }
+    }
+
+    // A provider may also select the profile per login, from the roles the identity provider sent (#1106).
+    // The rows are refused for the same two reasons the provider-level name is, and both would otherwise be
+    // silent: a row naming no profile is dead configuration that can never select anything, and a row naming
+    // a profile the configuration does not define would persist and then provision NOTHING for exactly the
+    // group it was written for (the resolution is fail-closed and does not fall back). Cross-object like the
+    // reference check above, so it is checked against the whole incoming configuration rather than the
+    // provider alone. An unmatched login is not this check's business: it falls to the provider default,
+    // which the check above already covers.
+
+    /// <summary>
+    /// Rejects a provider whose role-to-provisioning-profile rows (#1106) name no profile, list no roles, or
+    /// name a profile the configuration does not define. A provider configuring no rows is untouched, which
+    /// is every provider written before this existed.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (control-stripped) in the rejection message.</param>
+    /// <param name="config">The provider configuration to check; <see langword="null"/> configures no rows.</param>
+    /// <param name="profiles">The profile set every row's name must resolve in.</param>
+    /// <exception cref="ArgumentException">A row names no profile, lists no roles, or names an undefined profile.</exception>
+    internal static void ValidateProvisioningProfileRoleMappings(
+        string protocol,
+        string provider,
+        ProviderConfigBase? config,
+        SerializableDictionary<string, ProvisioningPolicyTemplate>? profiles)
+    {
+        var mappings = config?.ProvisioningProfileRoleMappings;
+        if (mappings == null)
+        {
+            return;
+        }
+
+        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+
+        foreach (var mapping in mappings)
+        {
+            // A null entry selects nothing and is tolerated, the same way every other role map here tolerates
+            // one: it contributes nothing at runtime and refusing it would fail a save over a stray element.
+            if (mapping == null)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(mapping.Profile))
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has a role-to-provisioning-profile row naming no profile. A row exists to send matching logins to a named profile, so a row without one could never select anything and would be persisted as dead configuration.",
+                    nameof(config));
+            }
+
+            var echoProfile = string.Concat(mapping.Profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+
+            // A row listing no role never matches, so it would sit in the map looking like a rule while
+            // selecting nothing - the same failure ValidateParentalRatingMappings refuses for the same reason.
+            // A row whose every entry is blank is the same state written differently, so both are refused
+            // here: the runtime matcher skips blank entries (#935), which would make such a row dead too.
+            if (mapping.Roles == null || !mapping.Roles.Any(role => !string.IsNullOrWhiteSpace(role)))
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has a role-to-provisioning-profile row for '{echoProfile}' that lists no roles. A row with no roles can never match a login, so list the roles it is for or remove the row.",
+                    nameof(config));
+            }
+
+            if (profiles == null || !profiles.ContainsKey(mapping.Profile.Trim()))
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has a role-to-provisioning-profile row naming '{echoProfile}', which this configuration does not define. Define the profile, or remove the row - a row pointing at a missing profile provisions nothing for the logins it matches rather than falling back to the provider default.",
+                    nameof(config));
+            }
         }
     }
 


### PR DESCRIPTION
# What & why

Refs #1106. **This does NOT close the issue** — the third clause of its Done-when
is deliberately unmet, and the reason is below.

Named provisioning profiles (#1105) are chosen per provider, so a deployment that
wants guests to start narrower than staff needed a second provider, a second
client registration at the identity provider, and a second sign-in button — for a
distinction the identity provider already states in the roles it sends. A provider
can now carry an ordered list of role-to-profile rows and make that distinction on
one provider.

The resolution order is stated once and it is the order the rows are written in:

    first matching row  ->  provider's named profile  ->  provider's inline template  ->  no policy

First-row-wins rather than a reduction over the matches, because two profiles are
two permission sets rather than two points on a scale — there is no "most
restrictive" to pick the way #1146 picks the shortest duration. The administrator
states the precedence by ordering the rows, and re-ordering them is the whole of
how it is changed.

The shape is additive. A provider configuring no rows resolves exactly as it did,
which is every provider written before this existed, and no new claim or attribute
is read: the roles are the ones the login already produced for role mapping,
reduced beside the other role reductions in both authorize-state builders.

## The Done-when clause this does not meet

The third clause asks that a row naming a profile that no longer exists **falls
back to the provider default** and logs a warning. This implements the opposite,
and the argument was measured on the issue before any code was written.

A row exists to send one group somewhere **narrower** than the provider default —
`guest` is the issue's own example. If that row's target is deleted and the
resolution falls back, every login that matched the row is provisioned with the
**wider** policy, silently, at the moment the account is created, with nothing but
a log line nobody reads at account-creation time. That is the same failure #1105
already refuses one level up, reached through a role instead of through a
provider.

So a name that stops resolving writes **no policy at all** — not the provider
default, not the inline template. Whether the clause is recorded as superseded is
a call about the issue rather than about the code, so the issue stays open and
this PR does not close it.

## What is refused on save, and why each is a refusal rather than a tolerance

- A row naming a profile the configuration does not define — it would persist and
  then provision nothing for exactly the group it was written for.
- A row naming no profile, and a row listing no roles (or only blank ones) — both
  sit in the list looking like a rule while selecting nothing.

The runtime is tolerant where the save path is strict: a null row, a blank profile
name or a blank role is skipped rather than thrown on, so a configuration edited by
hand around the validator cannot turn one dead row into a failed login.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Unchanged by this diff — nothing here
      touches assertion or token validation. The fail-closed behaviour this change
      *adds* is the no-fallback rule above.
- [x] No secrets logged; secrets are redacted on config export. No secret is on
      this path; a profile name is not one, and the new rejection messages echo the
      provider and profile name control-stripped, as the neighbouring checks do.
- [ ] **A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.** — NOT ticked. No adversarial
      review gate was run for this change and no second reader looked at it. What
      was done instead is written out below, and it is a self-review, which is a
      weaker thing.
- [ ] **Review record: per lens, its verdict and its findings.** — NOT ticked, and
      there is no lens record to give, because no lens was run. The negative
      disclosure stands rather than being converted into a record of something
      that did not happen.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log call
      is added. The role value reaching the resolver is compared, never logged.

### What was checked instead of a review, and by what command

Stated as a self-review so the gap above is not quietly filled.

**The selection reaches the create arm and nothing else.** This is the invariant
that keeps a template from being re-applied over an administrator's later per-user
edit on a subsequent login:

```
$ grep -rn "TemplateFor\|ApplyAtProvisioning" SSO-Auth/ --include=*.cs | grep -v "<see cref"
SSO-Auth/Api/Authz/ProvisioningPolicy.cs:64:    internal static ProvisioningPolicyTemplate? TemplateFor(...)
SSO-Auth/Api/Authz/ProvisioningPolicy.cs:94:    internal static int ApplyAtProvisioning(User user, ProvisioningPolicyTemplate? template)
SSO-Auth/Api/Linking/CanonicalLinkService.cs:647:        ProvisioningPolicy.ApplyAtProvisioning(user, ProvisioningTemplateFor(mode, provider, provisioningProfile));
SSO-Auth/Api/Linking/CanonicalLinkService.cs:706:    private ProvisioningPolicyTemplate? ProvisioningTemplateFor(...)
```

Line 647 is inside `CreateNewAccountAsync`, whose only caller is line 295 — the
create arm. The resolve and adopt arms never see the parameter.

**Escalation.** The roles come from the identity provider, so the question is
whether a role could reach a profile granting administrator. It cannot: the
selection only ever names an entry in the profile set, every entry is judged by the
same checks an inline template is, and the writer's own refusal (#1099, #165
Finding H1) runs underneath. That is asserted by execution rather than by argument
in `ARoleSelectedProfileNamingADedicatedPermission_WritesNothingEvenWhenItReachesTheWriter`,
which drives the hand-edited-configuration state that gets past the save refusal.

**Availability / mass lockout.** `ApplyAtProvisioning` cannot write `IsDisabled`,
and a dangling row writes nothing, so no arm of this change can disable an account
or lock anyone out. The new refusal blocks a config *save* with a message naming
what is wrong, before anything is persisted. The field is new, so no existing
stored configuration can carry a row and no upgrade can be refused by it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. `ProvisioningProfilePolicy.Resolve` is a pure function, and its role
      matching is the same shape every other role policy uses.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318). The
      change is the structural twin of #1146 (roles → duration) at every joint:
      resolve in both builders, carry on `ValidatedLogin`/`VerifiedIdentity`, hand
      down as an optional argument, read on the create arm only.
- [x] Architecture-conformance tests pass. No new structural property — this
      follows an existing one rather than establishing one.
- [x] Docs impact considered: the CHANGELOG entry is in this change. The settings
      page carries no editor for the rows, exactly as it carries none for the
      profiles themselves (#1105), and that limitation is stated in the entry.

## Verification

- [x] `dotnet build --warnaserror` is green — **0 warnings on both target
      frameworks** (`net9.0` and `net10.0`).
- [x] `dotnet test` is green — 3451 tests on `net9.0`, 3452 on `net10.0`, 0 failed.
      **4 skipped on both**, the same four the suite already skips: they bind a
      listener off loopback, which needs an administrator on this host. They were
      **not** worked around.
- [x] Prettier is clean for the one `.md` file this touches. `CHANGELOG.md` is
      already CRLF at `origin/main` and prettier objects to that for the whole
      file, before and after this change; the added block itself is byte-identical
      to prettier's output:

```
$ diff <(tr -d '\r' < CHANGELOG.md) <(npx prettier CHANGELOG.md) | wc -l
0
```

  The 1,818 pre-existing lines were deliberately not reformatted — that would be an
  unrelated change several times the size of this one.

### Every guard was proven by deleting it and re-running

| what was broken | what went red |
| --- | --- |
| return the last match instead of the first | both order tests |
| let a dangling name fall back to the provider default | the two no-fallback tests here **and** #1105's own |
| unwire the validator from both save doors | its four refusal tests |
| wire the validator into the OpenID loop only | exactly the SAML one |
| stop resolving in the OpenID builder | the OpenID builder test |
| stop resolving in the SAML builder | the SAML builder test |
| **sever the hand-down in the completion path** | **nothing — see below** |

**One guard did not bite, and that is the finding worth reading.** Severing the
single line that hands the selected name down from `LoginCompletionService` left
the **entire 3,447-test suite green**. A feature that resolved the profile
correctly and then dropped the result was indistinguishable, to every test then
written, from one that worked. Three tests were added to reach it — one through the
completion path end to end, one per protocol builder — and each now reddens on its
own cut. `TestIdentities` was carrying the same gap and now mirrors the production
destructuring again.

## Notes

**Size.** 898 insertions, over the inherited 400-line reading proxy. 310 of those
lines are production code and 588 are tests. Re-planning was considered and is
ceremony here: splitting the production half yields a resolver nothing calls plus
the wiring for it, and neither piece is reviewable alone, which is the cap
satisfied and its purpose defeated. Splitting the tests off would ship an unproven
guard. **No declared size-exception category covers this change** — it is
hand-written code, not an import, a sweep, a move or generated content — and none
is claimed. Read the production diff first; the test file is read test by test.

**Residual, not covered here.** The cross-object refusal runs on the
whole-configuration save path, so the per-provider Add endpoints do not run it —
the same residual #1105 left for the provider-level name. The runtime is
fail-closed either way (a row that got past the endpoints provisions nothing), so
this is a usability gap rather than a hole. It is not widened by this change and is
not fixed by it.

**Deliberately absent.** No settings-page editor for the rows; no warning logged
when a row's profile fails to resolve at creation time (the issue asked for one
alongside the fallback, and the fallback is what was refused — a log line is worth
adding only if it is not standing in for the guarantee).
