### PR TITLE
Say in the log when a provisioning profile name resolves to nothing [#1106]

### DIFF
--- a/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
+++ b/SSO-Auth.Tests/Config/ProvisioningProfileRoleSelectionTests.cs
@@ -26,6 +26,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Session;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -51,6 +52,14 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// refuses a dangling row, and
 /// <see cref="ARowNamingAMissingProfile_WritesNoPolicy_AndNeverFallsBackToTheProviderDefault"/> covers the
 /// configuration file edited by hand around it.
+/// </para>
+/// <para>
+/// Writing no policy and writing no policy VISIBLY are different outcomes, and only the second one is
+/// recoverable. An account created from a dangling row carries Jellyfin's bare new-user defaults, which is
+/// byte-identical to one created by a provider that configured nothing, so
+/// <see cref="ARowNamingAMissingProfile_SaysSoInTheLog"/> pins the one line that separates the two - and
+/// <see cref="AProfileThatResolves_ProvisionsWithNoWarningAtAll"/> is what would go red if that line started
+/// firing on every provisioning, which is how a real warning gets trained out of an operator.
 /// </para>
 /// <para>
 /// The compatibility half is <see cref="AProviderWithNoRows_ProvisionsExactlyAsItDidBefore"/> and
@@ -228,6 +237,81 @@ public class ProvisioningProfileRoleSelectionTests
 
         Assert.Equal(before, created.MaxActiveSessions);
         Assert.NotEqual(9, created.MaxActiveSessions);
+    }
+
+    [Fact]
+    public async Task ARowNamingAMissingProfile_SaysSoInTheLog()
+    {
+        // The other half of the clause above, and the reason it is a separate test: writing no policy and
+        // writing no policy VISIBLY are the same account. An account created from a dangling row is
+        // byte-identical to one created by a provider that configured nothing at all, so the log line is the
+        // only thing that separates "the administrator wanted nothing" from "the administrator's profile was
+        // renamed and every new guest since has been created with the server's bare defaults".
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["default"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "default" };
+        var (service, users, logger) = BuildWithLogger(configuration);
+        Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "deleted-profile");
+
+        var warning = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("provisioning profile", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("deleted-profile", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("kc", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("role mapping", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AProviderDefaultNamingAMissingProfile_SaysSoInTheLog_AndNamesTheOtherSource()
+    {
+        // The same silence reached through #1105's door rather than #1106's. One line covers both, so the
+        // source has to be IN the line: an administrator repairing this edits a role row in one case and the
+        // provider's own profile field in the other, and a message that named neither would send them to
+        // the wrong form.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningProfile = "renamed-profile" };
+        var (service, users, logger) = BuildWithLogger(configuration);
+        Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: null);
+
+        var warning = Assert.Single(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("provisioning profile", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("renamed-profile", warning.Message, StringComparison.Ordinal);
+        Assert.Contains("provider default", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("role mapping", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AProfileThatResolves_ProvisionsWithNoWarningAtAll()
+    {
+        // The near-miss that costs the most if it is wrong. A condition inverted by one character turns this
+        // line into one every SSO account creation emits, on every server, saying a profile is undefined
+        // while it is being applied - which trains an operator to ignore exactly the warning this adds.
+        var configuration = new PluginConfiguration();
+        configuration.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var (service, users, logger) = BuildWithLogger(configuration);
+        var created = Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: "guest");
+
+        Assert.Equal(1, created.MaxActiveSessions);
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task AProviderNamingNoProfileAtAll_ProvisionsWithNoWarningAtAll()
+    {
+        // Every installation that never configured a profile, which is the majority. Nothing was named, so
+        // nothing failed to resolve, and the log has to stay exactly as quiet as it was before this existed.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var (service, users, logger) = BuildWithLogger(configuration);
+        Provisionable(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisioningProfile: null);
+
+        Assert.DoesNotContain(logger.Entries, e => e.Level == LogLevel.Warning);
     }
 
     [Fact]
@@ -556,9 +640,19 @@ public class ProvisioningProfileRoleSelectionTests
 
     private static (CanonicalLinkService Service, IUserManager Users) BuildFor(PluginConfiguration configuration)
     {
+        var (service, users, _) = BuildWithLogger(configuration);
+        return (service, users);
+    }
+
+    // The same wiring with the service's own logger handed back, rather than a second builder: a test that
+    // reads the log and a test that reads the account then look at one object graph, so a line asserted here
+    // is a line the account beside it actually produced.
+    private static (CanonicalLinkService Service, IUserManager Users, CapturingLogger Logger) BuildWithLogger(PluginConfiguration configuration)
+    {
         var users = Substitute.For<IUserManager>();
         var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
-        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger()), users);
+        var logger = new CapturingLogger();
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, logger), users, logger);
     }
 
     // The full completion path, wired exactly as LoginCompletionServiceTests wires it. A real AvatarService

--- a/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
@@ -60,29 +60,33 @@ internal static class ProvisioningPolicy
     /// matched no row. A selected name is authoritative: it never falls back to the provider's own default,
     /// for the reason in the remarks.
     /// </param>
-    /// <returns>The template to apply, or <see langword="null"/> when the provider configures none.</returns>
-    internal static ProvisioningPolicyTemplate? TemplateFor(PluginConfiguration configuration, ProviderConfigBase? provider, string? selectedProfile = null)
+    /// <returns>
+    /// The template to apply and, when a configured name pointed at no profile, that name - so the caller
+    /// can say so in the log rather than provisioning an account with nothing at all, silently (#1106).
+    /// </returns>
+    internal static ProvisioningTemplateResolution TemplateFor(PluginConfiguration configuration, ProviderConfigBase? provider, string? selectedProfile = null)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
         if (provider is null)
         {
-            return null;
+            return default;
         }
 
         // The role-selected profile (#1106) wins over the provider's own default, because that is the whole
         // point of the row: it names where THIS login goes instead of where the provider sends everyone else.
         // An unmatched login arrives here with null and the resolution below is byte-identical to #1105's.
-        var profile = string.IsNullOrWhiteSpace(selectedProfile) ? provider.ProvisioningProfile : selectedProfile;
+        var selectedByRole = !string.IsNullOrWhiteSpace(selectedProfile);
+        var profile = selectedByRole ? selectedProfile : provider.ProvisioningProfile;
         if (string.IsNullOrWhiteSpace(profile))
         {
-            return provider.ProvisioningPolicyTemplate;
+            return new ProvisioningTemplateResolution(provider.ProvisioningPolicyTemplate, null, false);
         }
 
         return configuration.ProvisioningProfiles != null
             && configuration.ProvisioningProfiles.TryGetValue(profile, out var named)
-                ? named
-                : null;
+                ? new ProvisioningTemplateResolution(named, null, selectedByRole)
+                : new ProvisioningTemplateResolution(null, profile, selectedByRole);
     }
 
     /// <summary>
@@ -171,4 +175,23 @@ internal static class ProvisioningPolicy
 
         return written;
     }
+
+    /// <summary>
+    /// What <see cref="TemplateFor(PluginConfiguration, ProviderConfigBase, string)"/> decided: the template
+    /// to write, and the profile name that pointed at nothing when one did.
+    /// </summary>
+    /// <remarks>
+    /// The unresolved name is carried out rather than swallowed because the fail-closed answer and the
+    /// invisible one are the same account otherwise: no policy is written either way, so an administrator
+    /// whose profile was renamed sees a new account with Jellyfin's bare defaults and nothing anywhere
+    /// saying which name did not resolve. The resolution itself stays a pure function of the configuration;
+    /// the caller owns the log, because only the caller knows this is the create arm.
+    /// </remarks>
+    /// <param name="Template">The template to apply, or <see langword="null"/> when there is none to apply.</param>
+    /// <param name="UnresolvedProfile">The configured profile name that resolved to nothing, or <see langword="null"/> when nothing was left unresolved.</param>
+    /// <param name="SelectedByRole">Whether the name came from a role row (#1106) rather than from the provider's own default (#1105); false whenever <see cref="UnresolvedProfile"/> is null.</param>
+    internal readonly record struct ProvisioningTemplateResolution(
+        ProvisioningPolicyTemplate? Template,
+        string? UnresolvedProfile,
+        bool SelectedByRole);
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -703,8 +703,30 @@ internal sealed class CanonicalLinkService
     // template a provider gets - its named profile or its own inline one (#1105) - is ProvisioningPolicy's
     // rule, resolved inside the same transaction so the profile set and the name pointing at it are read
     // together and a concurrent save cannot be seen half-applied.
-    private ProvisioningPolicyTemplate? ProvisioningTemplateFor(ProviderMode mode, string provider, string? provisioningProfile) =>
-        _configStore.Read(configuration => ProvisioningPolicy.TemplateFor(configuration, ProviderConfigFor(configuration, mode, provider), provisioningProfile));
+    private ProvisioningPolicyTemplate? ProvisioningTemplateFor(ProviderMode mode, string provider, string? provisioningProfile)
+    {
+        var resolution = _configStore.Read(configuration => ProvisioningPolicy.TemplateFor(configuration, ProviderConfigFor(configuration, mode, provider), provisioningProfile));
+
+        // The previously silent arm (#1106). A name that resolves to nothing writes NO policy and never
+        // falls back - deliberately, because falling back would hand the group an administrator singled out
+        // for a narrower profile the wider one instead. What that costs is visibility: the account comes out
+        // carrying Jellyfin's bare new-user defaults, which is byte-identical to a provider that configured
+        // no template at all, so without this line nothing anywhere says a configured name failed to
+        // resolve. Warning rather than error: the login succeeded and the account exists, and what is asked
+        // for is a configuration repair. Emitted only here, on the create arm, so it fires once per account
+        // rather than on every login of one.
+        if (resolution.UnresolvedProfile is not null && _logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning(
+                "SSO provisioning via {Mode}/{Provider}: provisioning profile {Profile} ({Source}) is not defined, so the new account was created with NO provisioning policy. The resolution deliberately does not fall back; define that profile or remove the reference.",
+                mode.ToToken(),
+                provider.ReplaceLineEndings(string.Empty),
+                resolution.UnresolvedProfile.ReplaceLineEndings(string.Empty),
+                resolution.SelectedByRole ? "selected by a role mapping" : "the provider default");
+        }
+
+        return resolution.Template;
+    }
 
     // The stored provider object the read above resolves its template from, or null when the provider is
     // gone or was stored with a null config object (#350).


### PR DESCRIPTION
# What & why

Part of #1106, and it lands the half of that issue's third Done-when clause that
was not refused.

A configured provisioning-profile name that points at no profile writes NO policy
and deliberately never falls back. That refusal is correct and stays: a role row
exists to send one group somewhere NARROWER, so falling back would hand exactly
those accounts the wider policy the administrator moved them off. What it costs is
visibility. An account created from a dangling name carries Jellyfin's bare
new-user defaults, which is byte-identical to one created by a provider that
configured no template at all, so a profile renamed out from under a role row - or
out from under a provider's own default - produced an account nothing anywhere
explained.

The resolution now carries the name that failed to resolve out to the create arm,
which logs one warning naming the provider, the name, and which of the two sources
pointed at it. The source is in the line because the two are repaired in different
forms: a role row in one, the provider's own profile field in the other, and a
message naming neither would send the operator to the wrong one.

The resolver stays a pure function of the configuration. Only the caller knows this
is the create arm, so only the caller logs, and the line therefore fires once per
account rather than on every login of one.

What this does NOT do is restore the fallback. The clause asked for a fallback to
the provider default with a warning beside it; the fallback was refused on the issue
with its argument written down before any code existed, and this adds only the
warning. Whether #1106 closes on three clauses met and one superseded is a call
about the issue rather than about the code, and it is left rather than taken here.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The fail-closed arm this touches is the
      profile resolution, and it is unchanged - a name that resolves to nothing
      still writes no policy and still falls back to neither the provider default
      nor the inline template. Every existing test for that is unmodified and green.
- [x] No secrets logged; secrets are redacted on config export. What the new line
      carries is a provider name, a profile NAME and a two-way literal. No template
      value, no secret and no user identifier reaches it.
- [ ] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline. **No adversarial review was run for this
      change, and no second reader looked at it.** What stands in place of one is
      below, stated as what it is rather than as a substitute.
- [ ] Review record: per lens, its verdict and its findings. **Not produced** - see
      the line above. Nothing is claimed CONFIRMED or PLAUSIBLE because no lens ran.
- [x] Log inputs from the IdP are sanitized inline at the log call. Both interpolated
      values are `ReplaceLineEndings(string.Empty)` at the call. Neither comes from the
      IdP - both are configuration the administrator wrote - and they are sanitized
      anyway, because a configuration file can be edited by hand.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
      The decision stays in `ProvisioningPolicy.TemplateFor`; the emit is one block in
      the one caller. The test builder gained a logger-returning variant and the
      existing one delegates to it, so there is one wiring rather than two.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass (they are in the suite runs below).
- [x] Docs impact considered: no README or wiki text describes what the log says on a
      dangling profile name, so nothing goes stale. Nothing is filed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Built on both target
      frameworks, 0 warnings each:
      `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror` and
      the same with `-f net10.0`.
- [x] `dotnet test` is green. Run through the built runner:
      `net9.0` Total: 3455, Failed: 0, Skipped: 4.
      `net10.0` Total: 3456, Failed: 0, Skipped: 4.
      The four skips are the four the suite already skips on this host: they bind a
      listener off loopback, which needs an administrator. They were not worked around.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This change
      touches three `.cs` files and nothing else, so there is no such change to check.

## How each guard was checked

Each was deleted or broken and the suite watched.

- Removing the emit reddens both log tests.
- Reporting a name that DID resolve, by returning `profile` instead of `null` on the
  success arm - a one-token mistake - reddens `AProfileThatResolves_ProvisionsWithNoWarningAtAll`.
  That is the near-miss worth the most: a warning emitted on every provisioning is how
  a real warning gets trained out of an operator.
- Collapsing the two sources into one string reddens `ARowNamingAMissingProfile_SaysSoInTheLog`.

One inversion could not be tested this way and the reason is worth stating: writing the
condition as `is null` does not compile under `--warnaserror`, because the sanitizing call
beside it then dereferences a value the compiler knows is null. The compiler refuses that
mistake before a test could.

## Notes

No second reader looked at this change and no adversarial review was run for it. That is
stated in the checklist above as an unticked box rather than worked around.

The provisioning path reaches the settings page nowhere: there is still no editor for the
role rows or for the profiles themselves (#1105), so an administrator repairing what this
line reports edits the configuration through the same route as before.
