### PR TITLE
Reach the declarative freeze when a save posts a null collection

### DIFF
--- a/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
@@ -171,6 +171,69 @@ public class DeclarativeManagedProvidersTests
     }
 
     [Fact]
+    public void ASaveWhoseWholeCollectionIsNull_PutsEveryManagedProviderBack()
+    {
+        // The same intent as the drop above, arriving in a shape nobody posted here before: a save whose
+        // whole provider collection is null rather than empty. It reached the freeze's own null check and
+        // returned before re-adding anything, so every managed provider was deleted and NO ignored write
+        // was audited - a page that wins against the file and leaves no trace, which is the exact pair this
+        // freeze exists to make impossible. A null collection is what a body carrying an explicit
+        // "OidConfigs": null deserializes to; an omitted key keeps the constructor's empty dictionary.
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        document.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        store.Save(new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! });
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal("from-the-file", saved.OidConfigs["keycloak"].OidClientId);
+        Assert.True(saved.SamlConfigs.ContainsKey("adfs"));
+        Assert.Equal(2, IgnoredWrites(log).Count);
+    }
+
+    [Fact]
+    public void ASaveWhoseWholeCollectionIsNull_OnAnInstallationManagingNothing_LeavesItNull()
+    {
+        // The other direction, and the one that costs more if it is wrong. The repair above materializes a
+        // collection, and doing that where no source named a provider would hand every deployment a shape
+        // the save path did not previously produce. ServerManagedFields already pins that a null map is left
+        // exactly as it arrived; this pins that the freeze does not undo that pin.
+        var (store, _, persisted, log) = CreateStore();
+
+        store.Save(new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! });
+
+        var saved = (PluginConfiguration)persisted.Single();
+        Assert.True(store.ManagedProviders.IsEmpty);
+        Assert.Null(saved.OidConfigs);
+        Assert.Null(saved.SamlConfigs);
+        Assert.Empty(IgnoredWrites(log));
+    }
+
+    [Fact]
+    public void ASaveWhoseWholeCollectionIsNull_MaterializesOnlyTheProtocolASourceNamed()
+    {
+        // The half of the repair the two tests above cannot reach, because an installation managing nothing
+        // returns at the IsEmpty check before any of it runs. Here a source names an OpenID provider and no
+        // SAML one, so the OpenID collection has to be materialized to put the provider back and the SAML
+        // one has to be left exactly as it arrived. Without the per-protocol condition the SAML half is
+        // materialized too, which changes the persisted shape of a deployment on behalf of a protocol no
+        // source ever named.
+        var (store, _, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        store.Save(new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! });
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal("from-the-file", saved.OidConfigs["keycloak"].OidClientId);
+        Assert.Null(saved.SamlConfigs);
+        Assert.Single(IgnoredWrites(log));
+    }
+
+    [Fact]
     public void ASaveThatChangesNothingOnAManagedProvider_AuditsNothing()
     {
         // The noise guard, and the reason the freeze runs AFTER ServerManagedFields.Preserve. A page save

--- a/SSO-Auth/Config/DeclarativeManagedProviders.cs
+++ b/SSO-Auth/Config/DeclarativeManagedProviders.cs
@@ -167,6 +167,22 @@ internal sealed class DeclarativeManagedProviders
             return;
         }
 
+        // A posted collection that is NULL rather than empty is the same admin intent as one that dropped
+        // every provider, and the freeze has to reach it. Without this the per-protocol loop below returns
+        // at its own null check before re-adding anything, so a save shaped this way deletes every managed
+        // provider AND reports no ignored write - the one combination this freeze exists to make impossible.
+        // Materialized only where a source actually named a provider of that protocol, so an installation
+        // managing nothing keeps a null collection exactly as it arrived.
+        if (_oid.Count > 0 && incoming.OidConfigs is null)
+        {
+            incoming.OidConfigs = new SerializableDictionary<string, OidConfig>();
+        }
+
+        if (_saml.Count > 0 && incoming.SamlConfigs is null)
+        {
+            incoming.SamlConfigs = new SerializableDictionary<string, SamlConfig>();
+        }
+
         Reinject(_oid, OpenIdProtocol, incoming.OidConfigs, live.OidConfigs, ignored, (holder, name, provider) => holder.OidConfigs[name] = provider);
         Reinject(_saml, SamlProtocol, incoming.SamlConfigs, live.SamlConfigs, ignored, (holder, name, provider) => holder.SamlConfigs[name] = provider);
     }


### PR DESCRIPTION
# What & why

A configuration save whose whole provider collection is null, rather than empty,
walked past the declarative freeze. The per-protocol loop returned at its own
null check before re-adding anything, so every declaratively managed provider
was deleted from the persisted configuration and no ignored-write line was
audited. The settings page winning against the file is the thing the freeze
refuses; winning silently is what stops an operator ever finding out.

The shape is reachable rather than theoretical. A body carrying an explicit
`"OidConfigs": null` deserializes to a null collection, while a body that omits
the key keeps the constructor's empty dictionary - which is why
`ASaveThatDropsAManagedProvider_PutsItBack` never met this case. I measured both
halves with throwaway probes before writing any repair:

```
PROBE saved.OidConfigs is null: True | count: n/a | keycloak present: False | ignored-write audit lines: 0
PROBE explicit-null -> OidConfigs is null: True | omitted -> OidConfigs is null: False
```

The repair materializes the collection before the loop, and only for a protocol
a source actually named, so an installation managing nothing still persists a
null map exactly as `ServerManagedFields` already pins.

Refs #1102. That issue stays open. This is its FIRST Done-when clause, which was
met only for a save carrying a non-null collection; the open question about its
second clause is untouched by this change and is not answered here.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Untouched by this change; what it
      restores is the fail-closed direction of the config freeze itself.
- [x] No secrets logged; secrets are redacted on config export. The audit line
      this restores names the protocol and the provider and nothing posted to
      them, which is the existing `SsoAudit.DeclarativeWriteIgnored` wording.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second
      reader looked at this change and no adversarial review was run for it.
      The evidence below stands in place of one and does not replace one.
- [ ] Review record. **NONE**, for the reason on the line above. No lens ran, so
      there are no CONFIRMED or PLAUSIBLE counts to report.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is added or altered here.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. Two guarded assignments inside the existing `Reinject` entry point.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment says why the null case differs
      from the empty one, not what the lines do.
- [x] Architecture-conformance tests pass. This establishes no new structural
      property, so no rule is added.
- [x] Docs impact considered: no README or wiki sentence describes the freeze at
      this granularity, so this needs no documentation update. #1116 is where
      the config-as-code page is drafted and it describes the read-only page
      behaviour rather than the save-path shape.

## Verification

- [x] `dotnet build --warnaserror` is green, on both target frameworks, 0
      warnings.
- [x] `dotnet test` is green: `net9.0` 3458 tests, `net10.0` 3459, 0 failed on
      each. Four tests are skipped on this host, the same four the suite already
      skips: they bind a listener off loopback, which needs an administrator.
      They were not worked around.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

How the guards were checked - each was broken and the suite watched.

- Deleting the repair reddens `..._PutsEveryManagedProviderBack` with a
  `NullReferenceException` on the persisted collection, and leaves the
  empty-installation test green.
- Dropping the per-protocol condition - the near-miss, one clause of an `if` -
  first reddened NOTHING. Both of the first two tests return at the `IsEmpty`
  check before that condition is ever reached, so it shipped unproven. The third
  test exists because of that: a source naming an OpenID provider and no SAML
  one, where the SAML half must stay null. With the condition dropped it fails
  `Assert.Null()` with `Actual: []`.

What this does not cover. The reachability probe measures how
`PluginConfiguration` deserializes, which is in this tree; that Jellyfin core's
plugin-configuration endpoint hands the deserialized object to
`UpdateConfiguration` in exactly this shape is read from the call chain and was
NOT executed against a running server, so no claim is made about an end-to-end
request. The actor is in every case an already-elevated administrator, and the
effect is the loss of a guard plus a silent audit trail, not a privilege
escalation: the next start re-applies the source and puts the providers back.
