### PR TITLE
Freeze the provisioning profiles a declarative source defined

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
@@ -63,6 +63,9 @@ public partial class ArchitectureConformanceTests
         //   ONE shape this rule has to keep out: a per-login event log would need a cap and a sweep, and the
         //   reason this needs neither is the bound, so the exemption is granted to the bounded design and not
         //   to the subject matter.
+        // - DeclarativeManagedProviders._profiles: the provisioning-profile-name-to-source map (#1102), the
+        //   same immutable shape as the two below and exempt for the same reason, on the object a managed
+        //   provider provisions THROUGH rather than on the provider.
         // - DeclarativeManagedProviders._oid / ._saml: the provider-name-to-source map (#1415). Exempt for a
         //   different reason from the four above, and it is the reason rather than the subject that is
         //   exempted. The type is IMMUTABLE - both fields are assigned once in a private constructor and
@@ -73,7 +76,7 @@ public partial class ArchitectureConformanceTests
         //   fields were HashSets until a refusal had to say WHICH source owns a provider, so what changed is
         //   the value beside each name, not where the state lives or how long it lives.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins", "DeclarativeManagedProviders._oid", "DeclarativeManagedProviders._saml" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins", "DeclarativeManagedProviders._oid", "DeclarativeManagedProviders._saml", "DeclarativeManagedProviders._profiles" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
@@ -71,6 +71,12 @@ public class DeclarativeManagedProvidersTests
         return posted;
     }
 
+    private static IReadOnlyList<string> IgnoredProfileWrites(CapturingLogger log) =>
+        log.Entries
+            .Where(e => e.Message.Contains("Configuration save ignored for provisioning profile", StringComparison.Ordinal))
+            .Select(e => e.Message)
+            .ToList();
+
     private static IReadOnlyList<string> IgnoredWrites(CapturingLogger log) =>
         log.Entries
             .Where(e => e.Message.Contains("Configuration save ignored", StringComparison.Ordinal))
@@ -523,4 +529,150 @@ public class DeclarativeManagedProvidersTests
 
         Assert.Equal("/run/secrets/sso.json", store.ManagedProviders.OidSource("keycloak"));
     }
+
+    [Fact]
+    public void ASaveToADeclarativelyDefinedProfile_KeepsTheDeclarativeValue_AndAuditsTheIgnoredWrite()
+    {
+        // The provider is frozen; the profile it provisions THROUGH was not. A managed provider writes its
+        // named profile onto every brand-new account, so a save that redefines that profile changes what the
+        // provider grants without naming the provider at all - the same silent fight this issue exists to
+        // end, reached one object over.
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        document.OidConfigs["keycloak"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "from-the-file",
+            ProvisioningProfile = "guest",
+        };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 4242 };
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal(1, saved.ProvisioningProfiles["guest"].MaxActiveSessions);
+
+        var ignored = Assert.Single(IgnoredProfileWrites(log));
+        Assert.Contains("guest", ignored, StringComparison.Ordinal);
+
+        // The audit names WHICH profile, never what was posted to it.
+        Assert.DoesNotContain("4242", ignored, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ASaveToAProfileNoSourceDefined_StillSavesNormally()
+    {
+        // The freeze is scoped to what a source DEFINED, exactly as it is for providers. A deployment that
+        // takes one profile from a file and writes a second by hand must keep the second editable.
+        var (store, live, persisted, log) = CreateStore();
+        live.ProvisioningProfiles["hand-made"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 2 };
+
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.ProvisioningProfiles["hand-made"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal(9, saved.ProvisioningProfiles["hand-made"].MaxActiveSessions);
+        Assert.Equal(1, saved.ProvisioningProfiles["guest"].MaxActiveSessions);
+        Assert.Empty(IgnoredProfileWrites(log));
+    }
+
+    [Fact]
+    public void ASaveThatDropsADeclarativelyDefinedProfile_PutsItBack()
+    {
+        // Deleting one is never a durable intent - the next start defines it again - but between the two
+        // moments every account a managed provider creates gets NO policy at all, because the resolution
+        // deliberately does not fall back (#1106).
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.ProvisioningProfiles.Remove("guest");
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal(1, saved.ProvisioningProfiles["guest"].MaxActiveSessions);
+        Assert.Single(IgnoredProfileWrites(log));
+    }
+
+    [Fact]
+    public void ASaveThatPostsANullProfileSet_StillKeepsTheDeclarativeProfiles()
+    {
+        // The shape an explicit null in the posted body produces, which is a different one from an omitted
+        // key: the loop returns at its own null check before re-adding anything, so a save shaped this way
+        // deletes the whole set AND audits nothing. The same hole the provider collections carried (#1441).
+        var (store, live, persisted, log) = CreateStore();
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var posted = PostedFrom(live);
+        posted.ProvisioningProfiles = null!;
+        store.Save(posted);
+
+        var saved = (PluginConfiguration)persisted.Last();
+        Assert.Equal(1, saved.ProvisioningProfiles["guest"].MaxActiveSessions);
+        Assert.Single(IgnoredProfileWrites(log));
+    }
+
+    [Fact]
+    public void NoDeclarativeSource_LeavesTheProfileSetAlone()
+    {
+        // The same pin the providers carry: an installation that mounts nothing must save its profiles
+        // exactly as one built before this existed.
+        var (store, live, persisted, log) = CreateStore();
+        live.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+
+        var posted = PostedFrom(live);
+        posted.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 9 };
+        store.Save(posted);
+
+        Assert.True(store.ManagedProviders.IsEmpty);
+        Assert.Equal(9, ((PluginConfiguration)persisted.Single()).ProvisioningProfiles["guest"].MaxActiveSessions);
+        Assert.Empty(IgnoredProfileWrites(log));
+    }
+
+    [Fact]
+    public void ADocumentRedefiningAManagedProfile_IsNamedForTheWholeDocumentRefusal()
+    {
+        // What the import door reads. A document carrying NO provider reaches this, which is why the
+        // provider-name refusal beside it cannot stand in for it.
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 999 };
+        incoming.ProvisioningProfiles["from-elsewhere"] = new ProvisioningPolicyTemplate();
+
+        Assert.Empty(store.ManagedProviders.NamedIn(incoming));
+        var named = Assert.Single(store.ManagedProviders.ProfilesNamedIn(incoming));
+        Assert.Equal("guest", named.Profile);
+        Assert.Equal("/run/secrets/sso.json", named.Source);
+    }
+
+    [Fact]
+    public void ADocumentRedefiningNoManagedProfile_NamesNothing()
+    {
+        var (store, _, _, _) = CreateStore();
+        var document = new PluginConfiguration();
+        document.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+
+        var incoming = new PluginConfiguration();
+        incoming.ProvisioningProfiles["from-elsewhere"] = new ProvisioningPolicyTemplate();
+
+        Assert.Empty(store.ManagedProviders.ProfilesNamedIn(incoming));
+    }
+
 }

--- a/SSO-Auth.Tests/Http/SSOControllerManagedWriteDoorTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerManagedWriteDoorTests.cs
@@ -266,4 +266,79 @@ public class SSOControllerManagedWriteDoorTests
         Assert.DoesNotContain('\n', message);
         Assert.DoesNotContain('\r', message);
     }
+
+    [Fact]
+    public void ImportConfig_DocumentRedefiningAManagedProfile_RefusesTheWholeDocument()
+    {
+        // The sixth door, one object over from the fifth. A managed provider writes its named provisioning
+        // profile onto every account it creates, so a document that names NO provider and only redefines that
+        // profile changes what the managed provider grants - past a refusal that reads provider names only.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+            c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client", ProvisioningProfile = "guest" };
+        });
+
+        Manage(declared =>
+        {
+            declared.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+            declared.OidConfigs["keycloak"] = new OidConfig { OidClientId = "declared-client", ProvisioningProfile = "guest" };
+        });
+
+        var imported = new PluginConfiguration();
+        imported.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 999 };
+        imported.ProvisioningProfiles["from-elsewhere"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 5 };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        var refusal = Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(document));
+
+        AssertNamesTheSource(harness, Assert.IsType<string>(refusal.Value), "guest");
+        Assert.Equal(1, SSOPlugin.Instance.ReadConfiguration(c => c.ProvisioningProfiles["guest"].MaxActiveSessions));
+
+        // Nothing of the document was applied, which is the whole-document half of the refusal.
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.ProvisioningProfiles.ContainsKey("from-elsewhere")));
+    }
+
+    [Fact]
+    public void ImportConfig_DocumentRedefiningNoManagedProfile_StillMerges()
+    {
+        // The half that would otherwise break in silence for every installation that defines a profile by
+        // hand: a document carrying a profile no source declared must still import.
+        var harness = new SsoControllerHarness(c =>
+            c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 });
+
+        Manage(declared =>
+            declared.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 });
+
+        var imported = new PluginConfiguration();
+        imported.ProvisioningProfiles["from-elsewhere"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 5 };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.IsType<NoContentResult>(harness.Controller.ImportConfig(document));
+
+        Assert.Equal(5, SSOPlugin.Instance.ReadConfiguration(c => c.ProvisioningProfiles["from-elsewhere"].MaxActiveSessions));
+        Assert.Equal(1, SSOPlugin.Instance.ReadConfiguration(c => c.ProvisioningProfiles["guest"].MaxActiveSessions));
+    }
+
+    [Fact]
+    public void ImportConfig_ProfileRefusalIsSingleLine_SoItCannotSplitALogLine()
+    {
+        // The source is a path an operator supplies, so it is not trusted to be one line, and the echoed
+        // body is the place a line ending would reach a log through a caller.
+        var harness = new SsoControllerHarness(c =>
+            c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 });
+
+        var declared = new PluginConfiguration();
+        declared.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 1 };
+        SSOPlugin.Instance.ConfigStore.RecordDeclarativelyManaged(declared, "/mnt/sso.json\nINJECTED audit line");
+
+        var imported = new PluginConfiguration();
+        imported.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 999 };
+        var refusal = Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(
+            new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported }));
+
+        var message = Assert.IsType<string>(refusal.Value);
+        Assert.DoesNotContain('\n', message);
+        Assert.DoesNotContain('\r', message);
+    }
 }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -235,6 +235,26 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records a configuration save whose write to a declaratively defined provisioning profile was ignored
+    /// (#1102). The profile is what a managed provider provisions a new account THROUGH, so a save that
+    /// redefines one changes what that provider grants without naming it - which is why this line exists
+    /// separately from <see cref="DeclarativeWriteIgnored"/> rather than borrowing its wording.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="profile">The profile name. No field value is recorded - the point is which profile, not what was posted.</param>
+    internal static void DeclarativeProfileWriteIgnored(ILogger logger, string profile)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Configuration save ignored for provisioning profile '{Profile}': it is defined by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
+            profile?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
     /// Records an elevated write door refusing to alter or delete a declaratively managed provider (#1415).
     /// The config-page save IGNORES such a write and keeps the stored value (see
     /// <see cref="DeclarativeWriteIgnored"/>); these doors carry a single-provider intent that cannot be
@@ -258,6 +278,30 @@ internal static class SsoAudit
             door?.ReplaceLineEndings(string.Empty),
             protocol,
             provider?.ReplaceLineEndings(string.Empty),
+            source?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
+    /// Records a whole-document write door refusing because the document redefines a declaratively defined
+    /// provisioning profile (#1102). Refuse rather than ignore, for the reason
+    /// <see cref="DeclarativeWriteRefused"/> gives: an import is all-or-nothing on every other rejection,
+    /// and dropping part of a document silently is the worse failure.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="door">The route that was refused, e.g. <c>Config/Import</c>.</param>
+    /// <param name="profile">The profile name. No field value is recorded.</param>
+    /// <param name="source">What names the source that defined the profile, so the line says where the change belongs.</param>
+    internal static void DeclarativeProfileWriteRefused(ILogger logger, string door, string profile, string source)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] {Door} refused for provisioning profile '{Profile}': it is defined by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
+            door?.ReplaceLineEndings(string.Empty),
+            profile?.ReplaceLineEndings(string.Empty),
             source?.ReplaceLineEndings(string.Empty));
     }
 

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -683,6 +683,11 @@ public class SSOController : ControllerBase
             CultureInfo.InvariantCulture,
             $"The {protocol} provider '{provider}' is managed by the declarative source {source}. Edit that source and restart the server; a change made here would be undone at the next start.");
 
+    private static string ManagedProfileRefusal(string profile, string source) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"The provisioning profile '{profile}' is defined by the declarative source {source}. Edit that source and restart the server; a change made here would be undone at the next start.");
+
     /// <summary>
     /// Refuses an elevated single-provider write against a provider a declarative source decided (#1415), and
     /// audits the refusal so an operator reading the log sees why nothing changed.
@@ -1607,6 +1612,25 @@ public class SSOController : ControllerBase
             return BadRequest(string.Create(
                 CultureInfo.InvariantCulture,
                 $"{ManagedProviderRefusal(firstProtocol, firstProvider, firstSource)} The import names {managed.Count} declaratively managed provider(s) and none of it was applied; remove them from the document and import the rest.").ReplaceLineEndings(string.Empty));
+        }
+
+        // #1102: the same refusal for a profile the document REDEFINES. A managed provider is what an
+        // administrator sees frozen, but the profile it points at is what that provider actually writes onto
+        // a brand-new account, so a document carrying no provider at all can still change what every managed
+        // provider grants. The whole document again, for the reason above: a partial import that reported
+        // success is the worse failure.
+        var managedProfiles = SSOPlugin.Instance.ConfigStore.ManagedProviders.ProfilesNamedIn(document.Configuration);
+        if (managedProfiles.Count > 0)
+        {
+            foreach (var (profile, profileSource) in managedProfiles)
+            {
+                SsoAudit.DeclarativeProfileWriteRefused(_logger, "Config/Import", profile, profileSource);
+            }
+
+            var (firstProfile, firstProfileSource) = managedProfiles[0];
+            return BadRequest(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{ManagedProfileRefusal(firstProfile, firstProfileSource)} The import redefines {managedProfiles.Count} declaratively defined provisioning profile(s) and none of it was applied; remove them from the document and import the rest.").ReplaceLineEndings(string.Empty));
         }
 
         try

--- a/SSO-Auth/Config/DeclarativeManagedProviders.cs
+++ b/SSO-Auth/Config/DeclarativeManagedProviders.cs
@@ -52,6 +52,7 @@ internal sealed class DeclarativeManagedProviders
     /// </summary>
     internal static readonly DeclarativeManagedProviders None = new(
         new Dictionary<string, string>(StringComparer.Ordinal),
+        new Dictionary<string, string>(StringComparer.Ordinal),
         new Dictionary<string, string>(StringComparer.Ordinal));
 
     // Name -> what names the source that owns it. A dictionary rather than a set because a refusal that
@@ -60,10 +61,19 @@ internal sealed class DeclarativeManagedProviders
     private readonly Dictionary<string, string> _oid;
     private readonly Dictionary<string, string> _saml;
 
-    private DeclarativeManagedProviders(Dictionary<string, string> oid, Dictionary<string, string> saml)
+    // The provisioning profiles a source DEFINED, held beside the providers rather than in a second type:
+    // every rule is the same one - a source decided it, so a write gets the stored value back - and a second
+    // holder would be a second place to forget one of the two doors.
+    private readonly Dictionary<string, string> _profiles;
+
+    private DeclarativeManagedProviders(
+        Dictionary<string, string> oid,
+        Dictionary<string, string> saml,
+        Dictionary<string, string> profiles)
     {
         _oid = oid;
         _saml = saml;
+        _profiles = profiles;
     }
 
     /// <summary>Gets the OpenID provider names the declarative sources named, ordered so the report is stable.</summary>
@@ -72,8 +82,11 @@ internal sealed class DeclarativeManagedProviders
     /// <summary>Gets the SAML provider names the declarative sources named, ordered so the report is stable.</summary>
     internal IReadOnlyList<string> SamlConfigs => _saml.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList();
 
-    /// <summary>Gets a value indicating whether no provider is declaratively managed.</summary>
-    internal bool IsEmpty => _oid.Count == 0 && _saml.Count == 0;
+    /// <summary>Gets the provisioning profile names the declarative sources defined, ordered so the report is stable.</summary>
+    internal IReadOnlyList<string> Profiles => _profiles.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList();
+
+    /// <summary>Gets a value indicating whether nothing at all is declaratively managed.</summary>
+    internal bool IsEmpty => _oid.Count == 0 && _saml.Count == 0 && _profiles.Count == 0;
 
     /// <summary>
     /// Answers a new set carrying everything this one carries plus every provider <paramref name="applied"/>
@@ -99,7 +112,9 @@ internal sealed class DeclarativeManagedProviders
         var saml = new Dictionary<string, string>(_saml, StringComparer.Ordinal);
         Add(oid, applied.OidConfigs, source);
         Add(saml, applied.SamlConfigs, source);
-        return new DeclarativeManagedProviders(oid, saml);
+        var profiles = new Dictionary<string, string>(_profiles, StringComparer.Ordinal);
+        AddProfiles(profiles, applied.ProvisioningProfiles, source);
+        return new DeclarativeManagedProviders(oid, saml, profiles);
     }
 
     /// <summary>
@@ -117,6 +132,14 @@ internal sealed class DeclarativeManagedProviders
     /// <param name="name">The SAML provider name a write door was asked to alter or delete.</param>
     /// <returns>The source, or null when the provider is not declaratively managed.</returns>
     internal string? SamlSource(string name) => Source(_saml, name);
+
+    /// <summary>
+    /// Answers what names the source that defined the provisioning profile <paramref name="name"/>, or null
+    /// where no declarative source defined it.
+    /// </summary>
+    /// <param name="name">The provisioning profile name a write door was asked to alter.</param>
+    /// <returns>The source, or null when the profile is not declaratively managed.</returns>
+    internal string? ProfileSource(string name) => Source(_profiles, name);
 
     /// <summary>
     /// Answers every managed provider <paramref name="incoming"/> names, so a whole-document write door
@@ -145,6 +168,39 @@ internal sealed class DeclarativeManagedProviders
     }
 
     /// <summary>
+    /// Answers every managed provisioning profile <paramref name="incoming"/> redefines, so the
+    /// whole-document write door can refuse before it merges anything.
+    /// </summary>
+    /// <remarks>
+    /// A document carrying no provider at all reaches this. A profile is what a managed provider provisions
+    /// a new account THROUGH, so redefining one changes what that provider grants without naming it, and a
+    /// refusal that looked only at provider names lets the whole policy in through the door it guards.
+    /// Ordered by name, so one document produces the same refusal on two runs and a test can pin the wording.
+    /// </remarks>
+    /// <param name="incoming">The document's configuration payload; null redefines nothing.</param>
+    /// <returns>The (profile, source) of each managed profile the payload redefines; empty when it redefines none.</returns>
+    internal IReadOnlyList<(string Profile, string Source)> ProfilesNamedIn(PluginConfiguration? incoming)
+    {
+        if (incoming?.ProvisioningProfiles is null || _profiles.Count == 0)
+        {
+            return [];
+        }
+
+        var named = new List<(string Profile, string Source)>();
+        foreach (var kvp in incoming.ProvisioningProfiles.OrderBy(entry => entry.Key, StringComparer.Ordinal))
+        {
+            // A null-valued entry carries nothing to import and is skipped by the merge (#538), so refusing
+            // on one would refuse a document that could not have altered the managed profile anyway.
+            if (kvp.Value is not null && _profiles.TryGetValue(kvp.Key, out var source))
+            {
+                named.Add((kvp.Key, source));
+            }
+        }
+
+        return named;
+    }
+
+    /// <summary>
     /// Freezes every managed provider in <paramref name="incoming"/> against its stored value, and reports
     /// the ones whose posted form differed so the caller can audit the ignored write.
     /// </summary>
@@ -158,9 +214,15 @@ internal sealed class DeclarativeManagedProviders
     /// <param name="incoming">The configuration about to be persisted.</param>
     /// <param name="live">The current live configuration, which holds the declarative values.</param>
     /// <param name="ignored">Collects (protocol, provider) for each managed provider whose posted form differed.</param>
-    internal void Reinject(PluginConfiguration? incoming, PluginConfiguration? live, ICollection<(string Protocol, string Provider)> ignored)
+    /// <param name="ignoredProfiles">Collects the name of each managed provisioning profile whose posted form differed.</param>
+    internal void Reinject(
+        PluginConfiguration? incoming,
+        PluginConfiguration? live,
+        ICollection<(string Protocol, string Provider)> ignored,
+        ICollection<string> ignoredProfiles)
     {
         ArgumentNullException.ThrowIfNull(ignored);
+        ArgumentNullException.ThrowIfNull(ignoredProfiles);
 
         if (incoming is null || live is null || IsEmpty)
         {
@@ -185,6 +247,16 @@ internal sealed class DeclarativeManagedProviders
 
         Reinject(_oid, OpenIdProtocol, incoming.OidConfigs, live.OidConfigs, ignored, (holder, name, provider) => holder.OidConfigs[name] = provider);
         Reinject(_saml, SamlProtocol, incoming.SamlConfigs, live.SamlConfigs, ignored, (holder, name, provider) => holder.SamlConfigs[name] = provider);
+
+        // The same materialization for the profile set, and for the same reason: a posted set that is NULL
+        // rather than empty is what an explicit null in the body produces, and the loop below would return
+        // at its own null check having re-injected nothing.
+        if (_profiles.Count > 0 && incoming.ProvisioningProfiles is null)
+        {
+            incoming.ProvisioningProfiles = new SerializableDictionary<string, ProvisioningPolicyTemplate>();
+        }
+
+        ReinjectProfiles(incoming.ProvisioningProfiles, live.ProvisioningProfiles, ignoredProfiles);
     }
 
     private static void Add<T>(Dictionary<string, string> names, SerializableDictionary<string, T>? providers, string source)
@@ -199,6 +271,68 @@ internal sealed class DeclarativeManagedProviders
         {
             names[kvp.Key] = source;
         }
+    }
+
+    private static void AddProfiles(
+        Dictionary<string, string> names,
+        SerializableDictionary<string, ProvisioningPolicyTemplate>? profiles,
+        string source)
+    {
+        if (profiles is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in profiles)
+        {
+            names[kvp.Key] = source;
+        }
+    }
+
+    // The provider loop written for the one type that is not a provider. A profile carries no write-only
+    // field, so unlike a provider there is nothing the JSON boundary withholds - but the comparison still
+    // goes through the store's own round-trip on BOTH sides, because XML serialization does not
+    // distinguish an absent collection from an empty one and only one of the two sides has been over the
+    // wire. Comparing a round-tripped posted set against a live object a loader built would call every
+    // untouched profile a changed one, which is the measurement the provider comparison already records.
+    private void ReinjectProfiles(
+        SerializableDictionary<string, ProvisioningPolicyTemplate>? incoming,
+        SerializableDictionary<string, ProvisioningPolicyTemplate>? live,
+        ICollection<string> ignored)
+    {
+        if (incoming is null || live is null)
+        {
+            return;
+        }
+
+        foreach (var name in _profiles.Keys)
+        {
+            if (!live.TryGetValue(name, out var stored) || stored is null)
+            {
+                // Defined by a source but no longer in the store: a later write removed it and there is no
+                // declarative value left to re-inject. Nothing is invented here; the next start re-applies
+                // the source and the profile comes back.
+                continue;
+            }
+
+            var posted = incoming.TryGetValue(name, out var candidate) ? candidate : null;
+            if (posted is null || !string.Equals(PersistedProfileForm(name, posted), PersistedProfileForm(name, stored), StringComparison.Ordinal))
+            {
+                ignored.Add(name);
+            }
+
+            incoming[name] = stored;
+        }
+    }
+
+    // The persisted form of ONE profile, reached through the configuration model for the same two reasons
+    // the provider form is: the persisted form is what the store writes, and putting both sides through the
+    // same round-trip is what makes them comparable at all.
+    private static string PersistedProfileForm(string name, ProvisioningPolicyTemplate profile)
+    {
+        var holder = new PluginConfiguration();
+        holder.ProvisioningProfiles[name] = profile;
+        return holder.DetachedCopy().ToPersistedForm();
     }
 
     private static string? Source(Dictionary<string, string> managed, string name) =>

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -143,6 +143,7 @@ internal sealed class ProviderConfigStore
         ArgumentNullException.ThrowIfNull(configuration);
         List<(string Protocol, string Provider, IReadOnlyList<string> Options)>? insecureToAudit = null;
         var declarativeWritesIgnored = new List<(string Protocol, string Provider)>();
+        var declarativeProfileWritesIgnored = new List<string>();
         lock (Sync)
         {
             if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
@@ -166,7 +167,7 @@ internal sealed class ProviderConfigStore
                 // the stored one, so the audit below reports a save that actually tried to change a managed
                 // provider instead of firing on every unrelated settings change. Nothing happens here on an
                 // installation that configures no declarative source.
-                ManagedProviders.Reinject(incoming, _live(), declarativeWritesIgnored);
+                ManagedProviders.Reinject(incoming, _live(), declarativeWritesIgnored, declarativeProfileWritesIgnored);
 
                 // Snapshot which providers were saved with an insecure option (#140) while under the
                 // lock, but emit the warnings AFTER releasing it (below) - logging must not run inside
@@ -192,6 +193,11 @@ internal sealed class ProviderConfigStore
             foreach (var (protocol, provider) in declarativeWritesIgnored)
             {
                 SsoAudit.DeclarativeWriteIgnored(_logger, protocol, provider);
+            }
+
+            foreach (var profile in declarativeProfileWritesIgnored)
+            {
+                SsoAudit.DeclarativeProfileWriteIgnored(_logger, profile);
             }
         }
     }


### PR DESCRIPTION
# What & why

The declarative freeze (#1102, extended to the elevated doors by #1415) records provider names only. A managed provider does not write a policy of its own onto a new account: it names a provisioning profile, and that profile is what gets written. So the object the freeze protected was not the object that decides what a file-managed provider grants.

Measured at `origin/main` `ad46a97632a9aded46a913e75f86243c1c712e1b` with a throwaway probe, before any repair was written. A document declares profile `guest` with `MaxActiveSessions = 1` and a provider pointing at it; then a document naming NO provider and only redefining `guest` goes through the import door, and a settings-page save posts a third value:

```
PROBE managed oid: [keycloak]
PROBE live guest MaxActiveSessions after load: 1
PROBE Config/Import refusal names: 0
PROBE live guest MaxActiveSessions after import: 999
PROBE saved guest MaxActiveSessions after page save: 4242
PROBE ignored-write audit lines: 0
```

Both doors let it through and neither left a trace. The import door names 0 because it compares provider names and the document carries no provider at all.

This records the profiles a source defined, re-injects the stored value on the save path, and refuses the whole document at `Config/Import` when it redefines one. The refusal names the profile and its source, because a source that is not named leaves an administrator with nowhere to make the change instead.

A posted profile set that is null rather than empty reaches the freeze - the shape #1441 had to repair for the provider collections, which would otherwise delete the whole set while auditing nothing.

Closes #1442

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a save or import that touches a declaratively defined profile keeps the stored value or is refused whole; nothing is default-accepted. The deletion direction was already fail-closed by `ValidateProvisioningProfileReference` and is unchanged.
- [x] No secrets logged. The audit lines name WHICH profile, never what was posted to it, asserted by a test.
- [ ] **No security review was performed.** No second reader looked at this change and no adversarial review was run for it. This box stays unticked rather than being explained away.
- [ ] No review record exists, for the same reason. **CONFIRMED 0 / PLAUSIBLE 0** raised, because no lens was run - not because a run found nothing.
- [x] The source is a path or an environment prefix an operator supplies, so it is not trusted to be one line; both the echoed body and the audit lines strip line endings inline at the call, and a test asserts the refusal body is single-line.

## Quality checklist

- [x] The profile rules sit beside the provider rules in `DeclarativeManagedProviders` rather than in a second holder, so there is one place that knows what a source decided rather than two to forget one of the doors.
- [x] No more code than the problem requires: one map, one re-injection loop, one refusal block, two audit lines.
- [x] Comments say why. The two that matter are why the profile comparison round-trips both sides, and why the null-set materialization exists.
- [x] Architecture-conformance tests pass. The state gate **refused** the new map until its immutable-shape exemption was extended, which is the gate working rather than a change to what it permits: the type is still assigned once in a private constructor and rebuilt whole by `Including()`, and the exemption records that reason.
- [x] Docs impact considered: config-as-code is documented on #1116, which is open and blocked on a wiki push; this change adds no user-facing surface of its own, and the behaviour it lands is what that page will describe when it is published.

## Verification

- [x] `dotnet build ... --warnaserror` green on `net9.0` and `net10.0`, 0 warnings.
- [x] Full suite green on both: `net9.0` 3468 tests, `net10.0` 3469, 0 failed on each. Four tests are skipped on this host, the same four the suite already skips: they bind a listener off loopback, which needs an administrator. They were not worked around.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is in this change.

### How the guards were checked

Each was deleted or inverted and the suite watched.

| cut | reddens |
| --- | --- |
| stop recording the profiles a source defined | 6 |
| keep the POSTED profile instead of the stored one | 1 |
| compare the posted profile with itself | 1 |
| drop the null-profile-set materialization | 1 |
| make the import door never find a managed profile | 2 |
| stop emitting the profile audit line | 3 |

Two inversions could not be proven that way, and the reason is worth recording rather than hiding: writing the report condition as a conjunction dereferences a value the compiler knows is null, and removing the emit loop leaves its list unread. The compiler refuses both before a test could reach them.

## Notes

Out of scope, deliberately. The `Config/Managed` endpoint still reports providers only; widening it to profiles would change the contract #1104's conformance rules pin, and the settings page carries no profile editor to render (#1105). Whether the report should name profiles belongs with the open call on #1102 rather than here.

This change does not touch the per-field question #1102 is waiting on, and nothing here asks for that to be decided.

This board had no second reader tonight, which the security checklist above records as unticked boxes rather than as prose.
