### PR TITLE
Name the endpoint when an authorization request produces no status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,17 @@ failing on a tree with no modifications at all, and a real formatting defect in
 your change is indistinguishable from the noise. On Linux the flag changes
 nothing.
 
+**Keep the whole output of a full test run.** Filtering the run down to the
+summary line is what cost issue #1444 its evidence: one `net10.0` run of the
+suite reported five failures in `SSOControllerAuthorizationTests`, the assertion
+text was filtered away as it was produced, and the run has not recurred, so the
+only thing left about it is the count. Redirect the run to a file, or pipe it
+through `tee`, and keep the file until the run is green:
+
+```sh
+./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe 2>&1 | tee run-net10.log
+```
+
 `dotnet test` requires the **.NET 10 SDK**: the repo's `global.json` selects the
 SDK's Microsoft.Testing.Platform mode of `dotnet test` (#718), which older SDKs
 do not support (the build itself multi-targets net9.0 + net10.0 either way, so

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -192,6 +193,23 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
             request.Content = new StringContent("null", Encoding.UTF8, "application/json");
         }
 
-        return await _fixture.Client.SendAsync(request).ConfigureAwait(false);
+        var caller = role ?? "an unauthenticated caller";
+        var elapsed = Stopwatch.StartNew();
+        try
+        {
+            return await _fixture.Client.SendAsync(request).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // A request that never produced a status carries none of that in its own text: the transport
+            // exception names an address and, on a non-English host, says so in that host's language. The five
+            // tests above each drive ~25 endpoints in a loop, so without this the reader of a red run cannot
+            // tell WHICH endpoint stalled, as which caller, or after how long - which is the evidence #1444
+            // lost the one time this went red. Diagnostics, not a guard: nothing here can fail a green run.
+            throw new InvalidOperationException(
+                FormattableString.Invariant(
+                    $"the request produced no status: {endpoint} as {caller} after {elapsed.ElapsedMilliseconds} ms, client timeout {_fixture.Client.Timeout}, {ex.GetType().Name}"),
+                ex);
+        }
     }
 }

--- a/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
@@ -124,7 +124,13 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
         var address = _app.Services.GetRequiredService<IServer>()
             .Features.Get<IServerAddressesFeature>()!.Addresses.GetEnumerator();
         address.MoveNext();
-        Client = new HttpClient { BaseAddress = new Uri(address.Current) };
+        // The timeout is explicit rather than inherited (#1444). HttpClient defaults to 100 seconds, measured
+        // on this type rather than read from documentation, and every request here is a loopback call to a
+        // server in this same process that answers in milliseconds. A stall therefore holds the suite for a
+        // minute and a half per request with nothing said about it. A red run of these tests once took four
+        // times as long as a green one and left no usable evidence; whether a stall produced that is not
+        // established, and bounding the wait is what would let the next occurrence say so itself.
+        Client = new HttpClient { BaseAddress = new Uri(address.Current), Timeout = TimeSpan.FromSeconds(30) };
 
         Endpoints = new EndpointCatalog(_app.Services);
     }


### PR DESCRIPTION
# What & why

Refs #1444. That issue records one `net10.0` run of the suite reporting five
failures in `SSOControllerAuthorizationTests`, with the assertion text filtered
away as it was produced and the run never recurring, so the only thing left
about it is the count. This change does not find the cause and does not meet
that issue's Done-when. It makes the next occurrence say what it was, and it is
deliberately written so that it cannot redden a green run.

**The five and the two.** The class holds seven tests. The five that failed are
exactly the five that send an HTTP request through the fixture client; the two
that passed, `CoversExactlyTheKnownElevationSurface` and
`PlainAuthorizeSurfaceIsDistinctFromElevation`, are the two that read the
endpoint table in memory and send nothing. The issue's "where to look first"
says all five build a controller and drive the authorization stage; the sharper
line through the same seven is the transport.

**What the transport says today.** A request that never produces a status throws
past `AssertAllAsync`, whose own message (endpoint and status) is never reached.
What the reader gets instead names an address and, on a non-English host, says
so in that host's language, with no mention of which of the ~25 endpoints in the
loop was being driven or as which caller:

```
System.Net.Http.HttpRequestException : Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte. (127.0.0.1:1)
```

**What it says after this change.** `SendAsync` wraps that case in an English
message carrying the endpoint, its method, its guard, the caller, the elapsed
milliseconds and the client timeout, keeping the transport exception as the
inner one. Proved by pointing the fixture at a closed port and running one of
the five:

```
System.InvalidOperationException : the request produced no status: POST /SSO/OID/Add/01f17000-239c-402a-bb98-23d271b8478a [RequiresElevation] (OidAdd) as an unauthenticated caller after 2080 ms, client timeout 00:00:30, HttpRequestException
```

**The timeout is now explicit.** The fixture client carried the inherited
default, measured on this type rather than read from documentation:

```
PROBE default HttpClient.Timeout=00:01:40 | fixture Client.Timeout=00:01:40 | fixture BaseAddress=http://127.0.0.1:51895/
```

Every request it makes is a loopback call to a server in the same process that
answers in milliseconds, so an inherited minute and a half per request buys
nothing and hides a stall inside the run's wall clock. It is 30 seconds now,
which is three orders of magnitude above what these requests take and far below
what would let one stall dominate a run.

**CONTRIBUTING.md** gains the cheapest half of the same repair: keep the whole
output of a full run rather than filtering it to the summary line, which is
what cost that run its evidence.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This touches no login path, no crypto, no config persistence and
no release pipeline: the two changed source files are the test fixture that
hosts the controller and the test that drives it, and no production code is
touched. No security review was run for this change, and none is claimed.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No new structural property is established here.
- [x] Docs impact considered: the documentation half is in this change, in
      `CONTRIBUTING.md`. No README or wiki surface describes how the suite's
      output is kept, so nothing else is owed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Run on this branch, both target frameworks, `--warnaserror` on the test project
so the analyzers are the gate:

```
=== build net9.0   Der Buildvorgang wurde erfolgreich ausgefuehrt.   0 Warnung(en)
=== build net10.0  Der Buildvorgang wurde erfolgreich ausgefuehrt.   0 Warnung(en)
   SSO-Auth.Tests  Total: 3468, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,653s
   SSO-Auth.Tests  Total: 3469, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 31,085s
```

The four skipped are the four the suite already skips on Windows: they bind a
listener off loopback, which needs an administrator. They were not worked
around.

```
$ bash scripts/check-lockfiles.sh
ok: 5 tracked lockfile(s) unchanged
$ npx prettier --check --end-of-line auto "CONTRIBUTING.md"
All matched files use Prettier code style!
```

## Notes

This is diagnostics, not a guard, and both changed source files say so where
they sit. There is no ledger-style proof that it "bites" in the sense a guard
would need, because nothing here can fail a run that would otherwise pass; what
was proved instead is that the message appears and carries what it promises,
by breaking the fixture's address and reading the failure, quoted above.

No cause for the red run is claimed. The five-versus-two split narrows where to
look and is not evidence of what happened.

The issue stays open. Its Done-when asks for the assertion text of an actual
occurrence, and this change is what would make that text worth having.

No second reader looked at this change.
