### PR TITLE
Prove the manual-login door is shut on a provisioned account [#1440]

### DIFF
--- a/SSO-Auth.Tests/Linking/ProvisionedAccountPasswordDoorTests.cs
+++ b/SSO-Auth.Tests/Linking/ProvisionedAccountPasswordDoorTests.cs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The manual-login door on an account this plugin provisions (#1440). Jellyfin creates a user with no
+/// password, and a user with no password is reachable from the ordinary login form by submitting an empty
+/// one - so an account created by an SSO login would be usable without the identity provider that is
+/// supposed to be the only way in. <see cref="CanonicalLinkService"/> closes that door twice on the create
+/// arm: it stamps an <c>AuthenticationProviderId</c> that resolves to no registered password provider, and
+/// it stores a hash of 64 cryptographically random bytes. Both were unproven until these tests; each one
+/// here reddens when its line is deleted, which is the only reason to believe either is load-bearing.
+/// </summary>
+public class ProvisionedAccountPasswordDoorTests
+{
+    private static readonly Guid Created = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid Second = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    private static (CanonicalLinkService Service, IUserManager Users, RecordingCryptoProvider Crypto) Build(Action<PluginConfiguration>? seed = null)
+    {
+        var cfg = new PluginConfiguration();
+        seed?.Invoke(cfg);
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        var crypto = new RecordingCryptoProvider();
+        return (new CanonicalLinkService(users, crypto, store, new CapturingLogger()), users, crypto);
+    }
+
+    private static User ExpectCreate(IUserManager users, string name, Guid id)
+    {
+        var created = TestUsers.Named(name, id);
+        users.GetUserByName(name).Returns((User?)null);
+        users.CreateUserAsync(name).Returns(created);
+        users.GetUserById(id).Returns(created);
+        return created;
+    }
+
+    [Fact]
+    public async Task NewAccount_IsStampedOffJellyfinsNativePasswordProvider()
+    {
+        // The first of the two doors. The stamped id is deliberately one that resolves to no registered
+        // IAuthenticationProvider, so core substitutes its InvalidAuthenticationProvider and rejects every
+        // password attempt on the account - including the empty one the login form will happily post.
+        var (service, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = ExpectCreate(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(SsoManagedProviderId.Value, created.AuthenticationProviderId);
+        Assert.False(SsoAuthenticationProviders.IsDefaultPasswordProvider(created.AuthenticationProviderId));
+    }
+
+    [Fact]
+    public async Task NewAccount_GetsAStoredPasswordAndItIsNotTheEmptyOne()
+    {
+        // The second door, and the one that still holds if an administrator later points the account back
+        // at the native password provider: the stored hash is of a long random string, so the empty
+        // password that reaches the login form does not verify against it.
+        var (service, users, crypto) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = ExpectCreate(users, "alice", Created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        var plaintext = Assert.Single(crypto.Hashed);
+        Assert.False(string.IsNullOrWhiteSpace(plaintext));
+
+        // 64 random bytes in base64. Asserted as a floor rather than as the exact length so a future move to
+        // a different encoding of the same entropy does not redden a test about the door being shut.
+        Assert.True(plaintext.Length >= 64, "provisioned password was " + plaintext.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " characters");
+        Assert.False(string.IsNullOrEmpty(created.Password));
+    }
+
+    [Fact]
+    public async Task TwoNewAccounts_DoNotShareAPassword()
+    {
+        // A constant password would satisfy the test above and would be worth exactly nothing: one leak, or
+        // one reading of the source, opens every account the plugin has ever created. This is the test that
+        // separates "a password was set" from "a random password was set".
+        var (service, users, crypto) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var alice = ExpectCreate(users, "alice", Created);
+        var bob = ExpectCreate(users, "bob", Second);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-2", "bob", allowExistingAccountLink: false);
+
+        Assert.Equal(2, crypto.Hashed.Count);
+        Assert.NotEqual(crypto.Hashed[0], crypto.Hashed[1]);
+        Assert.NotEqual(alice.Password, bob.Password);
+    }
+
+    [Fact]
+    public async Task PendingApprovalAccount_IsPersistedWithBothDoorsAlreadyShut()
+    {
+        // The pending-approval arm (#737) short-circuits before the session minter and persists the account
+        // itself, so it is the one arm where the plugin writes a brand-new account to the database and then
+        // refuses the login. An account left sitting there for an administrator to approve must not be the
+        // one that is reachable without the identity provider in the meantime.
+        var (service, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = ExpectCreate(users, "alice", Created);
+        User? persisted = null;
+        users.UpdateUserAsync(Arg.Do<User>(u => persisted = u)).Returns(Task.CompletedTask);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisionDisabled: true);
+
+        Assert.Same(created, persisted);
+        Assert.Equal(SsoManagedProviderId.Value, persisted!.AuthenticationProviderId);
+        Assert.False(string.IsNullOrEmpty(persisted.Password));
+    }
+
+    [Fact]
+    public async Task AlreadyLinkedAccount_KeepsItsOwnPasswordAndProviderRouting()
+    {
+        // The fail-safe in the other direction, and the reason the two writes live on the create arm rather
+        // than on every login. An account that already exists may belong to an administrator who
+        // deliberately left it on the native password provider; a login that resolves it must not lock that
+        // owner out by re-routing it or by overwriting the password they chose.
+        var (service, users, crypto) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Created },
+        });
+        var existing = TestUsers.Named("alice", Created);
+        existing.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
+        existing.Password = "the-hash-the-owner-chose";
+        users.GetUserById(Created).Returns(existing);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Empty(crypto.Hashed);
+        Assert.Equal(SsoAuthenticationProviders.DefaultPasswordProviderId, existing.AuthenticationProviderId);
+        Assert.Equal("the-hash-the-owner-chose", existing.Password);
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+}

--- a/SSO-Auth.Tests/_Support/RecordingCryptoProvider.cs
+++ b/SSO-Auth.Tests/_Support/RecordingCryptoProvider.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using MediaBrowser.Model.Cryptography;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// An <see cref="ICryptoProvider"/> that keeps every plaintext it was asked to hash, for the tests that
+/// have to assert something about the password the provisioning path invents rather than merely that a
+/// hash was produced (#1440). <see cref="FakeCryptoProvider"/> returns one constant hash for every input,
+/// so a test built on it cannot tell a random password from a hard-coded one - which is the exact
+/// distinction the door this class exists to prove is made of.
+/// </summary>
+/// <remarks>
+/// The produced hash embeds the plaintext bytes, so <c>User.Password</c> differs whenever the plaintext
+/// does. That makes the assertions readable on the persisted field as well as on the recording. It is a
+/// test double and hashes nothing: never use this shape anywhere but in the suite.
+/// </remarks>
+internal sealed class RecordingCryptoProvider : ICryptoProvider
+{
+    private readonly List<string> _hashed = new();
+
+    /// <summary>Gets every plaintext handed to <see cref="CreatePasswordHash"/>, in call order.</summary>
+    internal IReadOnlyList<string> Hashed => _hashed;
+
+    /// <inheritdoc />
+    public string DefaultHashMethod => "PBKDF2-SHA512";
+
+    /// <inheritdoc />
+    public PasswordHash CreatePasswordHash(ReadOnlySpan<char> password)
+    {
+        var plaintext = password.ToString();
+        _hashed.Add(plaintext);
+        return new PasswordHash(DefaultHashMethod, Encoding.UTF8.GetBytes(plaintext));
+    }
+
+    /// <inheritdoc />
+    public bool Verify(PasswordHash hash, ReadOnlySpan<char> password) => true;
+
+    /// <inheritdoc />
+    public byte[] GenerateSalt() => Array.Empty<byte>();
+
+    /// <inheritdoc />
+    public byte[] GenerateSalt(int length) => new byte[length];
+}


### PR DESCRIPTION
# What & why

An account this plugin creates would be reachable from the ordinary login form
without the identity provider if it carried no password: Jellyfin creates a user
with none, and a user with none accepts the empty one. That is the class #1440
reports.

On `main` the create arm of `CanonicalLinkService` already closes that door
twice, and neither write had a test:

```
$ git grep -n "AuthenticationProviderId = SsoManagedProviderId\|CreatePasswordHash" origin/main -- SSO-Auth/Api/Linking/CanonicalLinkService.cs
origin/main:SSO-Auth/Api/Linking/CanonicalLinkService.cs:633:        user.AuthenticationProviderId = SsoManagedProviderId.Value;
origin/main:SSO-Auth/Api/Linking/CanonicalLinkService.cs:649:        user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
$ git grep -c "SsoManagedProviderId.Value\|CreatePasswordHash" origin/main -- SSO-Auth.Tests/Linking/
$ echo "exit=$?"
exit=1
```

So both lines could have been deleted, or the password reduced to a constant,
and every route in this tree stayed green. This change ends that state and
changes no behaviour.

Five tests in `SSO-Auth.Tests/Linking/ProvisionedAccountPasswordDoorTests.cs`:
the stamped provider id is one that resolves to no registered password provider;
a created account carries a stored password of at least 64 characters of
plaintext entropy; two created accounts do not share one; the pending-approval
arm persists an account with both doors already shut; and an already-linked
account keeps the password and the provider routing its owner chose.

`RecordingCryptoProvider` exists because the suite's `FakeCryptoProvider` returns
one constant hash for every input, so a test built on it cannot tell a random
password from a hard-coded one - the exact distinction this door is made of.

This is the unit-level half of the third part of the direction on #1440. It does
not close that issue: the one-time sweep over accounts created before this, and
the end-to-end leg against a running server, are not in it.

Refs #1440

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No validation path is touched; the diff
      is two test files and adds no production code.
- [x] No secrets logged; secrets are redacted on config export. The tests assert
      on the length and the distinctness of the provisioned plaintext, never on
      its value, and nothing is logged.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second
      reader looked at this change, and no lens was run on it. What stands in
      place of one is written below.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
      **No record exists, because no review was run.**
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is added or moved.

In place of a second reader, each test was proven by breaking what it covers.
Run at the head of this branch, on `net9.0`:

```
$ # the provider stamp deleted from CanonicalLinkService.cs:633
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "...ProvisionedAccountPasswordDoorTests"
    ...NewAccount_IsStampedOffJellyfinsNativePasswordProvider [FAIL]
    ...PendingApprovalAccount_IsPersistedWithBothDoorsAlreadyShut [FAIL]
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,400s

$ # the password write deleted from CanonicalLinkService.cs:649
    ...NewAccount_GetsAStoredPasswordAndItIsNotTheEmptyOne [FAIL]
    ...PendingApprovalAccount_IsPersistedWithBothDoorsAlreadyShut [FAIL]
    ...TwoNewAccounts_DoNotShareAPassword [FAIL]
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 3, Skipped: 0, Not Run: 0, Time: 0,403s

$ # the near-miss: both writes applied on the UseExistingLink arm too
    ...AlreadyLinkedAccount_KeepsItsOwnPasswordAndProviderRouting [FAIL]
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0, Time: 0,423s
```

The near-miss is the mistake somebody hardening this would actually make -
shutting the door on every login rather than only on creation - and it reddens
exactly the one test that stops it from locking an administrator out of an
account they deliberately left on the native password provider.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      This change establishes no structural property; it adds no production code.
- [x] Docs impact considered: this change needs no README/wiki update. Nothing
      user-facing moves, and the CHANGELOG is left alone for the same reason -
      the behaviour it would describe already shipped.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings, build SUCCEEDED before each run below.
- [x] `dotnet test` is green.

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3473, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,125s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3474, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 37,635s
```

The four skips are the four the suite already skips on this host: they bind a
listener off loopback, which needs an administrator (#1227). They were not
worked around, and the skip is disclosed here rather than filtered out.

Both runs were kept whole rather than filtered to the summary line, which is what
#1444 asks of every full run on this target framework.

- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. There is
      none; the diff is two `.cs` files.

## Notes

What this does NOT cover, and what stays open on #1440:

- The one-time migration sweep over accounts created before this, which is the
  second part of the direction on that issue. Nothing here touches an existing
  account, and the fail-safe test above deliberately pins that it must not.
- The end-to-end leg that creates a user through the SSO path against a running
  server and asserts the manual form refuses the empty password. This host has no
  Docker engine, so that leg cannot be exercised here at all.
- Whether the reported class reproduces against a real 10.11.11 server on
  4.3.0.47. Nothing here was run against a server; every claim above is a unit
  test or a reading of this tree.
