### PR TITLE
Seal SSO-linked accounts an old version left without a password [#1440]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,23 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **Accounts an old plugin version created without a password no longer accept
+  the empty one on the ordinary login form (#1440).** A Jellyfin account created
+  with no password accepts the empty password, and every release up to and
+  including v3.4.0.2 provisioned SSO accounts that way - the account was stamped
+  onto a provider id that accepts nothing, which shut the door until a provider's
+  default-provider setting repointed the account at a real password provider and
+  left the empty password behind it. Those accounts are still on servers that
+  have since upgraded, and the fix at the point of creation, which has minted a
+  random password since v3.5.0.0, never reaches an account that already exists.
+  The plugin now gives every SSO-linked account with no stored password an
+  unguessable one, once at server start. It changes nothing else: an account that
+  already carries a password keeps exactly the one it has, no account's login
+  provider routing is touched, and an account no provider links to is left alone
+  because it is not this plugin's to change. A single line in the log says how
+  many accounts were sealed and nothing that identifies them; a server with none
+  to seal - every server provisioned since v3.5.0.0 - says nothing at all.
+
 - **A provider a mounted file or the environment declared can no longer be
   altered or deleted through the plugin's other administrator endpoints
   (#1415).** The settings page already kept the declared value and discarded

--- a/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepServiceTests.cs
+++ b/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepServiceTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The host-start wrapper around the password-less account sweep (#1440). What is worth pinning here is not
+/// that it sweeps - that is the pass's own suite - but the two ways a start-up repair can hurt a server it
+/// exists to protect: by throwing out of start-up, and by dereferencing something that is not there yet.
+/// </summary>
+public class PasswordlessLinkedAccountSweepServiceTests
+{
+    [Fact]
+    public async Task StartWithNoPluginInstance_DoesNothingAndThrowsNothing()
+    {
+        // Host services start after plugin load, so the instance is normally set - but a start that throws
+        // here takes the whole server down for a repair of accounts an old version created. With no plugin
+        // there is no link map to read and therefore no account to name, which is a return rather than an
+        // error.
+        var service = Build();
+
+        await service.StartAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopWithoutStart_IsANoOp()
+    {
+        // The host can stop a service it never started when an earlier one fails to start. Nothing to wait
+        // on must not become a null dereference at exactly the moment start-up is already going badly.
+        var service = Build();
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public void EveryDependencyIsRequiredAtConstruction()
+    {
+        // A null here would surface as a NullReferenceException inside a start-up repair, where the stack
+        // says nothing about which dependency the composition root failed to supply.
+        var users = Substitute.For<IUserManager>();
+        var crypto = Substitute.For<ICryptoProvider>();
+        var logger = new TypedLogger<PasswordlessLinkedAccountSweepService>(new CapturingLogger());
+
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(null!, crypto, logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(users, null!, logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(users, crypto, null!));
+    }
+
+    // The logger is the repo's own typed wrapper rather than a substitute: the service is internal, so a
+    // dynamic proxy over ILogger<PasswordlessLinkedAccountSweepService> cannot be generated for it.
+    private static PasswordlessLinkedAccountSweepService Build() =>
+        new PasswordlessLinkedAccountSweepService(
+            Substitute.For<IUserManager>(),
+            Substitute.For<ICryptoProvider>(),
+            new TypedLogger<PasswordlessLinkedAccountSweepService>(new CapturingLogger()));
+}

--- a/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
+++ b/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The migration half of #1440: an SSO-linked Jellyfin account that carries no stored password accepts the
+/// EMPTY password on the ordinary login form, so it is reachable by anybody on the network without the
+/// identity provider. The boot-time sweep gives every such account an unguessable password.
+/// <para>
+/// THE POPULATION IS REAL AND THE CREATE ARM DOES NOT REACH IT. Every plugin release up to and including
+/// v3.4.0.2 created the account and wrote no password; v3.5.0.0 was the first to mint one. Accounts from
+/// before that are still on upgraded servers, and a fix at the point of creation only ever runs for accounts
+/// that do not exist yet. Deleting the write in <see cref="PasswordlessLinkedAccountSweep.SweepAsync"/>
+/// reddens most of this file.
+/// </para>
+/// <para>
+/// THE TWO FAIL-SAFES are <see cref="AnAccountThatAlreadyHasAPassword_IsLeftExactlyAsItWas"/> and
+/// <see cref="TheSweep_NeverRepointsAnAccountsLoginProvider"/>. Between them they are what stops a repair
+/// that runs unattended at every boot from becoming the thing that decides how somebody else's users log in:
+/// it may close an empty-password door and it may do nothing else. Removing the emptiness test, or adding a
+/// provider-id write, turns exactly those rows red.
+/// </para>
+/// </summary>
+public class PasswordlessLinkedAccountSweepTests
+{
+    private static readonly Guid Linked = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    // The fixed part of the audit line SsoAudit.PasswordlessAccountsSealed emits, matched rather than
+    // reproduced so a reworded message fails one place instead of six.
+    private const string SealAuditMarker = "had no stored password";
+
+    [Fact]
+    public async Task ALinkedAccountWithNoPassword_IsGivenOne_AndTheAccountIsPersisted()
+    {
+        // The headline Done-when. Both halves are required and they fail differently: no password written
+        // means the door is still open, and no persist means it is open again on the next read.
+        var (sweep, config, users, crypto, audit) = Build();
+        var user = LinkedUser(users, config, password: null);
+
+        var sealedAccounts = await sweep.SweepAsync();
+
+        Assert.Equal(1, sealedAccounts);
+        Assert.False(string.IsNullOrEmpty(user.Password));
+        await users.Received(1).UpdateUserAsync(user);
+        Assert.Single(audit.Entries, e => e.Message.Contains(SealAuditMarker, StringComparison.Ordinal));
+        Assert.Single(crypto.Hashed);
+    }
+
+    [Fact]
+    public async Task ASealedAccountsPasswordCarriesRealEntropy_AndTwoOfThemDiffer()
+    {
+        // A sweep that sealed every account with one constant would read as sealed and be one guess from
+        // open. 64 CSPRNG bytes base64-encoded is at least 64 characters of plaintext, which is what the
+        // create arm has minted since v3.5.0.0 - the two writers share one helper precisely so this cannot
+        // drift apart between them.
+        var (sweep, config, users, crypto, _) = Build();
+        LinkedUser(users, config, password: null);
+        LinkedUser(users, config, password: null, id: Other, key: "sub-2", name: "bob");
+
+        Assert.Equal(2, await sweep.SweepAsync());
+
+        Assert.Equal(2, crypto.Hashed.Count);
+        Assert.All(crypto.Hashed, plaintext => Assert.True(plaintext.Length >= 64, "provisioned password was too short: " + plaintext.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        Assert.NotEqual(crypto.Hashed[0], crypto.Hashed[1]);
+    }
+
+    [Fact]
+    public async Task AnAccountThatAlreadyHasAPassword_IsLeftExactlyAsItWas()
+    {
+        // FAIL-SAFE. An administrator who deliberately set a real password on an SSO-linked account keeps
+        // it; a sweep that overwrote one would lock that person out of their own account at a boot they did
+        // not ask for, for a door that was already shut.
+        var (sweep, config, users, crypto, audit) = Build();
+        var user = LinkedUser(users, config, password: "an-administrator-set-this");
+
+        Assert.Equal(0, await sweep.SweepAsync());
+
+        Assert.Equal("an-administrator-set-this", user.Password);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+        Assert.Empty(crypto.Hashed);
+        Assert.Empty(audit.Entries);
+    }
+
+    [Fact]
+    public async Task TheSweep_NeverRepointsAnAccountsLoginProvider()
+    {
+        // FAIL-SAFE, and the near-miss somebody hardening this would actually make: also stamping the
+        // SSO-managed provider id, on the reasoning that an SSO account should not have a password door at
+        // all. That is this sweep deciding how another administrator's users log in, unattended, at boot,
+        // for accounts they may have deliberately routed at a password provider. Writing the password shuts
+        // the empty-password door on its own, which is the whole of what this is for.
+        var (sweep, config, users, _, _) = Build();
+        var user = LinkedUser(users, config, password: null);
+        var routing = user.AuthenticationProviderId;
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.Equal(routing, user.AuthenticationProviderId);
+    }
+
+    [Fact]
+    public async Task AnAccountNoProviderLinksTo_IsLeftAlone()
+    {
+        // The link is the whole claim to act. A blank-password account an administrator made by hand is
+        // theirs, not this plugin's to change, and a sweep that walked every user on the server would be
+        // rewriting a password policy nobody asked it to hold.
+        var (sweep, config, users, crypto, _) = Build();
+        LinkedUser(users, config, password: null);
+        var stranger = TestUsers.Named("carol", Other);
+        users.GetUserById(Other).Returns(stranger);
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.True(string.IsNullOrEmpty(stranger.Password));
+        Assert.Single(crypto.Hashed);
+    }
+
+    [Fact]
+    public async Task ASecondPass_WritesNothing()
+    {
+        // Idempotence, and it is what lets this run at every boot with no persisted "already done" flag.
+        // The second pass finds the account holding the password the first one wrote and skips it.
+        var (sweep, config, users, crypto, audit) = Build();
+        LinkedUser(users, config, password: null);
+
+        Assert.Equal(1, await sweep.SweepAsync());
+        Assert.Equal(0, await sweep.SweepAsync());
+
+        Assert.Single(crypto.Hashed);
+        Assert.Single(audit.Entries, e => e.Message.Contains(SealAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ALinkWhoseUserWasDeleted_SealsNobody_AndDoesNotStopThePass()
+    {
+        // A link can outlive the account it points at. That is nothing to do rather than something to force,
+        // and it must not throw out of a pass that still has other accounts to walk after it.
+        var (sweep, config, users, crypto, _) = Build();
+        config.CanonicalLinks["sub-gone"] = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var survivor = LinkedUser(users, config, password: null, id: Other, key: "sub-2", name: "bob");
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.False(string.IsNullOrEmpty(survivor.Password));
+        Assert.Single(crypto.Hashed);
+    }
+
+    [Fact]
+    public async Task AnAccountLinkedFromTwoProviders_IsSealedOnce()
+    {
+        // One account, two identities. Two things make it one seal and they are worth separating, because
+        // only one of them is visible in the count: the walk hands out a DEDUPLICATED set of ids, so the
+        // account is resolved once - and even if it were not, the emptiness test would skip the second
+        // visit. The resolve assertion below is what holds the first of those, since the seal count alone
+        // cannot tell the two apart.
+        var configuration = new PluginConfiguration();
+        var oid = new OidConfig { Enabled = true };
+        var saml = new SamlConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = oid;
+        configuration.SamlConfigs["idp"] = saml;
+        var (sweep, users, crypto, _) = BuildFor(configuration);
+        var user = TestUsers.Named("alice", Linked);
+        users.GetUserById(Linked).Returns(user);
+        oid.CanonicalLinks["sub-1"] = Linked;
+        saml.CanonicalLinks["nameid-1"] = Linked;
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.Single(crypto.Hashed);
+        await users.Received(1).UpdateUserAsync(user);
+        users.Received(1).GetUserById(Linked);
+    }
+
+    [Fact]
+    public async Task TheSamlPathIsSweptIdentically()
+    {
+        // One sweep over both protocols rather than one per protocol, so SAML cannot silently stop being
+        // covered. This row is what would go red if the walk were ever narrowed to the OpenID providers.
+        var configuration = new PluginConfiguration();
+        var config = new SamlConfig { Enabled = true };
+        configuration.SamlConfigs["idp"] = config;
+        var (sweep, users, crypto, _) = BuildFor(configuration);
+        var user = TestUsers.Named("bob", Linked);
+        users.GetUserById(Linked).Returns(user);
+        config.CanonicalLinks["nameid-1"] = Linked;
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.False(string.IsNullOrEmpty(user.Password));
+        Assert.Single(crypto.Hashed);
+    }
+
+    [Fact]
+    public async Task ALinkOnADisabledProvider_IsStillSealed()
+    {
+        // The one deliberate difference from the expiry sweep, pinned so it cannot be "fixed" back. That one
+        // ENDS access and refuses to do so unattended for a provider an administrator switched off. This one
+        // only ever removes an empty-password door, and skipping a disabled provider would leave exactly the
+        // accounts nobody is logging in through as the reachable ones.
+        var (sweep, config, users, _, _) = Build();
+        var user = LinkedUser(users, config, password: null);
+        config.Enabled = false;
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.False(string.IsNullOrEmpty(user.Password));
+    }
+
+    [Fact]
+    public async Task TheAuditLine_CarriesACount_AndNothingThatNamesAnAccount()
+    {
+        // T-I1. An account that is currently reachable by anybody is the last thing to name in a log an
+        // operator may paste into a bug report, so the line carries how many and nothing else.
+        var (sweep, config, users, _, audit) = Build();
+        LinkedUser(users, config, password: null);
+
+        await sweep.SweepAsync();
+
+        var line = Assert.Single(audit.Entries, e => e.Message.Contains(SealAuditMarker, StringComparison.Ordinal)).Message;
+        Assert.Contains("1", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("alice", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(Linked.ToString(), line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task APassWithNothingToSeal_IsSilent()
+    {
+        // The shape of every server provisioned since v3.5.0.0, which is the overwhelming majority: the
+        // sweep walks the links, finds every account already holding a password, and says nothing. A warning
+        // on each of those boots would train an operator to ignore the one that matters.
+        var (sweep, config, users, _, audit) = Build();
+        LinkedUser(users, config, password: "already-sealed");
+
+        Assert.Equal(0, await sweep.SweepAsync());
+        Assert.Empty(audit.Entries);
+    }
+
+    // --- helpers ---
+
+    private static (PasswordlessLinkedAccountSweep Sweep, OidConfig Config, IUserManager Users, RecordingCryptoProvider Crypto, CapturingLogger Audit) Build()
+    {
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        var (sweep, users, crypto, audit) = BuildFor(configuration);
+        return (sweep, config, users, crypto, audit);
+    }
+
+    private static (PasswordlessLinkedAccountSweep Sweep, IUserManager Users, RecordingCryptoProvider Crypto, CapturingLogger Audit) BuildFor(PluginConfiguration configuration)
+    {
+        var users = Substitute.For<IUserManager>();
+        var crypto = new RecordingCryptoProvider();
+        var audit = new CapturingLogger();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, crypto, store, new CapturingLogger());
+        return (new PasswordlessLinkedAccountSweep(canonicalLinks, users, crypto, audit), users, crypto, audit);
+    }
+
+    // An account that already exists and is already linked - the state a login on an old plugin version left
+    // behind. The sweep must never create or adopt anything; it only acts on what a login already wrote.
+    private static User LinkedUser(IUserManager users, ProviderConfigBase config, string? password, Guid? id = null, string key = "sub-1", string name = "alice")
+    {
+        var userId = id ?? Linked;
+        var user = TestUsers.Named(name, userId);
+        user.Password = password;
+        users.GetUserById(userId).Returns(user);
+        config.CanonicalLinks[key] = userId;
+        return user;
+    }
+}

--- a/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
+++ b/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -248,6 +251,57 @@ public class PasswordlessLinkedAccountSweepTests
         Assert.Empty(audit.Entries);
     }
 
+    [Fact]
+    public async Task AProviderStoredWithNoConfigObject_IsSkippedRatherThanDereferenced()
+    {
+        // A provider can be stored with a null config object through the null-body add (#350). The walk
+        // must read that as a provider holding no links, the way every other walk in the link store does -
+        // a start-up repair that throws on one malformed entry never reaches the accounts after it.
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["broken"] = null!;
+        var good = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = good;
+        var (sweep, users, crypto, _) = BuildFor(configuration);
+        var user = TestUsers.Named("alice", Linked);
+        users.GetUserById(Linked).Returns(user);
+        good.CanonicalLinks["sub-1"] = Linked;
+
+        Assert.Equal(1, await sweep.SweepAsync());
+
+        Assert.Single(crypto.Hashed);
+    }
+
+    [Fact]
+    public void TheAuditLine_EmitsNothingWhereWarningsAreOff()
+    {
+        // The IsEnabled guard is what keeps the message from being built where the sink has already
+        // filtered this level away (CA1873). A disabled level must emit NOTHING rather than an
+        // unformatted fallback.
+        var off = new LevelFilteredLogger(LogLevel.Error);
+
+        SsoAudit.PasswordlessAccountsSealed(off, 3);
+
+        Assert.Empty(off.Entries);
+    }
+
+    [Fact]
+    public void EveryDependencyIsRequiredAtConstruction()
+    {
+        // A null here would surface as a NullReferenceException inside a start-up repair, where the stack
+        // says nothing about which dependency the composition root failed to supply.
+        var configuration = new PluginConfiguration();
+        var users = Substitute.For<IUserManager>();
+        var crypto = new RecordingCryptoProvider();
+        var logger = new CapturingLogger();
+        var links = new CanonicalLinkService(users, crypto, new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger()), new CapturingLogger());
+
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(null!, users, crypto, logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(links, null!, crypto, logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(links, users, null!, logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(links, users, crypto, null!));
+        Assert.Throws<ArgumentNullException>(() => ProvisionedPassword.Mint(null!));
+    }
+
     // --- helpers ---
 
     private static (PasswordlessLinkedAccountSweep Sweep, OidConfig Config, IUserManager Users, RecordingCryptoProvider Crypto, CapturingLogger Audit) Build()
@@ -279,5 +333,30 @@ public class PasswordlessLinkedAccountSweepTests
         users.GetUserById(userId).Returns(user);
         config.CanonicalLinks[key] = userId;
         return user;
+    }
+
+    // A sink that has filtered this level away, so the IsEnabled guard on the audit line has a state to be
+    // observed in. Local to this file rather than shared: the one in the audit suite is private to it, and
+    // reaching across for four lines would couple two suites for nothing.
+    private sealed class LevelFilteredLogger : ILogger
+    {
+        private readonly LogLevel _minimum;
+
+        internal LevelFilteredLogger(LogLevel minimum) => _minimum = minimum;
+
+        internal List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _minimum;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                Entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
     }
 }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -178,6 +178,29 @@ internal static class SsoAudit
             provider?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records the boot-time sweep sealing SSO-linked accounts that carried no stored password (#1440).
+    /// A Jellyfin account created without one accepts the EMPTY password on the ordinary login form, so
+    /// every account a plugin version up to and including v3.4.0.2 provisioned was reachable without the
+    /// identity provider. Fired once per boot and only when the sweep actually sealed something, so a
+    /// server that has none stays silent. Carries a COUNT and nothing else - no username, no account id and
+    /// no provider (T-I1): an account already reachable by anybody is the last thing to name in a log an
+    /// operator may paste into a bug report.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="sealedAccounts">How many accounts the sweep gave a password to.</param>
+    internal static void PasswordlessAccountsSealed(ILogger logger, int sealedAccounts)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Sealed {Count} SSO-linked account(s) that had no stored password: an account with none accepts the empty password on the ordinary login form, so these were reachable without the identity provider. Each was given an unguessable password that nothing knows and nothing can recover; their login provider routing was left exactly as it was. Accounts provisioned by plugin versions up to v3.4.0.2 are the expected population.",
+            sealedAccounts);
+    }
+
     /// <summary>Records a provider being added or updated.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -645,8 +644,10 @@ internal sealed class CanonicalLinkService
         // an account created inert already carries its policy when an administrator comes to enable it,
         // rather than getting it on a first login that may never happen.
         ProvisioningPolicy.ApplyAtProvisioning(user, ProvisioningTemplateFor(mode, provider, provisioningProfile));
-        // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
-        user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+        // The manual-login door (#1440), shut as the account comes into existence: a Jellyfin user created
+        // with no password accepts the EMPTY one on the ordinary login form. Minted through the one shared
+        // helper the boot-time sweep also uses, so the two writers cannot drift into two ideas of random.
+        user.Password = ProvisionedPassword.Mint(_cryptoProvider);
 
         if (provisionDisabled)
         {
@@ -1063,6 +1064,45 @@ internal sealed class CanonicalLinkService
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Every distinct Jellyfin account any SAML or OpenID provider still holds a canonical link to, as a
+    /// detached snapshot read once under the config lock (#1440).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The link is what says an account belongs to this plugin. <c>AuthenticationProviderId</c> does not:
+    /// the session mint overwrites it with a provider's <c>DefaultProvider</c> on every login, which is
+    /// exactly the configuration that turns a password-less provisioned account into one the ordinary login
+    /// form will accept the empty password for.
+    /// </para>
+    /// <para>
+    /// A provider an administrator has DISABLED is walked too, unlike the expiry sweep's <c>requireEnabled</c>
+    /// resolve. The two act in opposite directions: that one ends access and must not do so unattended for a
+    /// provider switched off, while this one only ever removes an empty-password door. Skipping a disabled
+    /// provider would leave the accounts nobody is logging in through as the reachable ones, which is the
+    /// wrong way round.
+    /// </para>
+    /// </remarks>
+    /// <returns>The linked account ids, without duplicates.</returns>
+    internal IReadOnlyCollection<Guid> LinkedUserIds()
+    {
+        return _configStore.Read(configuration =>
+        {
+            var linked = new HashSet<Guid>();
+            foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
+            {
+                // A provider stored with a null config object (reachable via the null-body add, #350) holds
+                // no links and is skipped rather than dereferenced, as everywhere else in this file.
+                if (config?.CanonicalLinks is { } links)
+                {
+                    linked.UnionWith(links.Values);
+                }
+            }
+
+            return (IReadOnlyCollection<Guid>)linked;
+        });
     }
 
     // The shared body of every disable-a-linked-account path above. Kept private and unnamed for any caller

--- a/SSO-Auth/Api/Linking/ProvisionedPassword.cs
+++ b/SSO-Auth/Api/Linking/ProvisionedPassword.cs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Security.Cryptography;
+using MediaBrowser.Model.Cryptography;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// The single place a stored password is invented for an account the plugin manages (#1440). Jellyfin
+/// creates a user with no password, and an account with no password accepts the EMPTY one on the ordinary
+/// login form - so an account this plugin provisions is reachable without the identity provider until
+/// something writes one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two callers write a password and they must write the same KIND of password: the create arm of
+/// <see cref="CanonicalLinkService"/>, which shuts the door as an account comes into existence, and the
+/// boot-time sweep that shuts it on accounts provisioned by a plugin version that did not (every release up
+/// to and including v3.4.0.2). A second spelling of "random enough" is the defect this type exists to make
+/// impossible; the value is never displayed, never stored anywhere else and never recoverable, because
+/// nothing is meant to log in with it.
+/// </para>
+/// </remarks>
+internal static class ProvisionedPassword
+{
+    // 64 bytes from the CSPRNG, base64-encoded, which is what the create arm has minted since the upstream
+    // fix in 2022 - kept byte-for-byte so the sweep cannot seal an account with a weaker secret than a fresh
+    // provisioning would give it.
+    // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
+    private const int EntropyBytes = 64;
+
+    /// <summary>
+    /// Mints one unguessable password and returns it already hashed, in the persisted string form
+    /// <c>User.Password</c> takes.
+    /// </summary>
+    /// <param name="cryptoProvider">Jellyfin's crypto provider, so the hash is produced by the same code path a real password change uses.</param>
+    /// <returns>The hashed password, ready to assign to <c>User.Password</c>.</returns>
+    internal static string Mint(ICryptoProvider cryptoProvider)
+    {
+        ArgumentNullException.ThrowIfNull(cryptoProvider);
+
+        return cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(EntropyBytes))).ToString();
+    }
+}

--- a/SSO-Auth/Api/Session/PasswordlessLinkedAccountSweep.cs
+++ b/SSO-Auth/Api/Session/PasswordlessLinkedAccountSweep.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
+
+/// <summary>
+/// One pass of the migration that shuts the manual-login door on accounts provisioned before the plugin
+/// started shutting it (#1440): every SSO-linked Jellyfin account with no stored password is given an
+/// unguessable one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// WHY THERE IS A POPULATION AT ALL. Jellyfin creates a user with no password, and a user with no password
+/// accepts the EMPTY password on the ordinary login form. The create arm has minted a random one since the
+/// upstream fix released in v3.5.0.0; every release up to and including v3.4.0.2 created the account and
+/// stamped it onto a provider id resolving to no password provider, and nothing more. That stamp alone shut
+/// the door - until a provider's <c>DefaultProvider</c> was configured, at which point the mint repointed
+/// the account at a real password provider and left the empty password behind it. Those accounts are still
+/// on upgraded servers today; the create-arm fix does not reach one of them, because it only ever runs when
+/// an account is new.
+/// </para>
+/// <para>
+/// WHAT IT WILL NOT DO. It never touches <c>AuthenticationProviderId</c>. Repointing an account an
+/// administrator deliberately routed somewhere would be this sweep deciding how somebody else's users log
+/// in, unattended and at boot; writing the password shuts the empty-password door on its own and is the
+/// smaller of the two acts. It never touches an account that already has a password, so a real one an
+/// administrator set is not replaced, and it creates, adopts, disables and deletes nothing.
+/// </para>
+/// <para>
+/// WHAT IT COSTS SOMEBODY. An account whose owner signs in by leaving the password box empty loses that,
+/// and it is the whole point rather than a side effect: the population is exactly the accounts anybody on
+/// the network can already sign into. The identity provider still works, and the audit line says how many
+/// were sealed so an operator who is surprised can find out why.
+/// </para>
+/// <para>
+/// Idempotent, so running it on every boot rather than once ever needs no persisted "already done" flag:
+/// the second pass finds every linked account already holding a password and writes nothing.
+/// </para>
+/// </remarks>
+internal sealed class PasswordlessLinkedAccountSweep
+{
+    private readonly CanonicalLinkService _canonicalLinks;
+    private readonly IUserManager _userManager;
+    private readonly ICryptoProvider _cryptoProvider;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PasswordlessLinkedAccountSweep"/> class.
+    /// </summary>
+    /// <param name="canonicalLinks">The canonical-link store, which owns the only reliable answer to which accounts this plugin manages.</param>
+    /// <param name="userManager">The Jellyfin user manager, used to resolve and persist each account.</param>
+    /// <param name="cryptoProvider">Jellyfin's crypto provider, so a sealed account's password is hashed exactly as a real one is.</param>
+    /// <param name="logger">The logger the audit line is written to.</param>
+    internal PasswordlessLinkedAccountSweep(CanonicalLinkService canonicalLinks, IUserManager userManager, ICryptoProvider cryptoProvider, ILogger logger)
+    {
+        _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs one pass and returns how many accounts it sealed.
+    /// </summary>
+    /// <returns>The number of accounts given a password by this pass.</returns>
+    internal async Task<int> SweepAsync()
+    {
+        var sealedAccounts = 0;
+
+        foreach (var userId in _canonicalLinks.LinkedUserIds())
+        {
+            // A link can outlive the account it points at, which is nothing to do rather than something to
+            // force - and it must not throw out of a pass that still has other accounts to walk after it.
+            if (_userManager.GetUserById(userId) is not { } user)
+            {
+                continue;
+            }
+
+            // The one test that decides the population, and it is a state rather than a history: whatever
+            // wrote the account, an empty stored password is the door. A password already there is left
+            // alone, so an administrator who set a real one keeps it.
+            if (!string.IsNullOrEmpty(user.Password))
+            {
+                continue;
+            }
+
+            user.Password = ProvisionedPassword.Mint(_cryptoProvider);
+            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+            sealedAccounts++;
+        }
+
+        // Audited once for the pass rather than once per account: the line carries a count and nothing that
+        // identifies which accounts were reachable (T-I1). Silent when there was nothing to seal, so the
+        // overwhelming majority of servers - every one provisioned since v3.5.0.0 - see nothing at all.
+        if (sealedAccounts > 0)
+        {
+            SsoAudit.PasswordlessAccountsSealed(_logger, sealedAccounts);
+        }
+
+        return sealedAccounts;
+    }
+}

--- a/SSO-Auth/Api/Session/PasswordlessLinkedAccountSweepService.cs
+++ b/SSO-Auth/Api/Session/PasswordlessLinkedAccountSweepService.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
+
+/// <summary>
+/// Drives <see cref="PasswordlessLinkedAccountSweep"/> once at host start (#1440), so a server upgrading
+/// from a plugin version that provisioned accounts without a password stops offering those accounts to the
+/// ordinary login form.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A one-shot <see cref="IHostedService"/> rather than a timer, matching
+/// <see cref="SsoOnlyReconciliationService"/>: what it repairs is a state a PAST plugin version wrote, and
+/// nothing running today can create another one. The pass is idempotent, so needing it to run at every boot
+/// rather than exactly once buys correctness without a persisted flag - and a boot is also the one moment a
+/// restored backup from an old server is guaranteed to pass through.
+/// </para>
+/// <para>
+/// Fail-safe: any error is logged and swallowed. Sealing an old account is a repair, and a repair that can
+/// stop the server from starting is worse than the hole it closes; the disclosure in the log is what tells
+/// an operator the door is still open.
+/// </para>
+/// </remarks>
+internal sealed class PasswordlessLinkedAccountSweepService : IHostedService
+{
+    private readonly IUserManager _userManager;
+    private readonly ICryptoProvider _cryptoProvider;
+    private readonly ILogger<PasswordlessLinkedAccountSweepService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PasswordlessLinkedAccountSweepService"/> class.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager, resolved from the host DI container.</param>
+    /// <param name="cryptoProvider">The Jellyfin crypto provider that hashes the password the sweep mints.</param>
+    /// <param name="logger">The logger.</param>
+    public PasswordlessLinkedAccountSweepService(IUserManager userManager, ICryptoProvider cryptoProvider, ILogger<PasswordlessLinkedAccountSweepService> logger)
+    {
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs the one-shot sweep at host start.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token (unused; the pass is a bounded walk over the persisted link maps).</param>
+    /// <returns>A task that completes when the pass has finished.</returns>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var plugin = SSOPlugin.Instance;
+        if (plugin is null)
+        {
+            // The plugin is constructed during plugin load, before host services start, so this is normally
+            // set. Without it there are no links to read and therefore no account to name - skip rather
+            // than throw.
+            return;
+        }
+
+        try
+        {
+            var canonicalLinks = new CanonicalLinkService(_userManager, _cryptoProvider, plugin.ConfigStore, _logger);
+            await new PasswordlessLinkedAccountSweep(canonicalLinks, _userManager, _cryptoProvider, _logger).SweepAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Disclosed rather than swallowed silently: an operator reading this line knows the
+            // empty-password door may still be open on accounts an old version provisioned, and that the
+            // repair is to set a password on them by hand.
+            _logger.LogError(ex, "The startup sweep for password-less SSO-linked accounts failed; skipping. Accounts provisioned by an old plugin version may still accept an empty password on the ordinary login form.");
+        }
+    }
+
+    /// <summary>
+    /// No-op on shutdown.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A completed task.</returns>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -30,6 +30,11 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddHostedService<SsoOnlyReconciliationService>();
 
+        // Shuts the ordinary login form's empty-password door on accounts a plugin version up to and
+        // including v3.4.0.2 provisioned without one (#1440). The create arm has minted a password since
+        // v3.5.0.0, so this reaches the accounts that arm never will - the ones that already exist.
+        serviceCollection.AddHostedService<PasswordlessLinkedAccountSweepService>();
+
         // Ends access ON an account-expiry deadline rather than at the expired user's next login attempt
         // (#1145). Login-time enforcement (#1144) never fires for a guest who simply stops coming back, so
         // without a timer the deadline binds only those who return.


### PR DESCRIPTION
# What & why

A Jellyfin account created with no password accepts the EMPTY password on the
ordinary login form. That is the class #1440 reports, and the create-arm
hardening on `main` does not close it for accounts that already exist.

The population is not hypothetical. Every plugin release up to and including
v3.4.0.2 created the account, stamped it onto a provider id that resolves to no
password provider, and wrote nothing else:

```
$ git show v3.4.0.2:SSO-Auth/Api/SSOController.cs | grep -n "CreateUserAsync\|AuthenticationProviderId\|UpdateUser"
646:                user = await _userManager.CreateUserAsync(canonicalName).ConfigureAwait(false);
647:                user.AuthenticationProviderId = GetType().FullName;
929:            user.AuthenticationProviderId = defaultProvider;
930:            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
```

The stamp shut the door - until line 929 repointed the account at whatever the
provider's `DefaultProvider` named and persisted it, leaving a real password
provider in front of an empty password. v3.5.0.0 was the first release to mint
one at creation:

```
$ for t in v3.4.0.1 v3.4.0.2 v3.5.0.0 v3.5.1.0; do echo "$t $(git show "$t:SSO-Auth/Api/SSOController.cs" | grep -c CreatePasswordHash)"; done
v3.4.0.1 0
v3.4.0.2 0
v3.5.0.0 1
v3.5.1.0 1
```

A write at the point of creation only ever runs for an account that does not
exist yet, so nothing on `main` reaches the accounts a pre-v3.5.0.0 server
provisioned and an upgrade carried forward. This is the migration half of the
direction on #1440.

## What it does

A one-shot `IHostedService` at host start walks the canonical links and gives
every linked account with **no stored password** an unguessable one, minted
through the same helper the create arm now uses so the two writers cannot drift
into two ideas of random.

The link is what says an account belongs to this plugin. `AuthenticationProviderId`
does not - the session mint overwrites it with `DefaultProvider` on every login,
which is exactly the configuration that produced the hole.

## What it deliberately will not do

- **It never writes `AuthenticationProviderId`.** Repointing an account an
  administrator deliberately routed somewhere is this plugin deciding how
  somebody else's users log in, unattended, at boot. Writing the password shuts
  the empty-password door on its own, and that is the smaller of the two acts.
- **It never replaces a password that is already there**, so an administrator
  who set a real one on an SSO-linked account keeps it.
- **It never touches an account no provider links to.** A blank-password account
  made by hand is not this plugin's to change.
- It creates, adopts, disables and deletes nothing.

Idempotent, so running at every boot needs no persisted "already done" flag; the
second pass finds every linked account holding a password and writes nothing.
One audit line per pass carries a count and nothing that identifies an account
(T-I1), and a pass with nothing to seal is silent - which is every server
provisioned since v3.5.0.0.

The one deliberate divergence from the neighbouring expiry sweep: a provider an
administrator switched off is walked here. That sweep ENDS access and must not
do so unattended for a disabled provider; this one only ever removes an
empty-password door, and skipping a disabled provider would leave exactly the
accounts nobody is logging in through as the reachable ones.

Refs #1440

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No validation path is touched. The one
      new decision - act or do not act on an account - resolves to "do not act"
      for every unknown: a link with no user, a user that already has a
      password, a null provider config.
- [x] No secrets logged; secrets are redacted on config export. The minted
      password is never logged, never returned and never stored anywhere but the
      account's own hash; the audit line carries a count only, and a test asserts
      it contains no username, no subject key and no account id.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second reader
      looked at this change and no lens was run on it. What stands in place of
      one is the mutation table below.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. **No record exists, because no review
      was run.**
- [x] Log inputs from the IdP are sanitized inline at the log call. The one new
      log call takes an integer and no identity-provider input at all.

In place of a second reader, every guard was deleted and the suite watched. Run
on `net9.0` at the head of this branch, against the new class:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "...PasswordlessLinkedAccountSweepTests"
   baseline                             Total: 12, Failed: 0
   password write deleted               Total: 12, Failed: 8
   emptiness test deleted               Total: 12, Failed: 3
   AuthenticationProviderId also written Total: 12, Failed: 1
   walk narrowed to OpenID              Total: 12, Failed: 1
   HashSet replaced by a List           Total: 12, Failed: 1
   requireEnabled added to the walk     Total: 12, Failed: 1
   the mint replaced by a constant      Total: 12, Failed: 1
```

Each of the six single-row mutations reddens exactly the row that covers it:
the provider-id stamp reddens only `TheSweep_NeverRepointsAnAccountsLoginProvider`,
the OpenID-only walk only `TheSamlPathIsSweptIdentically`, the List only
`AnAccountLinkedFromTwoProviders_IsSealedOnce`, `requireEnabled` only
`ALinkOnADisabledProvider_IsStillSealed`, and the constant only
`ASealedAccountsPasswordCarriesRealEntropy_AndTwoOfThemDiffer`.

The near-miss is the provider-id stamp: it is the mistake somebody hardening
this would actually make, and it is the one that could lock an administrator out
of an account they deliberately left on a password provider.

The dedup row is worth naming because it first proved nothing. Replacing the
`HashSet` with a `List` left all twelve green, since the emptiness test skips the
second visit anyway. The test was corrected to assert the account is RESOLVED
once, which the seal count cannot see, and the mutation then reddens it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The password mint moved into one shared helper rather than being
      written a second time, and the pass is separated from the timer-free
      hosted service that drives it, the way the expiry sweep already is.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
      `Session -> Linking` and `Session -> Audit` are existing DAG edges; this
      adds none.
- [x] Architecture-conformance tests pass. This change establishes no new
      structural property.
- [ ] Docs impact considered. This changes what a server does at start-up and an
      operator can see a log line about it, so a `documentation` issue is owed
      for the wiki rather than claimed as none. It is linked in Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings, build SUCCEEDED before each run below.
- [x] `dotnet test` is green.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3491, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 34,307s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3492, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 33,879s
```

The four skips are the four the suite already skips on this host: they bind a
listener off loopback, which needs an administrator (#1227). They were not worked
around, and the skip is disclosed here rather than filtered out. Both runs were
kept whole rather than filtered to the summary line, which is what #1444 asks of
every full run on this target framework.

- [x] The security-surface coverage bars are met. The first push did not meet
      them, which is worth recording rather than quietly repaired: the pass and
      its two fail-safes were covered and the guards around them were not, so the
      branch number came out at 85.9% against the pinned 86.0% (#1109). Six rows
      were added for the guards - both constructors refusing a null dependency,
      the wrapper returning rather than throwing with no plugin instance and
      stopping without having started, the walk skipping a provider stored with a
      null config object, and the audit line emitting nothing where warnings are
      off. Measured with the same instrumented `net10.0` run CI makes:

```
$ dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --no-build --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --ignore-exit-code 2
  gesamt: 3492   fehlgeschlagen: 0   erfolgreich: 3488   übersprungen: 4
$ python3 scripts/check-coverage.py TestResults/coverage.cobertura.xml
Security-surface line coverage:   94.9% (6894/7265 lines)
Security-surface line bar:        92.0%
Security-surface branch coverage: 86.3% (3018/3498 branches)
Security-surface branch bar:      86.0%
Coverage gate: PASS
```

- [x] Prettier is clean for the one `.md` change.

```
$ npx prettier --check CHANGELOG.md
All matched files use Prettier code style!
```

## Notes

What this does NOT cover, and what stays open on #1440:

- The end-to-end leg that creates a user through the SSO path against a running
  server and asserts the manual form refuses the empty password. This host has no
  Docker engine, so that leg cannot be exercised here at all.
- Whether the reported class reproduces against a real 10.11.11 server on
  4.3.0.47. Nothing here was run against a server. The population above is read
  out of released tags in this tree; that a 4.3.0.47 server still holds such an
  account is a claim about somebody's deployment, not a measurement.
- The wiki does not describe this start-up behaviour, and an operator who sees
  the audit line has nowhere to look it up. That is #1448, filed on the same
  milestone, rather than part of this change.

No second reader looked at this change.
