### PR TITLE
Reproduce and shut the manual-login door on a provisioned account [#1440]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **An account the plugin creates is now stored with the password and the login
+  routing it is given (#1440).** Both were written onto the account object the
+  server handed back at creation and neither reached the database: the session
+  that follows a login re-reads the account by id and saves that copy, so the
+  account was persisted routed at Jellyfin's own password provider with no
+  password stored - which is an account that accepts the EMPTY password on the
+  ordinary login form, reachable by anybody who can reach the server and without
+  ever touching the identity provider. Found by driving a real login against a
+  real server and reading the account back, not by any test in the suite: every
+  one of those asserted on the copy in memory, where both values were always
+  present. One save now carries the routing, the password and - where a provider
+  holds new accounts for approval - the disabled flag, and a save that fails
+  deletes the half-made account instead of leaving it behind enabled and
+  reachable.
+
 - **Accounts an old plugin version created without a password no longer accept
   the empty one on the ordinary login form (#1440).** A Jellyfin account created
   with no password accepts the empty password, and every release up to and

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -130,6 +130,27 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_PolicyOff_PersistFails_RollsBackTheAccountAndFailsClosed()
+    {
+        // The same fail-closed rollback on the ORDINARY arm, which had no persist to fail before #1440. An
+        // account whose persist throws exists, is enabled, carries neither the SSO routing nor a password,
+        // and has no link - reachable from the ordinary login form with the empty password and adoptable by
+        // a later login. Deleting it is the only outcome that leaves nothing behind.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+        users.When(u => u.UpdateUserAsync(created)).Do(_ => throw new InvalidOperationException("db down"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        await users.Received(1).DeleteUserAsync(Other);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
     public async Task ResolveOrCreateAsync_LiveLinkToDisabledAccount_ResolvesWithoutReAuditingProvisioning()
     {
         // The provisioning audit fires only at the create event, never on a later login of the now-pending
@@ -152,10 +173,18 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
-    public async Task ResolveOrCreateAsync_NewAccount_PolicyOff_IsCreatedEnabledAndNotPersistedHere()
+    public async Task ResolveOrCreateAsync_NewAccount_PolicyOff_IsCreatedEnabledAndPersistedHere()
     {
-        // Default (policy off): the new account is NOT disabled and is NOT persisted by the linking layer -
-        // the session minter persists it, exactly as before #737. No behavior change for existing deployments.
+        // THIS ROW ASSERTED THE OPPOSITE UNTIL #1440, AND THE OLD ASSERTION IS THE DEFECT RATHER THAN A
+        // STYLE CHOICE. It required that the create arm persist nothing, on the reasoning that the session
+        // minter would. The minter re-resolves the account by id and writes THAT object, so the provider
+        // stamp and the password set on the instance CreateUserAsync returned reached no database - the
+        // account was persisted routed at Jellyfin's own password provider with no password stored, which
+        // accepts the EMPTY password on the ordinary login form. Every unit test asserted on the in-memory
+        // object, where both writes were always present; the end-to-end harness read the account back after
+        // a real login and found neither.
+        //
+        // Default (policy off): the new account is NOT disabled, and it IS persisted here.
         var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
         var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
@@ -166,7 +195,7 @@ public class CanonicalLinkServiceTests
 
         Assert.Equal(Other, resolved);
         Assert.False(created.HasPermission(PermissionKind.IsDisabled));
-        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+        await users.Received(1).UpdateUserAsync(created);
         Assert.False(service.IsAccountAwaitingApproval(Other));
     }
 

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -649,35 +649,47 @@ internal sealed class CanonicalLinkService
         // helper the boot-time sweep also uses, so the two writers cannot drift into two ideas of random.
         user.Password = ProvisionedPassword.Mint(_cryptoProvider);
 
+        // PERSISTED HERE, once, and this write is the door rather than the two assignments above it (#1440).
+        // The session mint re-resolves the account by id and writes THAT object, so everything set on the
+        // instance CreateUserAsync returned reached no database: the account was persisted routed at
+        // Jellyfin's own password provider with no password stored, which is a Jellyfin account that accepts
+        // the EMPTY password on the ordinary login form. Found by the end-to-end harness reading the account
+        // back after a real login, never by a unit test - every one of them asserts on the in-memory object,
+        // where both writes were always present.
+        //
+        // The pending-approval hold (#737) is applied BEFORE this write rather than after it, so one write
+        // carries the routing, the password and the disabled flag. IsDisabled is otherwise never written by
+        // this plugin and is barred from SSO role mapping (PermissionRolePolicy) precisely so no login can
+        // disable an EXISTING account; this is the one sanctioned write, and it targets ONLY a brand-new
+        // account on this create arm - never an existing or adopted one. No permissions are applied - the
+        // account carries Jellyfin's default new-user policy until an administrator enables it, and the
+        // caller reads the disabled state and refuses the login.
         if (provisionDisabled)
         {
-            // Pending-approval provisioning (#737): create the account inert. IsDisabled is otherwise never
-            // written by this plugin and is barred from SSO role mapping (PermissionRolePolicy) precisely so
-            // no login can disable an EXISTING account; this is the one sanctioned write, and it targets ONLY
-            // a brand-new account on this create arm - never an existing or adopted one. The normal path lets
-            // the session minter persist the account; this deferred path short-circuits before the mint, so it
-            // must persist the disabled flag (and this account's SSO provider id / password) itself. No
-            // permissions are applied - the account carries Jellyfin's default new-user policy until an
-            // administrator enables it. The caller reads the disabled state and refuses the login.
             user.SetPermission(PermissionKind.IsDisabled, true);
-            var persisted = false;
-            try
-            {
-                await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-                persisted = true;
-            }
-            finally
-            {
-                if (!persisted)
-                {
-                    // If persisting the disabled flag failed, the just-created account would otherwise survive
-                    // ENABLED and link-less, and a later login could adopt it (with AllowExistingAccountLink on)
-                    // and mint a session - defeating the hold. Roll it back so the login fails closed with no
-                    // orphan. The original failure still propagates out of this finally.
-                    await _userManager.DeleteUserAsync(user.Id).ConfigureAwait(false);
-                }
-            }
+        }
 
+        var persisted = false;
+        try
+        {
+            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+            persisted = true;
+        }
+        finally
+        {
+            if (!persisted)
+            {
+                // A create whose persist failed leaves an account that exists, is ENABLED, carries neither
+                // the SSO routing nor a password, and has no link - the exact shape this arm exists to
+                // prevent, reachable from the ordinary login form and adoptable by a later login (with
+                // AllowExistingAccountLink on). Roll it back so the login fails closed with no orphan. The
+                // original failure still propagates out of this finally.
+                await _userManager.DeleteUserAsync(user.Id).ConfigureAwait(false);
+            }
+        }
+
+        if (provisionDisabled)
+        {
             // Audited here, at the actual provisioning event, so the line fires exactly once (not on every
             // later refused login of the now-pending account) and is always accurate - the completion-path
             // gate that refuses the login covers any disabled account, including one an admin disabled, so

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1392,6 +1392,36 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
     fail "SSO-only: the password user stayed locked out after disable - restoration failed"
   fi
 
+  # ------------------------------------------------------------------------------------------------
+  # Phase 6e - the manual login form is shut on an account the plugin provisioned (#1440). A Jellyfin
+  # user created with no password accepts the EMPTY password on that form, so an SSO account that got
+  # one would be reachable by anybody on the network without ever touching the identity provider.
+  #
+  # PLACED HERE ON PURPOSE, and the placement is the whole of what makes the assertion mean anything.
+  # It runs AFTER SSO-only was enabled and disabled again, at the one moment the phase above has just
+  # PROVEN that native password login works on this server: pwuser answered 200 one line up. Run
+  # while SSO-only was on, the same three refusals would be produced by the mode rather than by
+  # anything this issue is about, and the phase would pass on a build with the door wide open.
+  # ------------------------------------------------------------------------------------------------
+  log "== Extended: the manual login form is refused for the SSO-provisioned account =="
+
+  EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
+  if [ "$EMPTY_PW_STATUS" != "200" ]; then
+    pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"
+  else
+    fail "provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP"
+  fi
+
+  # The identity provider's own password is not the Jellyfin account's password either. Without this
+  # the phase would still pass on a build that copied the IdP credential onto the account, which is a
+  # different way of leaving a guessable door on it.
+  IDP_PW_STATUS="$(jf_auth_status "alice" "$PASSWORD_ALICE")"
+  if [ "$IDP_PW_STATUS" != "200" ]; then
+    pass "provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP $IDP_PW_STATUS)"
+  else
+    fail "provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form"
+  fi
+
 fi
 
 # --------------------------------------------------------------------------------------------------

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1405,6 +1405,12 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
   # ------------------------------------------------------------------------------------------------
   log "== Extended: the manual login form is refused for the SSO-provisioned account =="
 
+  # Read the account's own record first, so a failure below names the STATE that produced it rather
+  # than leaving the next reader to guess between "no password stored" and "routed at a provider that
+  # accepts one". Both are visible here and they fail for different reasons.
+  ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
+  log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword // "?"') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword // "?"') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId // "?"')"
+
   EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
   if [ "$EMPTY_PW_STATUS" != "200" ]; then
     pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1409,7 +1409,10 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
   # than leaving the next reader to guess between "no password stored" and "routed at a provider that
   # accepts one". Both are visible here and they fail for different reasons.
   ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
-  log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword // "?"') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword // "?"') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId // "?"')"
+  # jq -r, with no // fallback on purpose: `// "?"` takes its alternative for FALSE as well as for absent,
+  # so a stored password of false and a field that is not there would print the same character. That cost a
+  # wrong reading of this very line once; an absent field prints null and a false one prints false.
+  log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId')"
 
   EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
   if [ "$EMPTY_PW_STATUS" != "200" ]; then


### PR DESCRIPTION
# What & why

**#1440 REPRODUCED AGAINST THE CURRENT BUILD, AND THIS PULL REQUEST CARRIES BOTH
THE REPRODUCTION AND THE REPAIR.** It was opened to add the end-to-end leg the
third direction on that issue asks for. The leg's first run went red on `main`,
which is not what anybody expected, so the change grew a second half.

## What the harness found

The new phase drives Jellyfin's own `/Users/AuthenticateByName` for `alice` -
the account a real Keycloak OIDC login had just provisioned - with the EMPTY
password. On `3e8a305`, with no plugin change on the branch:

```
harness-1 | == Extended: the manual login form is refused for the SSO-provisioned account ==
harness-1 | alice: HasPassword=? HasConfiguredPassword=? AuthenticationProviderId=Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider
harness-1 | FAIL: provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP
harness-1 | PASS: provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP 401)
harness-1 | E2E CHECKS FAILED: 1 assertion(s) did not hold
```

(The two `?` are a `jq -r '… // "?"'` taking its alternative for `false` as well
as for absent - the field was `false`, not missing. The last commit here removes
that fallback so the next reader is not misled the way this one was.)

So a current build, on the canonical harness, provisioned an account that any
visitor to the login form could sign into by leaving the password box empty.
That is exactly the class #1440 reports, and it was live.

## Why the suite could not see it

The create arm's two writes - `AuthenticationProviderId = SsoManagedProviderId.Value`
and the random `user.Password` - are made on the `User` object `CreateUserAsync`
returned. The session mint re-resolves the account by id and writes THAT object:

```
$ git grep -n "GetUserById" origin/main -- SSO-Auth/Api/Session/SessionMinter.cs
origin/main:SSO-Auth/Api/Session/SessionMinter.cs:56:        User? user = _userManager.GetUserById(parameters.UserId);
```

Nothing set on the first instance reached a database. The account was stored
routed at Jellyfin's own password provider with no password, which is a Jellyfin
account that accepts the empty password.

Every unit test asserts on the in-memory object, where both writes were always
present - including the five added a few hours ago by PR #1446, which proved the
writes happen and could not prove they survive. One row went further and
actively required the create arm to persist NOTHING:

```
$ git grep -n "IsCreatedEnabledAndNotPersistedHere" origin/main -- SSO-Auth.Tests/
origin/main:SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs:155:    public async Task ResolveOrCreateAsync_NewAccount_PolicyOff_IsCreatedEnabledAndNotPersistedHere()
```

It is inverted here, with its old reasoning kept visible in the comment rather
than deleted, because the reasoning is the trap.

## The repair

One guarded save at the point the values are written. The pending-approval hold
(#737) moves ahead of it, so a single save carries the routing, the password and
the disabled flag instead of two, and the rollback that arm already had now
covers both arms: a create whose save fails deletes the half-made account rather
than leaving it behind enabled, password-less, link-less and adoptable.

## The leg itself

After a real OIDC login has provisioned `alice`, the phase reads her account
record and then drives `/Users/AuthenticateByName` twice, requiring both to be
refused: with the **empty password**, and with the **identity provider's own
password**. The second is not redundant - without it the phase would still pass
on a build that copied the IdP credential onto the account.

**The placement carries the meaning.** The phase runs after SSO-only login has
been enabled and disabled again, at the one moment the preceding block has just
PROVEN native password login works on this server - `pwuser` answers `200` one
line above. Run while SSO-only was on, both refusals would be produced by that
mode rather than by anything #1440 is about, and the phase would be green on a
build with the door wide open.

## After the repair

```
harness-1 | == Extended: the manual login form is refused for the SSO-provisioned account ==
harness-1 | alice: HasPassword=true HasConfiguredPassword=true AuthenticationProviderId=Jellyfin.Plugin.SSO_Auth.Api.SSOController
harness-1 | PASS: provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP 401)
harness-1 | PASS: provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP 401)
harness-1 | ALL E2E CHECKS PASSED
```

Refs #1440

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. No validation path is touched. The one new failure
      mode - a save that throws - deletes the half-made account and lets the
      original failure propagate, so the login fails closed with nothing left
      behind.
- [x] No secrets logged. The minted password is never logged, returned or stored
      anywhere but the account's own hash. The harness phase sends the stack's
      own throwaway fixture values and prints `HasPassword`, never a password.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second reader
      looked at this change and no lens was run on it.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. **No record exists, because no review
      was run.** What stands in place of one is a reproduction on a real stack
      and the mutation table below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is added or moved.

Guards proven by breaking them, on `net9.0` at this branch head, over
`CanonicalLinkServiceTests` (101 rows):

```
   baseline                        Total: 101, Failed: 0
   the save deleted                Total: 101, Failed: 4
   only the rollback deleted       Total: 101, Failed: 2
```

The rollback mutation reddens exactly the two rows that assert it -
`ResolveOrCreateAsync_NewAccount_PolicyOff_PersistFails_RollsBackTheAccountAndFailsClosed`
(new here, the ordinary arm had no save to fail before) and the pending-approval
one that already existed.

## Quality checklist

- [x] No duplicated logic. The two arms now share one save and one rollback
      instead of the disabled arm carrying its own; the harness phase reuses the
      existing `jf_auth_status` helper.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
      No module edge moves.
- [x] Architecture-conformance tests pass. This change establishes no new
      structural property.
- [x] Docs impact considered: the CHANGELOG carries the entry; nothing an
      operator configures changes. The start-up sweep from #1447 has its own
      documentation issue, #1448.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings, build SUCCEEDED before each run below.
- [x] `dotnet test` is green.

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3492, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 39,161s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3493, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 38,325s
```

The four skips are the four the suite already skips on this host: they bind a
listener off loopback, which needs an administrator (#1227). They were not
worked around. Both runs were kept whole rather than filtered to the summary
line, which is what #1444 asks of every full run on this target framework.

- [x] The security-surface coverage bars are met, measured with the same
      instrumented `net10.0` run CI makes:

```
$ python3 scripts/check-coverage.py TestResults/coverage.cobertura.xml
Security-surface line coverage:   94.8% (6893/7268 lines)
Security-surface line bar:        92.0%
Security-surface branch coverage: 86.2% (3016/3500 branches)
Security-surface branch bar:      86.0%
Coverage gate: PASS
```

- [x] Prettier is clean for the one `.md` change.

**The harness was not run on this host.** There is no Docker engine here:

```
$ docker version --format '{{.Server.Version}}'
failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
$ echo "exit=$?"
exit=1
```

Every harness output quoted above is from this pull request's own runs on
GitHub, which is where the `E2E Login Harness` workflow fires for a change under
`test/e2e/**`. Locally only `bash -n` was run.

## Notes

What stays open on #1440 after this:

- Whether the reported class reproduces against the reporter's own 10.11.11
  server on 4.3.0.47. The harness proves the current build; nothing here was run
  against that configuration.
- The harness proves the CREATE arm end to end. The start-up sweep from #1447 is
  not driven here: reaching it needs a server that already holds a password-less
  linked account, and this stack has no way to make one, since every account it
  creates is created by a current build.
- Accounts already provisioned by a build carrying this defect are exactly the
  population #1447's sweep seals at the next start, so the two halves meet - but
  that meeting is not exercised anywhere.

No second reader looked at this change.
