### PR TITLE
Prove the login-door writes are saved where they are written

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.UserPersistence.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.UserPersistence.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// The rule that generalises #1440: the two account fields whose absence from the DATABASE is a login-security
+/// defect are written and saved in one method, never written here and left for some other method to save.
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    // The two fields, and the reason the rule stops at two rather than covering every User member. Both decide
+    // whether the ordinary Jellyfin login form opens an SSO account: AuthenticationProviderId routes the
+    // account away from the native password provider, and Password is the stored hash the empty password is
+    // checked against. An unsaved write to either leaves an account reachable without the identity provider,
+    // which is #1440. A permission or a preference that fails to persist is a wrong policy on the next login,
+    // not an open door, so it is outside this rule rather than forgotten by it.
+    private static readonly string[] DoorFields = new[] { "AuthenticationProviderId", "Password" };
+
+    [Fact]
+    public void EveryLoginDoorFieldIsSavedInTheMethodThatWritesIt()
+    {
+        // #1440 was not a missing write. Both writes were there and neither was durable: the create arm
+        // mutated the object CreateUserAsync returned, and the save that followed was in a different method
+        // (SessionMinter), on a different instance re-resolved by id. Every unit test asserted on the object
+        // it held, where the values were always present, so the whole suite was blind to it for the life of
+        // the defect. The shape is "write here, hope somebody else saves", and this rule refuses it at the
+        // one place it can be seen without running anything: the method.
+        //
+        // What it cannot see, stated so nobody reads more into a green run than is there. It does not check
+        // that the save comes after the write in EXECUTION order, only in source order, and it does not
+        // follow the object into a helper that saves on the writer's behalf - a helper taking the user and
+        // saving it would be refused here even though it is correct, which is a false refusal this rule
+        // accepts in exchange for having no way to be quietly wrong. The per-site proof that each save is
+        // load-bearing is the tests, not this.
+        var apiRoot = Path.Combine(RepoTree.Root, "SSO-Auth", "Api");
+        var write = new Regex(@"^\s*(?<obj>[A-Za-z_][A-Za-z0-9_]*)\.(?<field>" + string.Join("|", DoorFields) + @")\s*=\s*[^=]", RegexOptions.None, TimeSpan.FromSeconds(5));
+        var offenders = new List<string>();
+        var covered = new List<string>();
+
+        foreach (var src in Directory.EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories).OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var lines = File.ReadAllLines(src);
+            foreach (var (start, end) in MethodBodies(lines))
+            {
+                for (var i = start; i <= end; i++)
+                {
+                    var match = write.Match(lines[i]);
+                    if (!match.Success)
+                    {
+                        continue;
+                    }
+
+                    var obj = match.Groups["obj"].Value;
+                    var saved = false;
+                    for (var j = i + 1; j <= end; j++)
+                    {
+                        if (lines[j].Contains("UpdateUserAsync(" + obj + ")", StringComparison.Ordinal))
+                        {
+                            saved = true;
+                            break;
+                        }
+                    }
+
+                    var site = Path.GetRelativePath(RepoTree.Root, src).Replace(Path.DirectorySeparatorChar, '/') + ":" + (i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        + " writes " + obj + "." + match.Groups["field"].Value;
+                    (saved ? covered : offenders).Add(site);
+                }
+            }
+        }
+
+        // The rule is worth nothing if it walks an empty population - a rename of either field, or a change of
+        // formatting that defeats the method split, would leave it silently passing over nothing at all.
+        Assert.True(
+            covered.Count + offenders.Count >= 7,
+            "expected at least the 7 known login-door writes under SSO-Auth/Api, found " + (covered.Count + offenders.Count).ToString(System.Globalization.CultureInfo.InvariantCulture) + ": " + string.Join("; ", covered.Concat(offenders)));
+
+        Assert.True(
+            offenders.Count == 0,
+            "a login-door field is written in a method that does not save the same object (#1440/#1450): " + string.Join("; ", offenders));
+    }
+
+    // Method bodies, split on the one thing StyleCop guarantees in this tree: a member sits at four-space
+    // indentation and closes with a brace alone at four-space indentation. Cheaper than a parser and exact
+    // enough for the population above, and the count assertion in the caller is what notices if it ever stops
+    // being exact.
+    private static IEnumerable<(int Start, int End)> MethodBodies(string[] lines)
+    {
+        var open = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i] == "    {")
+            {
+                open = i;
+            }
+            else if (lines[i] == "    }" && open >= 0)
+            {
+                yield return (open, i);
+                open = -1;
+            }
+        }
+    }
+}

--- a/SSO-Auth.Tests/Session/PersistedUserMutationTests.cs
+++ b/SSO-Auth.Tests/Session/PersistedUserMutationTests.cs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The two write sites #1450 found unproven, each asserted against what the user manager was ASKED TO SAVE
+/// rather than against the object the test holds. That distinction is the whole of #1440: both writes were
+/// present on the in-memory object the whole time, every unit test read them there, and neither reached the
+/// database. A test that reads the object it constructed cannot tell a durable write from a lost one, so the
+/// captures below take their values inside the <c>UpdateUserAsync</c> call - which reddens for a save that is
+/// missing and for a save made before the field was set, and both are ways an account ends up stored wrong.
+/// </summary>
+public class PersistedUserMutationTests
+{
+    private static readonly Guid RootId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+    private static readonly Guid AliceId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000002");
+    private static readonly Guid CreatedId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000003");
+
+    [Fact]
+    public async Task DisablingTheMode_SavesTheRestoredPasswordRouting_NotOnlyTheObjectInHand()
+    {
+        // The one save site on this board that could be deleted with the whole suite staying green, measured
+        // by deleting it: 3492 tests, 0 failed. What it restores is the ordinary password door for every
+        // account the mode repointed, and the tracking set is cleared in the same method - so a restore that
+        // is written and not saved leaves those accounts stamped at a provider with no password door AND
+        // forgotten, which is an unrecoverable lockout of the whole repointed userbase by the off-switch
+        // itself. The existing coverage read alice.AuthenticationProviderId on the object the test made.
+        var root = PasswordAdmin("root", RootId);
+        var alice = PasswordUser("alice", AliceId);
+        var (service, _, users) = Build(new[] { root, alice });
+        await service.TryEnableAsync("root");
+
+        string? routingAtWrite = null;
+        var writes = 0;
+        users.UpdateUserAsync(Arg.Do<User>(u =>
+        {
+            if (u.Id == AliceId)
+            {
+                routingAtWrite = u.AuthenticationProviderId;
+                writes++;
+            }
+        })).Returns(Task.CompletedTask);
+
+        var restored = await service.DisableAsync();
+
+        Assert.Equal(1, restored);
+        Assert.Equal(1, writes);
+        Assert.Equal(SsoAuthenticationProviders.DefaultPasswordProviderId, routingAtWrite);
+    }
+
+    [Fact]
+    public async Task ProvisioningTemplate_ReachesTheObjectTheManagerIsAskedToSave()
+    {
+        // #1450's third clause, for the half that is about today. The template is applied at creation and only
+        // at creation - the session mint does not re-apply it - so every field it writes depends on the create
+        // arm's own save carrying it. Read at the write rather than after the call, and every field the
+        // template can set is asserted, so a template field added later without reaching the save reddens here.
+        var template = new ProvisioningPolicyTemplate
+        {
+            Permissions = new List<ProvisionedPermissionEntry>
+            {
+                new ProvisionedPermissionEntry { Permission = nameof(PermissionKind.EnableSyncTranscoding), Granted = true },
+            },
+            RemoteClientBitrateLimit = 3_000_000,
+            MaxActiveSessions = 4,
+            AudioLanguagePreference = "deu",
+            SubtitleLanguagePreference = "eng",
+            SubtitleMode = nameof(SubtitlePlaybackMode.Always),
+            PlayDefaultAudioTrack = false,
+            RememberAudioSelections = false,
+            RememberSubtitleSelections = false,
+        };
+
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, ProvisioningPolicyTemplate = template };
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        var created = TestUsers.Named("alice", CreatedId);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(CreatedId).Returns(created);
+
+        User? saved = null;
+        var snapshot = default((bool Transcoding, int? Bitrate, int? Sessions, string? Audio, string? Subtitle, SubtitlePlaybackMode Mode, bool PlayDefault, bool RememberAudio, bool RememberSubtitles));
+        users.UpdateUserAsync(Arg.Do<User>(u =>
+        {
+            saved = u;
+            snapshot = (
+                u.HasPermission(PermissionKind.EnableSyncTranscoding),
+                u.RemoteClientBitrateLimit,
+                u.MaxActiveSessions,
+                u.AudioLanguagePreference,
+                u.SubtitleLanguagePreference,
+                u.SubtitleMode,
+                u.PlayDefaultAudioTrack,
+                u.RememberAudioSelections,
+                u.RememberSubtitleSelections);
+        })).Returns(Task.CompletedTask);
+
+        var service = new CanonicalLinkService(users, new RecordingCryptoProvider(), store, new CapturingLogger());
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Same(created, saved);
+        Assert.True(snapshot.Transcoding);
+        Assert.Equal(3_000_000, snapshot.Bitrate);
+        Assert.Equal(4, snapshot.Sessions);
+        Assert.Equal("deu", snapshot.Audio);
+        Assert.Equal("eng", snapshot.Subtitle);
+        Assert.Equal(SubtitlePlaybackMode.Always, snapshot.Mode);
+        Assert.False(snapshot.PlayDefault);
+        Assert.False(snapshot.RememberAudio);
+        Assert.False(snapshot.RememberSubtitles);
+    }
+
+    private static User PasswordAdmin(string name, Guid id)
+    {
+        var user = new User(name, "SSO-Auth", "Default") { Id = id, Password = "hash-" + name };
+        user.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
+        user.SetPermission(PermissionKind.IsAdministrator, true);
+        return user;
+    }
+
+    private static User PasswordUser(string name, Guid id)
+    {
+        var user = new User(name, "SSO-Auth", "Default") { Id = id, Password = "hash-" + name };
+        user.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
+        return user;
+    }
+
+    private static (SsoOnlyLoginService Service, PluginConfiguration Config, IUserManager Users) Build(IReadOnlyList<User> allUsers)
+    {
+        var cfg = new PluginConfiguration();
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        users.GetUsers().Returns(allUsers);
+        foreach (var user in allUsers)
+        {
+            users.GetUserByName(user.Username).Returns(user);
+            users.GetUserById(user.Id).Returns(user);
+        }
+
+        return (new SsoOnlyLoginService(users, store, new CapturingLogger()), cfg, users);
+    }
+}


### PR DESCRIPTION
# What & why

Closes #1450. Refs #1440.

#1440 was not a missing write. The create arm set `AuthenticationProviderId` and
`Password` on the object `CreateUserAsync` returned, and the save that followed
was in another method, on another instance re-resolved by id, so neither value
reached the database. Every unit test read those values off the object it held,
where they were always present. This is the sweep that stops the shape coming
back, and it starts by measuring which saves are already proven rather than by
assuming which are not.

## Which saves are load-bearing, measured by deleting them

Read at `origin/main` `cea14b1494c85b72f10299a2b1f77582bbb989b9`. Each save was
replaced by an awaited no-op in turn, the test project rebuilt, and the whole
`net9.0` suite run against a baseline of `Total: 3492, Failed: 0`:

| site | what it saves | tests that reddened |
| --- | --- | --- |
| `CanonicalLinkService.cs:675` | provider id, template, password, disabled | 5 |
| `CanonicalLinkService.cs:1164` | `IsDisabled` on a denied login | 6 |
| `SessionMinter.cs:137` | permissions, folders, rating, provider id | 2 |
| `SSOController.cs:1848` | provider id on unregister | 3 |
| `PasswordlessLinkedAccountSweep.cs:96` | password | 2 |
| `SsoOnlyLoginService.cs:327` | provider id on mode enable | 1 |
| `SsoOnlyLoginService.cs:375` | provider id on mode disable | **0** |

The first Done-when clause was already answered on the issue by a walk of the
sites; this is the second clause answered the way the repository asks a guard to
be answered, and it disagrees with the reading on the issue that only two sites
had a test. Six of the seven had one. The seventh had none.

## The site nothing could see

`RestoreRepointedAccountsAsync` gives back the ordinary password door to every
account the SSO-only mode repointed, and clears the tracking set in the same
method. A restore that is written and never saved therefore leaves that whole
userbase stamped at a provider with no password door **and** with no record of
which accounts to repair - the off-switch itself becoming the lockout. The
existing coverage, `Disable_RestoresDefaultProvider_WithoutTouchingPasswordHash`,
asserts on `alice.AuthenticationProviderId` on the object the test constructed,
which is exactly the in-memory reading #1440 walked through.

## What this adds

- A behavioural test per unproven site, capturing the value **inside** the
  `UpdateUserAsync` call rather than off the object in hand, so it reddens for
  an absent save and for a save made before the write.
- The provisioning template asserted field by field on the object the manager is
  asked to save.
- A conformance rule, `EveryLoginDoorFieldIsSavedInTheMethodThatWritesIt`: a
  write to `AuthenticationProviderId` or `Password` under `SSO-Auth/Api` must be
  followed by a save of the same object in the same method.

## The provisioning-template question, third Done-when clause

The historical half is answered from the tree. Before `b37e7a70` the create arm
saved only on the pending-approval branch:

```
$ git show b37e7a7^:SSO-Auth/Api/Linking/CanonicalLinkService.cs | sed -n '647,666p'
        ProvisioningPolicy.ApplyAtProvisioning(user, ProvisioningTemplateFor(mode, provider, provisioningProfile));
        ...
        if (provisionDisabled)
        {
            ...
                await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
```

So on every build carrying `ApplyAtProvisioning` and not the repair, a template
reached the database **only** where the provider held new accounts for approval.
On the ordinary arm it was written to an object nobody saved, and the session
mint does not re-apply it. That window is twenty released tags:

```
$ comm -23 <(git tag --contains ac0f5b20 | sort) <(git tag --contains b37e7a70 | sort) | wc -l
20
```

`ac0f5b20` is where `ProvisioningPolicy` was added (#1099). The "now" half is the
new test: every field the template can write is asserted on the saved object, and
it reddens if either the template application or the save is removed.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no production behaviour changes here; the change is
      tests plus one conformance rule.
- [x] No secrets logged; nothing in the new tests writes a password to a log, and
      the template test asserts on preference fields only.
- [ ] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline. **Not performed** - this touches none
      of those three surfaces and adds no production code.
- [ ] Review record: per lens, its verdict and its findings. **No lens was run
      and no second reader looked at this change.** There is no review record to
      report, and this box stays unticked rather than being filled with the
      measurements above, which are not a review.
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged, no
      log call is added.

## Quality checklist

- [x] No duplicated logic; the new rule is one method plus a five-line body
      splitter.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments say why.
- [x] Architecture-conformance tests pass, and the structural property this
      establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki statement changes - nothing here
      alters what the plugin does.

## Verification

- [x] `dotnet build ... --warnaserror` green on both target frameworks, 0
      warnings.
- [x] Full suite green on both: `net9.0` `Total: 3495, Failed: 0, Skipped: 4`,
      `net10.0` `Total: 3496, Failed: 0, Skipped: 4`.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

Every guard here was proven by deleting what it names and watching exactly it
redden, each failing its own test and no other:

```
delete the restore save (SsoOnlyLoginService:375)
  PersistedUserMutationTests.DisablingTheMode_SavesTheRestoredPasswordRouting_NotOnlyTheObjectInHand [FAIL]
delete the create-arm save (CanonicalLinkService:675)
  PersistedUserMutationTests.ProvisioningTemplate_ReachesTheObjectTheManagerIsAskedToSave [FAIL]
delete the template application (CanonicalLinkService:646)
  PersistedUserMutationTests.ProvisioningTemplate_ReachesTheObjectTheManagerIsAskedToSave [FAIL]
remove the save at SsoOnlyLoginService:375, conformance rule only
  ArchitectureConformanceTests.EveryLoginDoorFieldIsSavedInTheMethodThatWritesIt [FAIL]
  a login-door field is written in a method that does not save the same object
  (#1440/#1450): SSO-Auth/Api/Session/SsoOnlyLoginService.cs:374 writes
  user.AuthenticationProviderId
```

What the conformance rule cannot see, so nobody reads more into a green run than
is there. It compares source order, not execution order. It does not follow the
object into a helper that saves on the writer's behalf, and would refuse such a
helper as an offender - a false refusal accepted deliberately, in exchange for a
rule with no way to be quietly wrong. It stops at two fields because those two
decide whether the ordinary Jellyfin login form opens the account; a permission
or a preference that fails to persist is a wrong policy on the next login rather
than an open door, and is outside the rule rather than forgotten by it. The
per-site proof that each save is load-bearing is the tests, not this rule.

The fourth Done-when clause offered a note in the coding standards where a rule
was not possible. A rule was possible, so no standards note is proposed here.

Out of scope, and left as it stands: the `IsDisabled`, permission, folder and
parental-rating writes are all covered by the existing tests the table above
measured, so no test was added beside them.
