### PR TITLE
Exercise the start-up pass that seals password-less SSO accounts

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -265,6 +265,27 @@ jobs:
           COMPOSE: ${{ matrix.compose }}
         run: bash test/e2e/phases/proxy-client-attribution.sh
 
+      - name: The start-up pass seals a password-less SSO account (#1440)
+        # The second half of the #1440 remediation, which nothing outside a unit test had ever run.
+        # The canonical harness proves the create arm; reaching the start-up pass needs a server that
+        # already holds a password-less linked account, and a current build makes none - so this phase
+        # makes one, through the server's own admin API, in the exact shape a build up to v3.4.0.2
+        # stored it in, and asserts the empty password mints a session on it BEFORE the restart. That
+        # control is what makes the refusal afterwards attributable to the pass rather than to the
+        # account's routing, which refuses the same login for a different reason the whole time.
+        #
+        # Release and `providers: all` only, and only on the canonical Keycloak stack, for the same
+        # reasons as the phases above: it costs an extra login pass, and it is the one stack that can
+        # be re-run in place. Runs on a green harness only, so a real login failure surfaces as the
+        # harness failure.
+        #
+        # AHEAD of the rollover phase below, which mutates the identity provider. This one only
+        # changes account state in Jellyfin and puts the routing back.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: bash test/e2e/phases/passwordless-account-sweep.sh
+
       - name: SAML signing-cert rollover, the new cert validates and the old one is refused (#1128)
         # Rotates the realm's SAML signing key mid-run, imports the new certificate into the plugin,
         # and requires all three of the issue's clauses in ONE run: an assertion signed by the

--- a/test/e2e/phases/passwordless-account-sweep.sh
+++ b/test/e2e/phases/passwordless-account-sweep.sh
@@ -22,13 +22,17 @@
 #
 # The shape:
 #
-#   arrange   alice is repointed at the built-in password provider and her password is reset away.
+#   arrange   alice is repointed at the built-in password provider, dropped from administrator, and
+#             her password is reset away. The admin flag has to go: Jellyfin refuses to empty an
+#             administrator's password, and the first run of this phase died at exactly that, on a
+#             400 from the reset, because the role this stack maps makes her one.
 #   control   the empty password mints a session on her, so the door is demonstrably open.
 #   restart   Jellyfin comes back and the plugin's hosted start-up service runs the pass.
 #   assert    she holds a password again, the empty one is refused, her ROUTING is untouched, and the
 #             audit line names one sealed account.
-#   restore   the routing goes back where the canonical pass left it, and a RELOGIN_ONLY pass proves
-#             the stack was left working rather than merely left.
+#   restore   the routing and the admin flag go back to what the probe read before it changed
+#             anything, and a RELOGIN_ONLY pass proves the stack was left working rather than merely
+#             left.
 #
 # Never `docker compose down` here: that removes Keycloak, the realm is re-imported into a fresh
 # instance with a NEW SAML signing certificate, and the certificate the canonical pass wrote into the
@@ -79,10 +83,16 @@ ALICE_ID="$(field "$SEED_OUT" PROBE-ALICE-ID)"
 [ -n "$ALICE_ID" ] || die "the probe found no account named alice - its own output is above"
 # Read from the probe's FIRST reading, before it changed anything, so the restore at the end puts back
 # what the canonical pass left rather than what this phase happens to expect.
-PROVIDER_BEFORE="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-BEFORE-SEED$/,/^PROBE-POLICY-STATUS/p' | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
+BEFORE_BLOCK="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-BEFORE-SEED$/,/^PROBE-POLICY-STATUS/p')"
+PROVIDER_BEFORE="$(printf '%s' "$BEFORE_BLOCK" | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
+ADMIN_BEFORE="$(printf '%s' "$BEFORE_BLOCK" | sed -n 's/^PROBE-ADMIN //p' | head -1)"
 [ -n "$PROVIDER_BEFORE" ] && [ "$PROVIDER_BEFORE" != "null" ] \
     || die "could not read the provider id alice carried before this phase touched her, so the restore would be a guess"
-pass "alice is $ALICE_ID, routed at $PROVIDER_BEFORE before this phase"
+case "$ADMIN_BEFORE" in
+    true|false) : ;;
+    *) die "could not read whether alice was an administrator before this phase touched her (got '$ADMIN_BEFORE'), so the restore would be a guess" ;;
+esac
+pass "alice is $ALICE_ID, routed at $PROVIDER_BEFORE with IsAdministrator=$ADMIN_BEFORE before this phase"
 
 SEEDED_HASPASSWORD="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-HASPASSWORD //p' | head -1)"
 SEEDED_PROVIDER="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
@@ -91,7 +101,7 @@ SEEDED_EMPTY="$(field "$SEED_OUT" PROBE-EMPTY-PASSWORD)"
 [ "$SEEDED_PROVIDER" = "$BUILTIN_PROVIDER" ] \
     || die "alice is routed at '$SEEDED_PROVIDER' rather than the built-in password provider, so the seed did not produce the shape this phase is about"
 [ "$SEEDED_HASPASSWORD" = "false" ] \
-    || die "alice still holds a password after the reset (HasPassword=$SEEDED_HASPASSWORD), so there is nothing for the start-up pass to seal and a green result below would mean nothing"
+    || die "alice still holds a password after the reset (HasPassword=$SEEDED_HASPASSWORD), so there is nothing for the start-up pass to seal and a green result below would mean nothing. Jellyfin refuses to empty an ADMINISTRATOR's password, which is what the first run of this phase hit: the seed drops that flag and the restore puts it back"
 pass "alice is seeded: routed at the built-in password provider, holding no password"
 
 log "The control: the door is open before the restart"
@@ -137,13 +147,15 @@ printf '%s\n' "$AUDIT" | grep -qE 'Sealed 1 SSO-linked account' \
     || die "the audit line does not name ONE sealed account. Exactly one was seeded, so a different count means the pass reached accounts this phase did not put in front of it"
 pass "the pass audited exactly one sealed account"
 
-log "Putting alice's routing back"
-RESTORE_OUT="$(probe restore -e "RESTORE_PROVIDER=$PROVIDER_BEFORE")" || die "the restore probe container could not be started"
+log "Putting alice's routing and admin flag back"
+RESTORE_OUT="$(probe restore -e "RESTORE_PROVIDER=$PROVIDER_BEFORE" -e "RESTORE_ADMIN=$ADMIN_BEFORE")" || die "the restore probe container could not be started"
 printf '%s\n' "$RESTORE_OUT" | sed 's/^/  probe| /'
 [ "$(field "$RESTORE_OUT" PROBE-PROVIDER)" = "$PROVIDER_BEFORE" ] \
     || die "alice's routing is not back at $PROVIDER_BEFORE, so this phase left the stack in a state the canonical pass did not create"
+[ "$(field "$RESTORE_OUT" PROBE-ADMIN)" = "$ADMIN_BEFORE" ] \
+    || die "alice's IsAdministrator is not back at $ADMIN_BEFORE, so this phase left the stack in a state the canonical pass did not create"
 docker compose -f "$COMPOSE" stop >/dev/null
-pass "alice is routed as the canonical pass left her"
+pass "alice is routed and privileged as the canonical pass left her"
 
 log "A login after the restore"
 # STOPPED above and brought up by this `up` rather than started separately, for the reason the phase

--- a/test/e2e/phases/passwordless-account-sweep.sh
+++ b/test/e2e/phases/passwordless-account-sweep.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# The start-up pass that seals password-less SSO accounts, exercised against a real server for the
+# first time (#1440). The plugin ships two halves against that defect: the create arm, which the
+# canonical harness already proves, and this pass, which has never run outside a unit test. The issue
+# says why the two had not been exercised together - reaching the pass needs a server that already
+# holds a password-less linked account, and every account the stack makes is made by a current build,
+# which no longer produces one.
+#
+# THIS PHASE MAKES THAT ACCOUNT RATHER THAN WAITING FOR ONE. It puts alice into the exact shape a
+# build up to v3.4.0.2 stored her in - routed at Jellyfin's built-in password provider with no
+# password - through the server's own admin API, and only then restarts.
+#
+# THE SEED IS ALSO THE CONTROL, and without it this phase would be worth nothing. It asserts that the
+# empty password MINTS A SESSION on the seeded account before the restart. A run that skipped that
+# and only checked the refusal afterwards would pass identically on a build whose sweep does nothing,
+# because alice is refused for a second reason the whole time: her routing. The control is what makes
+# the refusal afterwards attributable to the password the pass minted.
+#
+# It runs on the HOST rather than inside the harness container, like the phases beside it: it has to
+# restart Jellyfin, and the harness mounts only /harness. The readings are HTTP, so they happen in a
+# probe container on the compose network - Jellyfin publishes no port to the host.
+#
+# The shape:
+#
+#   arrange   alice is repointed at the built-in password provider and her password is reset away.
+#   control   the empty password mints a session on her, so the door is demonstrably open.
+#   restart   Jellyfin comes back and the plugin's hosted start-up service runs the pass.
+#   assert    she holds a password again, the empty one is refused, her ROUTING is untouched, and the
+#             audit line names one sealed account.
+#   restore   the routing goes back where the canonical pass left it, and a RELOGIN_ONLY pass proves
+#             the stack was left working rather than merely left.
+#
+# Never `docker compose down` here: that removes Keycloak, the realm is re-imported into a fresh
+# instance with a NEW SAML signing certificate, and the certificate the canonical pass wrote into the
+# plugin's SAML configuration would no longer match. `stop` and `start` keep the containers.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
+CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
+
+log() { printf '%s\n' "== $* =="; }
+die() { printf '::error::%s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+PHASES_DIR="${PHASES_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+BUILTIN_PROVIDER="Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider"
+
+log "Preconditions"
+[ -s "$CONFIG" ] || die "the plugin persisted no configuration at $CONFIG - run the canonical pass first"
+grep -q '<CanonicalLinks' "$CONFIG" \
+    || die "no <CanonicalLinks> element in $CONFIG - the sweep's population is the accounts a canonical link names, so with none there the pass would correctly seal nothing and this phase would prove nothing"
+pass "the persisted configuration is present and carries canonical links"
+
+# The probe runs in a container on the harness network, the way the budget probe beside it does. A
+# FILE rather than a string through `sh -c`, for the reason probe-oid-start.sh gives: a script that
+# arrives as one argument through two layers is not readable in the log it fails in.
+probe() { # $1 stage, $2.. extra -e arguments
+    stage="$1"; shift
+    docker compose -f "$COMPOSE" run --rm --no-deps -T \
+        -v "$PHASES_DIR:/probe:ro" "$@" \
+        --entrypoint sh harness /probe/probe-passwordless-sweep.sh "$stage"
+}
+
+field() { printf '%s\n' "$1" | sed -n "s/^$2 //p" | tail -1; }
+
+log "Starting the stack"
+# The phase before this one ends with `docker compose up --abort-on-container-exit`, which stops every
+# container when the harness exits, so this phase inherits a stopped stack. Keycloak is started too:
+# forgetting it cost a run on the phase beside this one, because the plugin's readiness route answers
+# only once discovery can be read.
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
+pass "Jellyfin and Keycloak are running"
+
+log "Seeding the pre-v3.5.0.0 account shape on alice"
+SEED_OUT="$(probe seed)" || die "the seed probe container could not be started"
+printf '%s\n' "$SEED_OUT" | sed 's/^/  probe| /'
+
+ALICE_ID="$(field "$SEED_OUT" PROBE-ALICE-ID)"
+[ -n "$ALICE_ID" ] || die "the probe found no account named alice - its own output is above"
+# Read from the probe's FIRST reading, before it changed anything, so the restore at the end puts back
+# what the canonical pass left rather than what this phase happens to expect.
+PROVIDER_BEFORE="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-BEFORE-SEED$/,/^PROBE-POLICY-STATUS/p' | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
+[ -n "$PROVIDER_BEFORE" ] && [ "$PROVIDER_BEFORE" != "null" ] \
+    || die "could not read the provider id alice carried before this phase touched her, so the restore would be a guess"
+pass "alice is $ALICE_ID, routed at $PROVIDER_BEFORE before this phase"
+
+SEEDED_HASPASSWORD="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-HASPASSWORD //p' | head -1)"
+SEEDED_PROVIDER="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
+SEEDED_EMPTY="$(field "$SEED_OUT" PROBE-EMPTY-PASSWORD)"
+
+[ "$SEEDED_PROVIDER" = "$BUILTIN_PROVIDER" ] \
+    || die "alice is routed at '$SEEDED_PROVIDER' rather than the built-in password provider, so the seed did not produce the shape this phase is about"
+[ "$SEEDED_HASPASSWORD" = "false" ] \
+    || die "alice still holds a password after the reset (HasPassword=$SEEDED_HASPASSWORD), so there is nothing for the start-up pass to seal and a green result below would mean nothing"
+pass "alice is seeded: routed at the built-in password provider, holding no password"
+
+log "The control: the door is open before the restart"
+[ "$SEEDED_EMPTY" = "200" ] \
+    || die "the EMPTY password answered $SEEDED_EMPTY on the seeded account rather than minting a session. The seed did not open the door, so a refusal after the restart would not be attributable to the start-up pass - which is the only thing this phase exists to show"
+pass "the empty password mints a session on the seeded account (HTTP $SEEDED_EMPTY) - the door is open"
+
+log "Restarting Jellyfin so the start-up pass runs"
+docker compose -f "$COMPOSE" stop jellyfin >/dev/null
+docker compose -f "$COMPOSE" start jellyfin >/dev/null
+VERIFY_OUT="$(probe verify)" || die "the verify probe container could not be started"
+printf '%s\n' "$VERIFY_OUT" | sed 's/^/  probe| /'
+
+SEALED_HASPASSWORD="$(field "$VERIFY_OUT" PROBE-HASPASSWORD)"
+SEALED_PROVIDER="$(field "$VERIFY_OUT" PROBE-PROVIDER)"
+SEALED_EMPTY="$(field "$VERIFY_OUT" PROBE-EMPTY-PASSWORD)"
+
+log "Asserting"
+[ "$SEALED_HASPASSWORD" = "true" ] \
+    || die "alice still holds no password after the restart (HasPassword=$SEALED_HASPASSWORD) - the start-up pass did not seal an account that was exactly its population"
+pass "alice holds a password again after the restart"
+
+[ "$SEALED_EMPTY" != "200" ] \
+    || die "the EMPTY password STILL mints a session for alice after the restart - the account remains reachable without the identity provider, which is the whole of #1440"
+pass "the empty password is refused on the sealed account (HTTP $SEALED_EMPTY)"
+
+# The pass writes one field and the issue says so in as many words: it never changes an account's
+# login routing. Asserted because a pass that repointed the account would ALSO produce the refusal
+# above, and would be a different and much larger change than the one that shipped.
+[ "$SEALED_PROVIDER" = "$BUILTIN_PROVIDER" ] \
+    || die "alice's routing moved from '$BUILTIN_PROVIDER' to '$SEALED_PROVIDER' across the restart - the pass is meant to write a password and nothing else"
+pass "alice's login routing is untouched by the pass, still $BUILTIN_PROVIDER"
+
+log "The audit line"
+# Quoted rather than paraphrased, against the leading words of what SsoAudit.PasswordlessAccountsSealed
+# emits. Only the stable head of the message is matched: the tail explains the population in a sentence
+# that may be reworded, and pinning the whole of it would redden this phase for a documentation edit.
+AUDIT="$(docker compose -f "$COMPOSE" logs jellyfin 2>/dev/null | grep -F 'Sealed' | grep -F 'SSO-linked account' | tail -3)"
+[ -n "$AUDIT" ] \
+    || die "the Jellyfin log carries no line about sealed SSO-linked accounts, so the pass either did not run or sealed silently - an operator meeting this on a real server would have no record of it at all"
+printf '%s\n' "$AUDIT" | sed 's/^/  log| /'
+printf '%s\n' "$AUDIT" | grep -qE 'Sealed 1 SSO-linked account' \
+    || die "the audit line does not name ONE sealed account. Exactly one was seeded, so a different count means the pass reached accounts this phase did not put in front of it"
+pass "the pass audited exactly one sealed account"
+
+log "Putting alice's routing back"
+RESTORE_OUT="$(probe restore -e "RESTORE_PROVIDER=$PROVIDER_BEFORE")" || die "the restore probe container could not be started"
+printf '%s\n' "$RESTORE_OUT" | sed 's/^/  probe| /'
+[ "$(field "$RESTORE_OUT" PROBE-PROVIDER)" = "$PROVIDER_BEFORE" ] \
+    || die "alice's routing is not back at $PROVIDER_BEFORE, so this phase left the stack in a state the canonical pass did not create"
+docker compose -f "$COMPOSE" stop >/dev/null
+pass "alice is routed as the canonical pass left her"
+
+log "A login after the restore"
+# STOPPED above and brought up by this `up` rather than started separately, for the reason the phase
+# beside this one records: `start` returns when the container is running, not when the server is
+# listening, and the harness then races it. RELOGIN_ONLY skips the seed, the wizard and the two
+# provider Add calls and reads the persisted configuration back (#1123).
+RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \
+    --abort-on-container-exit --exit-code-from harness \
+    || die "the login after the restore failed - the phase left the stack broken rather than as it found it"
+pass "the stack still logs in, and phase 6e still refuses the manual form for alice"
+
+printf '\nPASSWORDLESS ACCOUNT SWEEP PHASE PASSED\n'

--- a/test/e2e/phases/probe-passwordless-sweep.sh
+++ b/test/e2e/phases/probe-passwordless-sweep.sh
@@ -70,6 +70,7 @@ report_state() {
   say "PROBE-HASPASSWORD $(printf '%s' "$rec" | jq -r '.HasPassword')"
   say "PROBE-CONFIGURED $(printf '%s' "$rec" | jq -r '.HasConfiguredPassword')"
   say "PROBE-PROVIDER $(printf '%s' "$rec" | jq -r '.Policy.AuthenticationProviderId')"
+  say "PROBE-ADMIN $(printf '%s' "$rec" | jq -r '.Policy.IsAdministrator')"
 }
 
 # The empty password against the ordinary login form. This is the whole subject: an account with no
@@ -92,9 +93,15 @@ case "$STAGE" in
     # nothing to reset. Repointing it at Jellyfin's built-in provider first is also exactly how the
     # historical population came about: a provider's DefaultProvider setting moved SSO accounts onto
     # a real password provider, and the account had no password to meet it with.
+    #
+    # THE ADMIN FLAG COMES OFF IN THE SAME WRITE, and it is not tidiness. Jellyfin refuses to empty an
+    # administrator's password - UserManager.ChangePassword throws for an empty one on an account
+    # holding IsAdministrator - and the reset answered 400 for exactly that reason on the first run of
+    # this phase. alice carries the realm role this stack maps to Jellyfin admin, so she is one. It is
+    # put back at the restore stage from the value read here, not from a constant.
     POLICY="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null | jq -c '.Policy')"
     [ -n "$POLICY" ] || { say "PROBE-ERROR could not read alice's policy"; exit 0; }
-    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c '.AuthenticationProviderId = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider"')"
+    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c '.AuthenticationProviderId = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider" | .IsAdministrator = false')"
     POLICY_STATUS="$(curl -sS -o /tmp/policy.out -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/$ALICE_ID/Policy" \
       -H "Content-Type: application/json" -H "$AUTHZ" -d "$NEW_POLICY" 2>/dev/null)"
     say "PROBE-POLICY-STATUS $POLICY_STATUS"
@@ -109,18 +116,32 @@ case "$STAGE" in
     say "PROBE-EMPTY-PASSWORD $(empty_password_status)"
     ;;
   verify)
+    # BOUNDED WAIT, AND THE BOUND IS REPORTED. The pass runs in an IHostedService.StartAsync, and
+    # whether that completes before the server answers a request depends on the order the host starts
+    # its services in - which is not this phase's to assert. Reading once and finding no password
+    # would be indistinguishable from a pass that does nothing, so the reading is repeated for a
+    # stated interval and the log carries how long it took. A pass that never runs still fails: the
+    # loop ends and the state below is the unsealed one.
+    j=0
+    while [ "$j" -lt 30 ]; do
+      sealed="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null | jq -r '.HasPassword')"
+      [ "$sealed" = "true" ] && break
+      j=$((j + 1))
+      sleep 2
+    done
+    say "PROBE-SEALED-AFTER $((j * 2))s of at most 60s"
     say "PROBE-AFTER-RESTART"
     report_state
     say "PROBE-EMPTY-PASSWORD $(empty_password_status)"
     ;;
   restore)
-    # Put the routing back where the canonical pass left it, so the phase after this one meets the
-    # stack it expects. The password cannot be put back and is not meant to be: what is on the
-    # account now is the unguessable one the sweep minted, which is the state every sealed account is
-    # left in on a real server.
+    # Put the routing and the admin flag back where the canonical pass left them, so the phase after
+    # this one meets the stack it expects. The password cannot be put back and is not meant to be:
+    # what is on the account now is the unguessable one the pass minted, which is the state every
+    # sealed account is left in on a real server.
     POLICY="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null | jq -c '.Policy')"
     [ -n "$POLICY" ] || { say "PROBE-ERROR could not read alice's policy"; exit 0; }
-    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c --arg p "$RESTORE_PROVIDER" '.AuthenticationProviderId = $p')"
+    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c --arg p "$RESTORE_PROVIDER" --argjson a "$RESTORE_ADMIN" '.AuthenticationProviderId = $p | .IsAdministrator = $a')"
     RESTORE_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/$ALICE_ID/Policy" \
       -H "Content-Type: application/json" -H "$AUTHZ" -d "$NEW_POLICY" 2>/dev/null)"
     say "PROBE-RESTORE-STATUS $RESTORE_STATUS"

--- a/test/e2e/phases/probe-passwordless-sweep.sh
+++ b/test/e2e/phases/probe-passwordless-sweep.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# The two readings the passwordless-sweep phase is made of, in one script run twice (#1440). Jellyfin
+# publishes no port to the host, so both halves have to happen from inside a container on `ssonet`,
+# and both are HTTP against the server rather than edits to a file - the account state this phase is
+# about lives in Jellyfin's own database, which nothing outside the server may touch.
+#
+# STAGE is the argument. `seed` puts alice into the shape every account provisioned by a build up to
+# v3.4.0.2 was stored in, and proves the door is open on it. `verify` reads her back after the
+# restart the caller made in between, when the plugin's start-up pass has run.
+#
+# It never exits non-zero, like the probes beside it: a failure here prints PROBE-ERROR and the
+# caller decides what a missing answer means, so a broken probe cannot be read as a sealed account.
+set -u
+
+STAGE="${1:-}"
+
+say() { printf '%s\n' "$*"; }
+
+if ! apk add --no-cache curl jq >/tmp/apk.out 2>&1; then
+  say "PROBE-ERROR could not install curl and jq:"
+  sed 's/^/  /' /tmp/apk.out
+  exit 0
+fi
+
+EMBY_AUTH='MediaBrowser Client="e2e-sweep", Device="probe", DeviceId="e2e-sweep-probe", Version="1.0.0"'
+
+# READINESS IS THE PLUGIN'S OWN ROUTE, for the reason probe-oid-start.sh states: /System/Info/Public
+# answers while the server is still coming up, and on the verify stage that would read alice back
+# BEFORE the hosted service that seals her has run - a false red that looks exactly like a sweep that
+# does nothing. /sso/OID/GetNames only answers once the plugin is loaded.
+i=0
+until curl -fsS -o /dev/null "$JELLYFIN_URL/sso/OID/GetNames" 2>/tmp/ready.err; do
+  i=$((i + 1))
+  if [ "$i" -ge 150 ]; then
+    say "PROBE-ERROR the plugin did not answer $JELLYFIN_URL/sso/OID/GetNames within 300s:"
+    sed 's/^/  /' /tmp/ready.err
+    exit 0
+  fi
+  sleep 2
+done
+say "PROBE-STAGE plugin ready after $i retries ($((i * 2))s)"
+
+AUTH_JSON="$(curl -fsS -X POST "$JELLYFIN_URL/Users/AuthenticateByName" \
+  -H "Content-Type: application/json" -H "Authorization: $EMBY_AUTH" \
+  -d "{\"Username\":\"$JF_ADMIN_USER\",\"Pw\":\"$JF_ADMIN_PASS\"}" 2>/tmp/auth.err)" || {
+  say "PROBE-ERROR admin authentication failed:"
+  sed 's/^/  /' /tmp/auth.err
+  exit 0
+}
+TOKEN="$(printf '%s' "$AUTH_JSON" | jq -r '.AccessToken // empty')"
+[ -n "$TOKEN" ] || { say "PROBE-ERROR no admin access token minted"; exit 0; }
+AUTHZ="Authorization: MediaBrowser Token=\"$TOKEN\""
+
+ALICE_ID="$(curl -fsS "$JELLYFIN_URL/Users" -H "$AUTHZ" 2>/tmp/users.err \
+  | jq -r '.[] | select(.Name == "alice") | .Id' | head -1)"
+if [ -z "$ALICE_ID" ]; then
+  say "PROBE-ERROR no account named alice on this server - the canonical login pass has to have run first:"
+  sed 's/^/  /' /tmp/users.err
+  exit 0
+fi
+say "PROBE-ALICE-ID $ALICE_ID"
+
+# Both stages report the same three facts about the account, so the caller compares like with like and
+# a reader of the log sees the state move rather than two differently-shaped readings. jq -r with no
+# `// "?"` fallback, for the reason the harness states at the same reading: the fallback takes its
+# alternative for FALSE as well as for absent, and "no password stored" and "field not there" are the
+# two answers that must never print the same.
+report_state() {
+  rec="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null)" || rec=""
+  say "PROBE-HASPASSWORD $(printf '%s' "$rec" | jq -r '.HasPassword')"
+  say "PROBE-CONFIGURED $(printf '%s' "$rec" | jq -r '.HasConfiguredPassword')"
+  say "PROBE-PROVIDER $(printf '%s' "$rec" | jq -r '.Policy.AuthenticationProviderId')"
+}
+
+# The empty password against the ordinary login form. This is the whole subject: an account with no
+# stored password accepts it, and that is how an SSO account becomes reachable without the identity
+# provider. 200 means a session was minted.
+empty_password_status() {
+  curl -sS -o /dev/null -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/AuthenticateByName" \
+    -H "Content-Type: application/json" -H "Authorization: $EMBY_AUTH" \
+    -d '{"Username":"alice","Pw":""}' 2>/dev/null
+}
+
+case "$STAGE" in
+  seed)
+    say "PROBE-BEFORE-SEED"
+    report_state
+
+    # ROUTING FIRST, PASSWORD SECOND, and the order is not cosmetic. The account is stored routed at
+    # the plugin's own provider id, which resolves to no registered IAuthenticationProvider, so core
+    # substitutes InvalidAuthenticationProvider - and a password reset against that provider has
+    # nothing to reset. Repointing it at Jellyfin's built-in provider first is also exactly how the
+    # historical population came about: a provider's DefaultProvider setting moved SSO accounts onto
+    # a real password provider, and the account had no password to meet it with.
+    POLICY="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null | jq -c '.Policy')"
+    [ -n "$POLICY" ] || { say "PROBE-ERROR could not read alice's policy"; exit 0; }
+    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c '.AuthenticationProviderId = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider"')"
+    POLICY_STATUS="$(curl -sS -o /tmp/policy.out -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/$ALICE_ID/Policy" \
+      -H "Content-Type: application/json" -H "$AUTHZ" -d "$NEW_POLICY" 2>/dev/null)"
+    say "PROBE-POLICY-STATUS $POLICY_STATUS"
+
+    RESET_STATUS="$(curl -sS -o /tmp/pw.out -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/$ALICE_ID/Password" \
+      -H "Content-Type: application/json" -H "$AUTHZ" \
+      -d '{"CurrentPw":"","NewPw":"","ResetPassword":true}' 2>/dev/null)"
+    say "PROBE-RESET-STATUS $RESET_STATUS"
+
+    say "PROBE-AFTER-SEED"
+    report_state
+    say "PROBE-EMPTY-PASSWORD $(empty_password_status)"
+    ;;
+  verify)
+    say "PROBE-AFTER-RESTART"
+    report_state
+    say "PROBE-EMPTY-PASSWORD $(empty_password_status)"
+    ;;
+  restore)
+    # Put the routing back where the canonical pass left it, so the phase after this one meets the
+    # stack it expects. The password cannot be put back and is not meant to be: what is on the
+    # account now is the unguessable one the sweep minted, which is the state every sealed account is
+    # left in on a real server.
+    POLICY="$(curl -fsS "$JELLYFIN_URL/Users/$ALICE_ID" -H "$AUTHZ" 2>/dev/null | jq -c '.Policy')"
+    [ -n "$POLICY" ] || { say "PROBE-ERROR could not read alice's policy"; exit 0; }
+    NEW_POLICY="$(printf '%s' "$POLICY" | jq -c --arg p "$RESTORE_PROVIDER" '.AuthenticationProviderId = $p')"
+    RESTORE_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$JELLYFIN_URL/Users/$ALICE_ID/Policy" \
+      -H "Content-Type: application/json" -H "$AUTHZ" -d "$NEW_POLICY" 2>/dev/null)"
+    say "PROBE-RESTORE-STATUS $RESTORE_STATUS"
+    say "PROBE-AFTER-RESTORE"
+    report_state
+    ;;
+  *)
+    say "PROBE-ERROR unknown stage '$STAGE' - expected seed, verify or restore"
+    ;;
+esac


### PR DESCRIPTION
# What & why

Refs #1440. Does **not** close it - see Notes.

#1440's own body names three things holding it open. This addresses the second:
the two halves of the remediation have never been exercised together. The
canonical harness proves the create arm. The start-up pass that seals
password-less SSO accounts has never run outside a unit test, and the issue says
why - reaching it needs a server that already holds a password-less linked
account, and every account the stack makes is made by a current build, which no
longer produces one.

This phase makes that account rather than waiting for one. Through Jellyfin's own
admin API it repoints alice at the built-in password provider, drops her
administrator flag, and resets her password away. That is the exact shape every
account provisioned up to v3.4.0.2 was stored in, and it is how the population
came about: a provider's `DefaultProvider` setting moved SSO accounts onto a real
password provider and they had no password to meet it with.

## The seed is also the control

Without it the phase would be worth nothing, so it is asserted rather than
assumed: the empty password must **mint a session** on the seeded account before
the restart.

A run that skipped that and only checked the refusal afterwards would pass
identically on a build whose start-up pass does nothing, because alice's routing
refuses that same login for a second reason the whole time. The control is what
makes the refusal after the restart attributable to the password the pass minted.

## What it asserts after the restart

- The account holds a password again.
- The empty password is refused on `/Users/AuthenticateByName`.
- Its login **routing is untouched**. The pass writes one field; asserting this
  separates it from a much larger change that would produce the same refusal.
- The audit line names exactly one sealed account, matched against the leading
  words of what `SsoAudit.PasswordlessAccountsSealed` emits rather than
  paraphrased. Only the stable head is matched, so a reworded explanation in the
  message tail does not redden the phase.

Then the routing and the admin flag go back to what the probe read before it
changed anything, rather than to constants, and a `RELOGIN_ONLY` pass proves the
stack was left working rather than merely left.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no production code is touched. The change is one
      workflow step and two harness scripts.
- [x] No secrets logged: the probe prints statuses and account state, never a
      password. The password the pass mints is never read back and cannot be.
- [ ] A security review was performed. **Not performed.**
- [ ] Review record: per lens, its verdict and its findings. **No lens was run
      and no second reader looked at this change.** There is no review record to
      report, and this box stays unticked.
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged, no
      log call is added.

## Quality checklist

- [x] No duplicated logic; the phase follows the host-driver plus network-probe
      shape the four phases beside it already use.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments say why.
- [x] Architecture-conformance tests pass - unaffected, no `.cs` file changes.
- [x] Docs impact considered: #1448 already owns documenting this pass for
      operators and is on the board; nothing here changes what the plugin does.

## Verification

- [x] `bash -n` and `sh -n` are clean on the driver and the probe.
- [x] The workflow file still parses as YAML.
- [x] **The phase passes against a real server.** Docker is not reachable on the
      machine this was written on, so nothing was run locally:

      ```
      $ docker version --format '{{.Server.Version}}'
      failed to connect to the docker API at npipe:////./pipe/dockerDesktopLinuxEngine
      ```

      The verification is a `workflow_dispatch` of `e2e-login.yml` on this branch
      with `providers: all`, which is the documented route for exercising a phase
      before a release. Run `33195200061`, all seven provider jobs green, and the
      phase's own output on the Keycloak job:

      ```
      == Seeding the pre-v3.5.0.0 account shape on alice ==
        probe| PROBE-BEFORE-SEED
        probe| PROBE-HASPASSWORD true
        probe| PROBE-PROVIDER Jellyfin.Plugin.SSO_Auth.Api.SSOController
        probe| PROBE-ADMIN true
        probe| PROBE-POLICY-STATUS 204
        probe| PROBE-RESET-STATUS 204
        probe| PROBE-AFTER-SEED
        probe| PROBE-HASPASSWORD false
        probe| PROBE-PROVIDER Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider
        probe| PROBE-EMPTY-PASSWORD 200
      == The control: the door is open before the restart ==
      PASS: the empty password mints a session on the seeded account (HTTP 200) - the door is open
      == Restarting Jellyfin so the start-up pass runs ==
        probe| PROBE-SEALED-AFTER 0s of at most 60s
        probe| PROBE-HASPASSWORD true
        probe| PROBE-PROVIDER Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider
        probe| PROBE-EMPTY-PASSWORD 401
      == Asserting ==
      PASS: alice holds a password again after the restart
      PASS: the empty password is refused on the sealed account (HTTP 401)
      PASS: alice's login routing is untouched by the pass
      == The audit line ==
        log| [SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password:
      PASS: the pass audited exactly one sealed account
      PASS: alice is routed and privileged as the canonical pass left her
      PASS: the stack still logs in, and phase 6e still refuses the manual form for alice
      PASSWORDLESS ACCOUNT SWEEP PHASE PASSED
      ```

      That is the first time the start-up pass has run against a real server, and
      the 200 is what makes the 401 under it mean anything.

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.
- [x] `shellcheck` was **not** run: it is not installed on this machine.

## The two dispatches before the green one

The first dispatch, `33194010113`, failed at this phase's own precondition, which
is what the precondition is for. The reset answered 400 and the phase stopped and
said alice still held a password, instead of continuing and proving nothing:

```
  probe| PROBE-POLICY-STATUS 204
  probe| PROBE-RESET-STATUS 400
::error::alice still holds a password after the reset (HasPassword=true)
```

The cause is Jellyfin's, not the seed's: `UserManager.ChangePassword` refuses an
empty password on an account holding `IsAdministrator`, and alice carries the
realm role this stack maps to Jellyfin admin. The seed now drops that flag in the
same write as the routing change and the restore puts it back.

The second dispatch, `33194788849`, never reached this phase. It failed four
steps earlier at `Assert secrets-at-rest and the audit trail (#928 U8)`, which
reported an audit line as missing that its own failure dump then showed present
twice. That is not this change and it is filed separately as #1453.

## Notes

**This does not close #1440.** Two of the three things that issue names as
holding it open are untouched by this change and are not mine to close: nothing
has been run against 10.11.11 with Pocket-ID on 4.3.0.47, which needs the
reporter's combination rather than this stack; and nothing here has shipped in a
release.

The phase is gated exactly like the four beside it - release and
`providers: all` only, on the canonical Keycloak stack, on a green harness - so
it does **not** run on an ordinary pull request. That is consistent with its
neighbours and it is also a real limitation: between releases this phase runs
only when somebody dispatches it. Widening the gate is a cost question about the
30-minute job budget that belongs to whoever owns that budget, not something to
decide inside this change.

The seed drives Jellyfin's admin API rather than editing its database, so the
phase depends on `POST /Users/{id}/Policy` accepting a changed
`AuthenticationProviderId` and on `POST /Users/{id}/Password` with
`ResetPassword` clearing the hash. Both are asserted in the phase itself: if
either does nothing, the seed assertions fail with the state that produced them
rather than the phase quietly proving nothing afterwards - which is exactly what
happened on the first dispatch above.

The verify reading is a bounded wait of at most 60 seconds with the elapsed time
reported, because the pass runs in an `IHostedService.StartAsync` and whether
that completes before the server answers a request is not this phase's to assert.
It came back at 0s on the run above; the bound is there so a slower host is not
read as a pass that does nothing.
