### PR TITLE
Point the README and the config page at the config-as-code reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This project publishes only to the **beta channel** for now - a stable channel o
 
 ## Configuration
 
-Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details.
+Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details. Deployments that keep their configuration in version control can declare providers in a mounted file or in environment variables instead: [Config as code](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Config-as-code) covers the document, the variable naming scheme, what wins between the sources, and how a secret is referenced rather than written into the file.
 
 ## Documentation
 

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -63,7 +63,15 @@
                   class="button-link"
                   >help page</a
                 >
-                and
+                ,
+                <a
+                  is="emby-linkbutton"
+                  href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Config-as-code"
+                  class="button-link"
+                  >config as code</a
+                >
+                for declaring providers in a mounted file or in environment
+                variables, and
                 <a
                   is="emby-linkbutton"
                   href="https://github.com/users/iderex/projects/1"


### PR DESCRIPTION
# What & why

Closes #1116.

The config-as-code reference is published on the wiki as `ffb5e35`, and this is
the other half: the two in-tree pointers the Done-when asks for. They were held
back until the page existed, deliberately - a README line and a config-page link
pointing at an unpublished wiki page is a link to nothing, which is worse than
the absence they fix.

## What is on the wiki

`Config as code`, linked from the sidebar beside the options reference. It covers
the document and where to get a correct one, a working example, the same example
as environment variables with the four rules that refuse a source whole, the
precedence table, the two secret reference forms with a compose snippet, what a
refusal looks like and that the stored configuration survives it, and what the
settings page shows for a managed provider.

The text is the draft agreed on the issue, with its settings-page section
replaced by the one written after #1415 and #1416 landed the read-only rendering.
Every load-bearing claim was re-checked against `origin/main` `bf99b374` rather
than carried from a draft written on 2026-08-23:

```
$ git grep -n 'internal const string Prefix' origin/main -- SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
origin/main:SSO-Auth/Config/DeclarativeEnvironmentConfig.cs:118:    internal const string Prefix = "JELLYFIN_SSO_CONFIG__";
$ git grep -n 'DeclaredSurface =' origin/main -- SSO-Auth/Config/DeclarativeEnvironmentConfig.cs
origin/main:SSO-Auth/Config/DeclarativeEnvironmentConfig.cs:127:    internal static readonly string[] DeclaredSurface = [nameof(PluginConfiguration.OidConfigs), nameof(PluginConfiguration.SamlConfigs)];
$ git grep -n 'EnvironmentSuffix = \|FileSuffix = ' origin/main -- SSO-Auth/Config/DeclarativeSecretReference.cs
origin/main:SSO-Auth/Config/DeclarativeSecretReference.cs:69:    internal const string EnvironmentSuffix = "Env";
origin/main:SSO-Auth/Config/DeclarativeSecretReference.cs:72:    internal const string FileSuffix = "File";
$ git grep -n 'internal const int FormatVersion' origin/main -- SSO-Auth/Config/ConfigExport.cs
origin/main:SSO-Auth/Config/ConfigExport.cs:24:    internal const int FormatVersion = 1;
```

plus the trim on a referenced file (`content.Trim()`), the refusal of an inline
secret and of both reference forms on one field, and the `Config/Export` /
`Config/Import` route names.

## What is in this change

The README sentence goes in the Configuration section beside the two wiki links
already there, and names what the page answers so a reader can tell whether it is
the page they want.

The config page carries its link in the help block that already sends an
administrator to the wiki, **not** in the managed-provider note. That note is
written by `config.js` through `tr()` with `textContent` and deliberately carries
no `data-i18n` marker, so a link cannot go in it without changing how it is
rendered, and a one-sentence state announcement is not the place to explain a
whole feature.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: this change is two links and a sentence. It touches no login
path, no crypto, no config persistence and no release pipeline.

- [x] Fail-closed preserved: no behaviour changes.
- [x] No secrets logged; nothing is logged.
- [ ] A security review was performed. **Not performed**, and not owed on this
      surface.
- [ ] Review record: **no lens was run and no second reader looked at this
      change.**
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged.

## Quality checklist

- [x] No duplicated logic; the page is the one home and both pointers link to it
      rather than restating it.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting.
- [x] Architecture-conformance tests pass.
- [x] Docs impact: this **is** the docs change, and the wiki half is published.

## Verification

- [x] `dotnet build ... --warnaserror` green on both target frameworks, 0
      warnings.
- [x] Full suite green on both: `net9.0` `Total: 3495, Failed: 0, Skipped: 4`,
      `net10.0` `Total: 3496, Failed: 0, Skipped: 4`.
- [x] Prettier clean for both changed files:

      ```
      $ npx prettier --check README.md SSO-Auth/Web/configPage.html
      All matched files use Prettier code style!
      ```

      The repository-wide run reports pre-existing style issues in 23 other files
      this change does not touch and did not introduce.
- [x] `wiki-lint.py` clean against the published wiki, so the new page's anchors
      and its sidebar entry resolve.

## Notes

Nothing here was opened in a browser, so this says nothing about how the help
block looks rendered with the extra link in it. The link target was checked as a
URL, not as a page load.

The issue was carrying `blocked-on-decision` on the reading that a wiki push
needs an account cleared to publish there. That reading is settled the other way
on #1448: the wiki is a git repository of its own and the credentials that push
branches here push it.
