### PR TITLE
Say what the sealing pass's population is instead of naming a version range

### DIFF
--- a/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
+++ b/SSO-Auth.Tests/Session/PasswordlessLinkedAccountSweepTests.cs
@@ -62,6 +62,29 @@ public class PasswordlessLinkedAccountSweepTests
     }
 
     [Fact]
+    public async Task TheAuditLineStatesThePopulationAsAState_AndNamesNoVersionRange()
+    {
+        // #1454. The line used to end "Accounts provisioned by plugin versions up to v3.4.0.2 are the
+        // expected population", and that was wrong in the direction a security line must not be wrong in.
+        // The create arm generated a password years before that version and wrote it to an object nobody
+        // saved, so every account made before the write became durable is in the population - and an
+        // operator reading a version range concluded their newer accounts were unaffected and stopped
+        // looking. The population is a STATE, which is also the only thing the sweep actually tests.
+        //
+        // Asserted on the emitted message rather than on the source, so a version range reintroduced in
+        // either the format string or a future rewording of it fails here.
+        var (sweep, config, users, crypto, audit) = Build();
+        LinkedUser(users, config, password: null);
+
+        await sweep.SweepAsync();
+
+        var line = Assert.Single(audit.Entries, e => e.Message.Contains(SealAuditMarker, StringComparison.Ordinal)).Message;
+        Assert.Contains("whatever plugin version created it", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("v3.", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("versions up to", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ASealedAccountsPasswordCarriesRealEntropy_AndTwoOfThemDiffer()
     {
         // A sweep that sealed every account with one constant would read as sealed and be one guess from

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -181,8 +181,11 @@ internal static class SsoAudit
     /// <summary>
     /// Records the boot-time sweep sealing SSO-linked accounts that carried no stored password (#1440).
     /// A Jellyfin account created without one accepts the EMPTY password on the ordinary login form, so
-    /// every account a plugin version up to and including v3.4.0.2 provisioned was reachable without the
-    /// identity provider. Fired once per boot and only when the sweep actually sealed something, so a
+    /// an account this plugin provisioned was reachable without it on every build before the create arm's
+    /// password write was made durable. THE LINE NAMES NO VERSION RANGE, and #1454 is why: that write
+    /// existed for years and reached no database, so the population is a STATE - a linked account holding
+    /// no password - rather than a span of releases, and a message naming one told an operator with newer
+    /// accounts to stop looking. Fired once per boot and only when the sweep actually sealed something, so a
     /// server that has none stays silent. Carries a COUNT and nothing else - no username, no account id and
     /// no provider (T-I1): an account already reachable by anybody is the last thing to name in a log an
     /// operator may paste into a bug report.
@@ -197,7 +200,7 @@ internal static class SsoAudit
         }
 
         logger.LogWarning(
-            "[SSO Audit] Sealed {Count} SSO-linked account(s) that had no stored password: an account with none accepts the empty password on the ordinary login form, so these were reachable without the identity provider. Each was given an unguessable password that nothing knows and nothing can recover; their login provider routing was left exactly as it was. Accounts provisioned by plugin versions up to v3.4.0.2 are the expected population.",
+            "[SSO Audit] Sealed {Count} SSO-linked account(s) that had no stored password: an account with none accepts the empty password on the ordinary login form, so these were reachable without the identity provider. Each was given an unguessable password that nothing knows and nothing can recover; their login provider routing was left exactly as it was. Any SSO-linked account that held no stored password is in this set, whatever plugin version created it.",
             sealedAccounts);
     }
 


### PR DESCRIPTION
# What & why

Closes #1454.

The audit line the start-up sealing pass writes ended:

> Accounts provisioned by plugin versions up to v3.4.0.2 are the expected
> population.

That is wrong, and wrong in the direction a security line must not be wrong in.
#1440 established why: the create arm generated a password years before that
version and wrote it to an object nobody saved, so every account created before
that write became durable is in the population. The first releases carrying the
repair are:

```
$ git tag --contains b37e7a70
4.3.0-beta.50
5.0.0-JF12-beta.64
```

So an account made by 4.3.0-beta.49 is in the population and the message told its
operator it was not. Somebody reading it concludes their newer accounts are
unaffected and stops looking.

## What it says now

> Any SSO-linked account that held no stored password is in this set, whatever
> plugin version created it.

The population is a **state** and always was - a linked account holding no
password today - which is also the only thing the pass actually tests:

```
$ git grep -n "string.IsNullOrEmpty(user.Password)" origin/main -- SSO-Auth/Api/Session/PasswordlessLinkedAccountSweep.cs
origin/main:SSO-Auth/Api/Session/PasswordlessLinkedAccountSweep.cs:91:            if (!string.IsNullOrEmpty(user.Password))
```

Saying so names no release, so the line cannot go stale the next time the sealing
versions move. The XML documentation on the method is corrected the same way and
records why it names no range, so the next reader does not helpfully put one back.

## The test

`TheAuditLineStatesThePopulationAsAState_AndNamesNoVersionRange` asserts on the
**emitted** message rather than on the source, so a version range reintroduced in
the format string or in a future rewording of it fails there.

Proven by putting the old sentence back and running the class - that one test
reddens and no other:

```
Jellyfin.Plugin.SSO_Auth.Tests.PasswordlessLinkedAccountSweepTests.TheAuditLineStatesThePopulationAsAState_AndNamesNoVersionRange [FAIL]
Assert.Contains() Failure: Sub-string not found
SSO-Auth.Tests  Total: 16, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The change is one sentence of a log message plus its test. It alters no
behaviour: the pass's population test is untouched, and it sealed exactly the
same accounts before this change as after it.

- [x] Fail-closed preserved: no branch changes.
- [x] No secrets logged: the line still carries a count and nothing else - no
      username, no account id, no provider.
- [ ] A security review was performed. **Not performed.**
- [ ] Review record: **no lens was run and no second reader looked at this
      change.**
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged;
      the only interpolated value is an int.

## Quality checklist

- [x] No duplicated logic.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment says why the range is absent.
- [x] Architecture-conformance tests pass.
- [x] Docs impact: the wiki page quoting this line is updated - see Notes.

## Verification

- [x] `dotnet build ... --warnaserror` green on both target frameworks, 0
      warnings.
- [x] Full suite green on both: `net9.0` `Total: 3496, Failed: 0, Skipped: 4`,
      `net10.0` `Total: 3497, Failed: 0, Skipped: 4`.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

The wiki page `Security Model § Password-less SSO accounts are sealed at
start-up` quotes this line verbatim and today carries a block quote saying the
last sentence is wrong. That correction becomes stale the moment this merges, so
the page is updated **after** this is on `main` rather than with it: a page
quoting a message that has not shipped is the same defect one step over, and it
is the reason the pointers on #1116 were held back too.

Found while writing the operator documentation for this pass (#1448), by checking
the version claim against the tags rather than copying it.
