### PR TITLE
Read the audit-trail log from a file rather than through a pipe [#1453]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -188,11 +188,19 @@ jobs:
           fi
 
           echo "===== audit trail ====="
-          logs="$(docker compose -f "$COMPOSE" logs jellyfin --no-color 2>/dev/null || true)"
+          # The log is written to a file and grep reads that file, deliberately: the earlier form was
+          # `printf '%s' "$logs" | grep -qF`, and under `set -o pipefail` a `grep -q` that matches early
+          # can close the pipe while printf is still writing, so printf fails its write and the pipeline
+          # takes printf's status even though grep succeeded. That reported a present audit line as
+          # missing on run 33194788849 (#1453). Nothing here may make the presence of a line depend on
+          # how long the producer of the text lives.
+          logfile="${RUNNER_TEMP:-/tmp}/jellyfin-audit.log"
+          docker compose -f "$COMPOSE" logs jellyfin --no-color >"$logfile" 2>/dev/null || true
+          echo "read $(wc -c <"$logfile") bytes of Jellyfin log from the $COMPOSE stack"
           for expected in \
             "[SSO Audit] Provider configured:" \
             "[SSO Audit] Login succeeded:"; do
-            if printf '%s' "$logs" | grep -qF "$expected"; then
+            if grep -qF "$expected" "$logfile"; then
               echo "OK: audit line present -> $expected"
             else
               echo "::error::expected audit line missing from the Jellyfin log: $expected"; exit 1


### PR DESCRIPTION
# What & why

The E2E audit-trail assertion reported a present log line as missing, which reads
as the security audit trail having gone away. Closes #1453.

The step tested the log with a pipeline under `set -euo pipefail`:

```
$ git grep -n "printf '%s' \"\$logs\" | grep -qF" f011230f -- .github/workflows/e2e-login.yml
f011230f:.github/workflows/e2e-login.yml:195:            if printf '%s' "$logs" | grep -qF "$expected"; then
```

`grep -q` exits at its first match. That can close the pipe while `printf` is
still writing, `printf` then fails its write and dies of SIGPIPE, and under
`pipefail` the pipeline carries `printf`'s status even though `grep` matched. The
`if` takes its else branch and the step prints `expected audit line missing`.

The pipeline is removed rather than made more careful: the log is written to a
file and `grep` reads that file, so the verdict no longer depends on how long the
producer of the text lives. The step also prints the byte count it read, so a run
can be read for whether the log it judged was large enough to count as evidence
rather than that having to be inferred.

## The issue said this was not reproduced. It is now

The attempt recorded on the issue built its input with `head -c N /dev/zero | tr "\0" "x"`,
which carries no newline at all, so `grep` had to read to EOF before it could
delimit a line and `printf` was never cut off. Against line-structured text, the
way a container log is, the same command fails every run. Both halves measured
here, with the workflow's own literal:

```
$ bash repro.sh
    65579 bytes  old: PRESENT PRESENT PRESENT PRESENT PRESENT
    65579 bytes  new: PRESENT PRESENT PRESENT PRESENT PRESENT
   131115 bytes  old: MISSING(status=141) MISSING(status=141) MISSING(status=141) MISSING(status=141) MISSING(status=141)
   131115 bytes  new: PRESENT PRESENT PRESENT PRESENT PRESENT
  5000043 bytes  old: MISSING(status=141) MISSING(status=141) MISSING(status=141) MISSING(status=141) MISSING(status=141)
  5000043 bytes  new: PRESENT PRESENT PRESENT PRESENT PRESENT
  one 5 MB line, no newline, old: PRESENT PRESENT PRESENT
```

141 is SIGPIPE. The threshold on this host sits between 64 KiB and 128 KiB, which
is one pipe buffer; it is a property of this host rather than a constant, and the
failing run crossed it at a smaller size.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This changes no login path, no crypto, no config persistence and no release
pipeline step; it changes one assertion in the E2E harness workflow. The items
below are answered for what it does touch.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Unchanged, nothing here is on that path.
      The assertion itself keeps its fail-closed direction: a genuinely absent
      audit line still exits 1.
- [x] No secrets logged; secrets are redacted on config export. The step writes
      the Jellyfin container log to `$RUNNER_TEMP`, which is not an artifact and
      is not printed; only its byte count is echoed.
- [ ] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline. Not applicable, none is touched.
- [x] Review record: no second reader ran on this change. It carries a
      reproduction in place of one: the defect is reproduced deterministically at
      two sizes and five runs each, the fixed shape is exercised on the same
      inputs, and both transcripts are above. CONFIRMED 1 / PLAUSIBLE 0, the
      CONFIRMED one being the defect this closes.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment says why the file is read rather
      than what the lines do.
- [x] Architecture-conformance tests pass. No new structural property is
      established in C#; the property this change establishes lives in a workflow
      file, which `ArchitectureConformanceTests` does not read.
- [x] Docs impact considered: no README or wiki text describes this step.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

- [x] `dotnet test` is green.

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3496, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3497, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The four skips are the `SsoHttpTests` listeners that bind off loopback. On Windows
that raises the firewall consent dialog, which needs an administrator, so they are
skipped rather than worked around, and the skip is disclosed here rather than
counted as a pass.

- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. There is
      none in this change.

Neither suite exercises the changed line: it is a workflow step and no test in
this repository reads `.github/workflows/`. What exercises it is this pull
request's own `E2E Login Harness` run, which the `pull_request` trigger fires on a
change to `.github/workflows/e2e-login.yml`.

## Notes

**The second Done-when, and what it is waiting for.** The issue asks that the
change be exercised on a run whose Jellyfin log is at least as large as the one
that failed. That run is this pull request's own harness run, and the size it read
is now printed by the step. The bar it has to clear, measured from the failing
run's own dump:

```
$ gh run view 33194788849 --repo Flowfin/jellyfin-plugin-sso --log \
    | grep -P "^Keycloak \(OIDC \+ SAML\)\tDump container logs" \
    | sed -E 's/^[^\t]*\t[^\t]*\t[^ ]+ //' | grep '^jellyfin' | wc -c -l
    346   50958
```

So 346 lines and 50,958 bytes, including the `jellyfin  | ` prefix compose adds.

**The third Done-when: the same shape elsewhere.** Searched across
`.github/workflows/`, `test/e2e/` and `scripts/`, restricted to files that enable
`pipefail`, for a pipeline whose right-hand side can exit before its left-hand
side has finished writing:

```
$ grep -rn --include='*.yml' --include='*.sh' -E '\|[[:space:]]*(grep[^|]*-[a-zA-Z]*q|head\b)' \
    .github/workflows test/e2e scripts
```

Sites of that shape survive the filter in seven files: `dco.yml:69`,
`regenerate-manifest.yml:89`, `saml-cert-rollover.sh:48,87,90,93`,
`passwordless-account-sweep.sh:87,88,97,98,146`, `kek-loss-fails-closed.sh:52`,
`legacy-secret-migration.sh:42,45` and `proxy-client-attribution.sh:73,201`.
`harness.sh` and `probe-saml-rollover.sh` carry the shape many times over and
enable no `pipefail` at all, so it cannot bite there.

None of them is changed here, and the reason is stated rather than assumed away.
At every one of those sites the left-hand side is a bounded artefact - a commit
message, a version string, the persisted plugin configuration, one probe's stdout
- rather than a container log that grows with the length of the run, and the
reproduction above did not fire below one pipe buffer. That is a reading of what
those producers are, not a measurement of each one at the size it reaches on a
runner, and it is written as a reading. The audit-trail step is the one whose
producer is unbounded, which is why it is the one that failed and the only one
this change touches. Widening the fix would also put this change into five files
that belong to five other open issues.
