### PR TITLE
Ask the manual-login question on every provider stack [#1440]

### DIFF
--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1259,20 +1259,19 @@ post_saml_response() {
   fi
 }
 
+# jf_auth_status USERNAME PASSWORD -> the HTTP status of a password login attempt. Uses the same
+# X-Emby-Authorization idiom as the admin authenticate in phase 1; -o keeps the body out of the way.
+jf_auth_status() {
+  curl -sS -o /tmp/authbyname.out -w '%{http_code}' -X POST "$JELLYFIN/Users/AuthenticateByName" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: $EMBY_AUTH" \
+    -d "{\"Username\":\"$1\",\"Pw\":\"$2\"}"
+}
+
 # --------------------------------------------------------------------------------------------------
 # Extended phases (#928 U5) - gated by EXTENDED_PHASES (the canonical Keycloak stack turns them on).
 # --------------------------------------------------------------------------------------------------
 if [ "$EXTENDED_PHASES" = "true" ]; then
-
-  # jf_auth_status USERNAME PASSWORD -> the HTTP status of a password login attempt. Uses the same
-  # X-Emby-Authorization idiom as the admin authenticate in phase 1; -o keeps the body out of the way.
-  jf_auth_status() {
-    curl -sS -o /tmp/authbyname.out -w '%{http_code}' -X POST "$JELLYFIN/Users/AuthenticateByName" \
-      -H "Content-Type: application/json" \
-      -H "Authorization: $EMBY_AUTH" \
-      -d "{\"Username\":\"$1\",\"Pw\":\"$2\"}"
-  }
-
   # oidc_relogin_me VARPREFIX - drives a full second OIDC login for alice and echoes /Users/Me JSON.
   oidc_relogin_me() {
     r_jar="$(mktemp)"; r_hdr="$(mktemp)"
@@ -1391,46 +1390,73 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
   else
     fail "SSO-only: the password user stayed locked out after disable - restoration failed"
   fi
+fi
 
-  # ------------------------------------------------------------------------------------------------
-  # Phase 6e - the manual login form is shut on an account the plugin provisioned (#1440). A Jellyfin
-  # user created with no password accepts the EMPTY password on that form, so an SSO account that got
-  # one would be reachable by anybody on the network without ever touching the identity provider.
-  #
-  # PLACED HERE ON PURPOSE, and the placement is the whole of what makes the assertion mean anything.
-  # It runs AFTER SSO-only was enabled and disabled again, at the one moment the phase above has just
-  # PROVEN that native password login works on this server: pwuser answered 200 one line up. Run
-  # while SSO-only was on, the same three refusals would be produced by the mode rather than by
-  # anything this issue is about, and the phase would pass on a build with the door wide open.
-  # ------------------------------------------------------------------------------------------------
-  log "== Extended: the manual login form is refused for the SSO-provisioned account =="
+# --------------------------------------------------------------------------------------------------
+# The manual login form is shut on the account the plugin provisioned (#1440), on EVERY provider stack
+# rather than on the canonical one alone. This assertion lived inside the EXTENDED_PHASES gate, and
+# `EXTENDED_PHASES: "true"` is set in test/e2e/docker-compose.yml and nowhere else, so the six other
+# harnesses booted a Jellyfin and never asked the question. The report that opened #1440 was made
+# against Pocket ID, which is one of the six.
+#
+# THE CONTROL IS PART OF THE PHASE, and it is what makes the two refusals below mean anything. On a
+# server where no password login works at all, alice is refused for a reason that has nothing to do
+# with this issue, and the phase would then pass on a build with the door wide open. So an account
+# with a known password is proven to log in FIRST, in the same run, immediately above the assertion.
+# Inside the extended block that control was phase 6d's pwuser, proven one line up by the restoration
+# assert; carrying an explicit control here is what keeps the meaning on the six stacks that never
+# run 6d, and it stops the assertion depending on the placement of a phase beside it.
+# --------------------------------------------------------------------------------------------------
+log "== The manual login form is refused for the SSO-provisioned account =="
+[ -n "${ALICE_ID:-}" ] || die "provisioned account: the OIDC round-trip captured no alice account id"
 
-  # Read the account's own record first, so a failure below names the STATE that produced it rather
-  # than leaving the next reader to guess between "no password stored" and "routed at a provider that
-  # accepts one". Both are visible here and they fail for different reasons.
-  ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
-  # jq -r, with no // fallback on purpose: `// "?"` takes its alternative for FALSE as well as for absent,
-  # so a stored password of false and a field that is not there would print the same character. That cost a
-  # wrong reading of this very line once; an absent field prints null and a false one prints false.
-  log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId')"
+# Look first, create only when absent: /Users/New refuses a duplicate name, and a second pass over the
+# same server already holds this account. Creating it is setup rather than the thing under test.
+CTL_USER="pwcontrol"; CTL_PASS="Ctl-e2e-1!"
+CTL_ID="$(curl -fsS "$JELLYFIN/Users" \
+  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+  | jq -r --arg n "$CTL_USER" '[.[] | select(.Name == $n) | .Id][0] // empty')" || die "provisioned account: could not list users"
+if [ -n "$CTL_ID" ]; then
+  log "Reusing the existing control user '$CTL_USER' ($CTL_ID)"
+else
+  CTL_NEW="$(curl -fsS -X POST "$JELLYFIN/Users/New" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+    -d "{\"Name\":\"$CTL_USER\",\"Password\":\"$CTL_PASS\"}")" || die "provisioned account: creating the control user failed"
+  CTL_ID="$(printf '%s' "$CTL_NEW" | jq -r '.Id // empty')"
+  [ -n "$CTL_ID" ] || die "provisioned account: /Users/New returned no user id"
+fi
 
-  EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
-  if [ "$EMPTY_PW_STATUS" != "200" ]; then
-    pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"
-  else
-    fail "provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP"
-  fi
+# die rather than fail: a dead control leaves the assertions below unreadable rather than failed, and a
+# phase that cannot mean anything must stop instead of reporting a verdict it has not earned.
+CTL_STATUS="$(jf_auth_status "$CTL_USER" "$CTL_PASS")"
+[ "$CTL_STATUS" = "200" ] || die "provisioned account: the control account cannot log in with its own password (HTTP $CTL_STATUS) - native password login is not working on this server, so the refusals below would prove nothing"
+pass "control: a password account CAN log in on this server (HTTP 200) - the refusals below are about alice"
 
-  # The identity provider's own password is not the Jellyfin account's password either. Without this
-  # the phase would still pass on a build that copied the IdP credential onto the account, which is a
-  # different way of leaving a guessable door on it.
-  IDP_PW_STATUS="$(jf_auth_status "alice" "$PASSWORD_ALICE")"
-  if [ "$IDP_PW_STATUS" != "200" ]; then
-    pass "provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP $IDP_PW_STATUS)"
-  else
-    fail "provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form"
-  fi
+# Read the account's own record first, so a failure below names the STATE that produced it rather
+# than leaving the next reader to guess between "no password stored" and "routed at a provider that
+# accepts one". Both are visible here and they fail for different reasons.
+ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
+# jq -r, with no // fallback on purpose: `// "?"` takes its alternative for FALSE as well as for absent,
+# so a stored password of false and a field that is not there would print the same character. That cost a
+# wrong reading of this very line once; an absent field prints null and a false one prints false.
+log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId')"
 
+EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
+if [ "$EMPTY_PW_STATUS" != "200" ]; then
+  pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"
+else
+  fail "provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP"
+fi
+
+# The identity provider's own password is not the Jellyfin account's password either. Without this
+# the phase would still pass on a build that copied the IdP credential onto the account, which is a
+# different way of leaving a guessable door on it.
+IDP_PW_STATUS="$(jf_auth_status "alice" "$PASSWORD_ALICE")"
+if [ "$IDP_PW_STATUS" != "200" ]; then
+  pass "provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP $IDP_PW_STATUS)"
+else
+  fail "provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form"
 fi
 
 # --------------------------------------------------------------------------------------------------

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1120,6 +1120,83 @@ else
   fail "replay check skipped: no state captured from the alice round-trip"
 fi
 
+# jf_auth_status USERNAME PASSWORD -> the HTTP status of a password login attempt. Uses the same
+# X-Emby-Authorization idiom as the admin authenticate in phase 1; -o keeps the body out of the way.
+jf_auth_status() {
+  curl -sS -o /tmp/authbyname.out -w '%{http_code}' -X POST "$JELLYFIN/Users/AuthenticateByName" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: $EMBY_AUTH" \
+    -d "{\"Username\":\"$1\",\"Pw\":\"$2\"}"
+}
+
+
+# --------------------------------------------------------------------------------------------------
+# The manual login form is shut on the account the plugin provisioned (#1440), on EVERY provider stack
+# rather than on the canonical one alone. This assertion lived inside the EXTENDED_PHASES gate, and
+# `EXTENDED_PHASES: "true"` is set in test/e2e/docker-compose.yml and nowhere else, so the six other
+# harnesses booted a Jellyfin and never asked the question. The report that opened #1440 was made
+# against Pocket ID, which is one of the six.
+#
+# THE CONTROL IS PART OF THE PHASE, and it is what makes the two refusals below mean anything. On a
+# server where no password login works at all, alice is refused for a reason that has nothing to do
+# with this issue, and the phase would then pass on a build with the door wide open. So an account
+# with a known password is proven to log in FIRST, in the same run, immediately above the assertion.
+# Inside the extended block that control was phase 6d's pwuser, proven one line up by the restoration
+# assert; carrying an explicit control here is what keeps the meaning on the six stacks that never
+# run 6d, and it stops the assertion depending on the placement of a phase beside it.
+# --------------------------------------------------------------------------------------------------
+log "== The manual login form is refused for the SSO-provisioned account =="
+[ -n "${ALICE_ID:-}" ] || die "provisioned account: the OIDC round-trip captured no alice account id"
+
+# Look first, create only when absent: /Users/New refuses a duplicate name, and a second pass over the
+# same server already holds this account. Creating it is setup rather than the thing under test.
+CTL_USER="pwcontrol"; CTL_PASS="Ctl-e2e-1!"
+CTL_ID="$(curl -fsS "$JELLYFIN/Users" \
+  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+  | jq -r --arg n "$CTL_USER" '[.[] | select(.Name == $n) | .Id][0] // empty')" || die "provisioned account: could not list users"
+if [ -n "$CTL_ID" ]; then
+  log "Reusing the existing control user '$CTL_USER' ($CTL_ID)"
+else
+  CTL_NEW="$(curl -fsS -X POST "$JELLYFIN/Users/New" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+    -d "{\"Name\":\"$CTL_USER\",\"Password\":\"$CTL_PASS\"}")" || die "provisioned account: creating the control user failed"
+  CTL_ID="$(printf '%s' "$CTL_NEW" | jq -r '.Id // empty')"
+  [ -n "$CTL_ID" ] || die "provisioned account: /Users/New returned no user id"
+fi
+
+# die rather than fail: a dead control leaves the assertions below unreadable rather than failed, and a
+# phase that cannot mean anything must stop instead of reporting a verdict it has not earned.
+CTL_STATUS="$(jf_auth_status "$CTL_USER" "$CTL_PASS")"
+[ "$CTL_STATUS" = "200" ] || die "provisioned account: the control account cannot log in with its own password (HTTP $CTL_STATUS) - native password login is not working on this server, so the refusals below would prove nothing"
+pass "control: a password account CAN log in on this server (HTTP 200) - the refusals below are about alice"
+
+# Read the account's own record first, so a failure below names the STATE that produced it rather
+# than leaving the next reader to guess between "no password stored" and "routed at a provider that
+# accepts one". Both are visible here and they fail for different reasons.
+ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
+# jq -r, with no // fallback on purpose: `// "?"` takes its alternative for FALSE as well as for absent,
+# so a stored password of false and a field that is not there would print the same character. That cost a
+# wrong reading of this very line once; an absent field prints null and a false one prints false.
+log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId')"
+
+EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
+if [ "$EMPTY_PW_STATUS" != "200" ]; then
+  pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"
+else
+  fail "provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP"
+fi
+
+# The identity provider's own password is not the Jellyfin account's password either. Without this
+# the phase would still pass on a build that copied the IdP credential onto the account, which is a
+# different way of leaving a guessable door on it.
+IDP_PW_STATUS="$(jf_auth_status "alice" "$PASSWORD_ALICE")"
+if [ "$IDP_PW_STATUS" != "200" ]; then
+  pass "provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP $IDP_PW_STATUS)"
+else
+  fail "provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form"
+fi
+
 # ==================================================================================================
 # SAML
 # ==================================================================================================
@@ -1259,19 +1336,11 @@ post_saml_response() {
   fi
 }
 
-# jf_auth_status USERNAME PASSWORD -> the HTTP status of a password login attempt. Uses the same
-# X-Emby-Authorization idiom as the admin authenticate in phase 1; -o keeps the body out of the way.
-jf_auth_status() {
-  curl -sS -o /tmp/authbyname.out -w '%{http_code}' -X POST "$JELLYFIN/Users/AuthenticateByName" \
-    -H "Content-Type: application/json" \
-    -H "Authorization: $EMBY_AUTH" \
-    -d "{\"Username\":\"$1\",\"Pw\":\"$2\"}"
-}
-
 # --------------------------------------------------------------------------------------------------
 # Extended phases (#928 U5) - gated by EXTENDED_PHASES (the canonical Keycloak stack turns them on).
 # --------------------------------------------------------------------------------------------------
 if [ "$EXTENDED_PHASES" = "true" ]; then
+
   # oidc_relogin_me VARPREFIX - drives a full second OIDC login for alice and echoes /Users/Me JSON.
   oidc_relogin_me() {
     r_jar="$(mktemp)"; r_hdr="$(mktemp)"
@@ -1390,73 +1459,6 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
   else
     fail "SSO-only: the password user stayed locked out after disable - restoration failed"
   fi
-fi
-
-# --------------------------------------------------------------------------------------------------
-# The manual login form is shut on the account the plugin provisioned (#1440), on EVERY provider stack
-# rather than on the canonical one alone. This assertion lived inside the EXTENDED_PHASES gate, and
-# `EXTENDED_PHASES: "true"` is set in test/e2e/docker-compose.yml and nowhere else, so the six other
-# harnesses booted a Jellyfin and never asked the question. The report that opened #1440 was made
-# against Pocket ID, which is one of the six.
-#
-# THE CONTROL IS PART OF THE PHASE, and it is what makes the two refusals below mean anything. On a
-# server where no password login works at all, alice is refused for a reason that has nothing to do
-# with this issue, and the phase would then pass on a build with the door wide open. So an account
-# with a known password is proven to log in FIRST, in the same run, immediately above the assertion.
-# Inside the extended block that control was phase 6d's pwuser, proven one line up by the restoration
-# assert; carrying an explicit control here is what keeps the meaning on the six stacks that never
-# run 6d, and it stops the assertion depending on the placement of a phase beside it.
-# --------------------------------------------------------------------------------------------------
-log "== The manual login form is refused for the SSO-provisioned account =="
-[ -n "${ALICE_ID:-}" ] || die "provisioned account: the OIDC round-trip captured no alice account id"
-
-# Look first, create only when absent: /Users/New refuses a duplicate name, and a second pass over the
-# same server already holds this account. Creating it is setup rather than the thing under test.
-CTL_USER="pwcontrol"; CTL_PASS="Ctl-e2e-1!"
-CTL_ID="$(curl -fsS "$JELLYFIN/Users" \
-  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-  | jq -r --arg n "$CTL_USER" '[.[] | select(.Name == $n) | .Id][0] // empty')" || die "provisioned account: could not list users"
-if [ -n "$CTL_ID" ]; then
-  log "Reusing the existing control user '$CTL_USER' ($CTL_ID)"
-else
-  CTL_NEW="$(curl -fsS -X POST "$JELLYFIN/Users/New" \
-    -H "Content-Type: application/json" \
-    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-    -d "{\"Name\":\"$CTL_USER\",\"Password\":\"$CTL_PASS\"}")" || die "provisioned account: creating the control user failed"
-  CTL_ID="$(printf '%s' "$CTL_NEW" | jq -r '.Id // empty')"
-  [ -n "$CTL_ID" ] || die "provisioned account: /Users/New returned no user id"
-fi
-
-# die rather than fail: a dead control leaves the assertions below unreadable rather than failed, and a
-# phase that cannot mean anything must stop instead of reporting a verdict it has not earned.
-CTL_STATUS="$(jf_auth_status "$CTL_USER" "$CTL_PASS")"
-[ "$CTL_STATUS" = "200" ] || die "provisioned account: the control account cannot log in with its own password (HTTP $CTL_STATUS) - native password login is not working on this server, so the refusals below would prove nothing"
-pass "control: a password account CAN log in on this server (HTTP 200) - the refusals below are about alice"
-
-# Read the account's own record first, so a failure below names the STATE that produced it rather
-# than leaving the next reader to guess between "no password stored" and "routed at a provider that
-# accepts one". Both are visible here and they fail for different reasons.
-ALICE_REC="$(curl -fsS "$JELLYFIN/Users/$ALICE_ID" -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"")" || ALICE_REC=""
-# jq -r, with no // fallback on purpose: `// "?"` takes its alternative for FALSE as well as for absent,
-# so a stored password of false and a field that is not there would print the same character. That cost a
-# wrong reading of this very line once; an absent field prints null and a false one prints false.
-log "alice: HasPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasPassword') HasConfiguredPassword=$(printf '%s' "$ALICE_REC" | jq -r '.HasConfiguredPassword') AuthenticationProviderId=$(printf '%s' "$ALICE_REC" | jq -r '.Policy.AuthenticationProviderId')"
-
-EMPTY_PW_STATUS="$(jf_auth_status "alice" "")"
-if [ "$EMPTY_PW_STATUS" != "200" ]; then
-  pass "provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP $EMPTY_PW_STATUS)"
-else
-  fail "provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP"
-fi
-
-# The identity provider's own password is not the Jellyfin account's password either. Without this
-# the phase would still pass on a build that copied the IdP credential onto the account, which is a
-# different way of leaving a guessable door on it.
-IDP_PW_STATUS="$(jf_auth_status "alice" "$PASSWORD_ALICE")"
-if [ "$IDP_PW_STATUS" != "200" ]; then
-  pass "provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP $IDP_PW_STATUS)"
-else
-  fail "provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form"
 fi
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What & why

Refs #1440. Does **not** close it - see Notes.

#1440's first open item is that nothing has been run against Jellyfin 10.11.11
with Pocket ID, the provider it was reported against. Reading the harness says
why, and the reason is not that the stack is missing.

Every one of the seven stacks pins the reporter's server version:

```
$ git grep -n -E 'image:\s*.*jellyfin' origin/main -- test/e2e
origin/main:test/e2e/authelia/docker-compose.yml:37:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/authentik/docker-compose.yml:85:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/dex/docker-compose.yml:29:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/docker-compose.yml:40:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/kanidm/docker-compose.yml:40:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/pocket-id/docker-compose.yml:47:    image: jellyfin/jellyfin:10.11.11
origin/main:test/e2e/zitadel/docker-compose.yml:84:    image: jellyfin/jellyfin:10.11.11
```

What is missing is the question. The assertion added for this issue sits inside
the `EXTENDED_PHASES` gate, and that flag is turned on in exactly one file:

```
$ git grep -n "EXTENDED_PHASES" origin/main -- test/e2e
origin/main:test/e2e/docker-compose.yml:72:      EXTENDED_PHASES: "true"
origin/main:test/e2e/harness/harness.sh:77:EXTENDED_PHASES="${EXTENDED_PHASES:-false}"
origin/main:test/e2e/harness/harness.sh:1263:# Extended phases (#928 U5) - gated by EXTENDED_PHASES (the canonical Keycloak stack turns them on).
origin/main:test/e2e/harness/harness.sh:1265:if [ "$EXTENDED_PHASES" = "true" ]; then
origin/main:test/e2e/harness/harness.sh:1316:    die "extended: EXTENDED_PHASES is on but ADMIN_ROLES_JSON is empty - the stack must seed an admin role"
origin/main:test/e2e/harness/harness.sh:1479:# Extended SAML admin surfaces (#928 U8), gated by EXTENDED_PHASES: the plugin's own metadata importer
origin/main:test/e2e/harness/harness.sh:1483:if [ "$EXTENDED_PHASES" = "true" ]; then
origin/main:test/e2e/harness/harness.sh:1558:  if [ "$EXTENDED_PHASES" = "true" ]; then
```

So six of the seven harnesses booted a Jellyfin 10.11.11, provisioned an account
through a real OIDC login, and never asked whether the manual login form was shut
on it. Pocket ID is one of the six.

## What changed

The assertion runs after the extended block rather than inside it, so every stack
in the matrix makes it, and `jf_auth_status` moves out of the gate with it.
Nothing else about the extended phases moves.

## The control moves with the assertion, and becomes part of it

The comment the old placement carried is the important half of this change, so it
is kept rather than dropped. It said the placement was the whole of what made the
assertion mean anything: it ran one line after phase 6d had **proven** that native
password login works on that server, because on a server where no password login
works at all the same refusals are produced by that and not by anything this issue
is about - and the phase would then pass on a build with the door wide open.

Six stacks never run phase 6d, so carrying the assertion to them without its
control would have shipped exactly that fail-open. The phase now creates its own
known-password account and proves it logs in first, in the same run, immediately
above the assertion. That also stops the assertion depending on where a
neighbouring phase happens to sit.

A dead control is `die` rather than `fail`: it leaves the two assertions
unreadable rather than failed, and a phase that cannot mean anything must stop
instead of reporting a verdict it has not earned.

## The first attempt at this was wrong, and the falsifier is what said so

The second commit exists because the first placement did not work, and the shape
of the mistake is worth keeping rather than tidying away.

The assertion was first put after the `EXTENDED_PHASES` block. That block is
itself inside `if [ "$RUN_SAML" = "true" ]`, which opens at the SAML banner and
does not close until the end of the file:

```
$ grep -n 'RUN_SAML' test/e2e/harness/harness.sh   # at origin/main
31:RUN_SAML="${RUN_SAML:-true}"
1127:# sets RUN_SAML=false, and the SAML phases below are skipped.
1128:if [ "$RUN_SAML" = "true" ]; then
1655:  log "== SAML phases skipped (RUN_SAML=$RUN_SAML) =="
```

So the assertion still reached only the two stacks that speak SAML, and the five
OIDC-only ones skipped it exactly as before. The falsifier reddened Keycloak and
authentik and left Pocket ID, Dex, Authelia, Kanidm and Zitadel green, and the
Pocket ID transcript from that run goes from the replay check to the end with no
line from the phase in it at all:

```
harness-1   | PASS: replayed state refused (HTTP 400, one-time-use holds)
harness-1   | == SAML phases skipped (RUN_SAML=false) ==
harness-1   | ALL E2E CHECKS PASSED
```

A run of the change on its own would have been green on all seven and would have
been read as coverage that did not exist. The helper and the phase now sit above
the SAML gate.

This also means the extended phases as a whole are governed by `RUN_SAML`, which
costs nothing today because `EXTENDED_PHASES` is only ever set on the one stack
that has `RUN_SAML=true`. It is written here because it is a trap rather than a
defect, and it is what this change walked into.

## Proof that the arms bite

The harness needs Docker and there is none on the machine this was written on, so
every line below comes from a dispatched run rather than a local one. Two probe
branches carry the falsifications; neither is for merge, and both were rebuilt on
the corrected base after the placement moved.

**The change, `providers: all`, run `33309768920`: seven of seven green.** On
Pocket ID, the provider #1440 was reported against, on Jellyfin 10.11.11:

```
harness-1   | == The manual login form is refused for the SSO-provisioned account ==
harness-1   | PASS: control: a password account CAN log in on this server (HTTP 200) - the refusals below are about alice
harness-1   | alice: HasPassword=true HasConfiguredPassword=true AuthenticationProviderId=Jellyfin.Plugin.SSO_Auth.Api.SSOController
harness-1   | PASS: provisioned account: the EMPTY password is refused on /Users/AuthenticateByName (HTTP 401)
harness-1   | PASS: provisioned account: the IdP password is refused on /Users/AuthenticateByName (HTTP 401)
harness-1   | ALL E2E CHECKS PASSED
```

**Both refusal arms are falsified, on all seven stacks.**
`probe/1440-provisioned-account-falsifier-2`, run `33309770585`, points each arm
at an account that answers 200: a `pwnone` account created through `/Users/New`
with no password at all - the exact state #1440 reports - for the empty-password
arm, and the control account with its own working password for the IdP-password
arm. Every one of the seven jobs failed. Pocket ID:

```
harness-1   | == The manual login form is refused for the SSO-provisioned account ==
harness-1   | PASS: control: a password account CAN log in on this server (HTTP 200) - the refusals below are about alice
harness-1   | FAIL: provisioned account: the empty password MINTED A SESSION for alice - the account is reachable without the IdP
harness-1   | FAIL: provisioned account: alice's IdP password MINTED A JELLYFIN SESSION through the manual form
harness-1   | E2E CHECKS FAILED: 2 assertion(s) did not hold
```

The control still passes there, which is the part that matters: the arms go red
while the phase's own precondition holds, so they are red for what they assert
and not because the stack was broken.

**The control arm is falsified, on all seven stacks.**
`probe/1440-control-arm-falsifier-2`, run `33309791583`, gives the control a
password that cannot work. Every one of the seven jobs failed, and the phase
stops at the control instead of reaching either assertion:

```
harness-1   | == The manual login form is refused for the SSO-provisioned account ==
jellyfin-1  | [11:48:51] [INF] [11] Jellyfin.Server.Implementations.Users.UserManager: Authentication request for pwcontrol has been denied (IP: 11.0.5.4).
harness-1   | FATAL: provisioned account: the control account cannot log in with its own password (HTTP 401) - native password login is not working on this server, so the refusals below would prove nothing
##[error]Process completed with exit code 1.
```

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

Every box in this section is left unticked, and the reason is the same for all
five: no product code is in the diff. The change is confined to
`test/e2e/harness/harness.sh`, so validation, config persistence and the release
pipeline are all untouched, and no review was run. Ticking a box here would claim
work that was not done rather than describe a diff that cannot reach the surface
it names.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The assertion had one home and still has one; this moves that home rather than
adding a second copy for the six stacks. `test/e2e/README.md` documents the
stacks and the `RELOGIN_ONLY` second pass and names neither `EXTENDED_PHASES` nor
this assertion, so there is nothing in it that this change makes wrong.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No C# is in the diff, so neither build box can be ticked for work this change
caused. Both were run anyway and are green at this head, on both target
frameworks, with warnings promoted to errors:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3496, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,847s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3497, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,393s
```

The four skipped tests are the four this suite already skips on this host: they
bind a listener off loopback, which needs an administrator. They were not worked
around.

Prettier's glob covers `js/html/md/css/scss` and this change touches one `.sh`
file, so the third box is true by the diff carrying nothing it reads.

## Notes

**This does not meet #1440's Done-when and nothing here asks for it to be
closed.** What it moves is the first of the three open items, and it moves part
of it rather than all of it. After this, the current build is asserted against
Pocket ID on 10.11.11 to refuse both the empty password and the IdP password on a
provisioned account. What it still does not establish is what happened on
4.3.0.47, the build the report was made against: the harness packages the tree it
is run from, so no dispatch of it can speak for a released build.

One thing found while looking for the evidence and filed rather than fixed here:
the full provider matrix has never actually run on a release, so the six stacks
this change reaches are still exercised only by the nightly canonical run, a pull
request that touches the harness, or a hand dispatch. That is #1462, and it is
what decides whether this assertion runs again after today without somebody asking
for it.

The start-up sweep phase stays where it is, on the canonical stack at
`providers: all` only. It restarts Jellyfin and reads an audit line, which is a
different cost from two `curl` calls, and widening it is not this change.

The phase creates a `pwcontrol` account on every stack and does not remove it,
which is what phase 6d already does with `pwuser`. Nothing in the harness asserts
on how many accounts exist, checked at this head rather than assumed. The user
list is read twice and both readings look a name up rather than counting:

```
$ grep -n '"\$JELLYFIN/Users"' test/e2e/harness/harness.sh
1154:CTL_ID="$(curl -fsS "$JELLYFIN/Users" \
1402:  PW_ID="$(curl -fsS "$JELLYFIN/Users" \
```

The first of those is this change's own.

No second reader looked at this change.
