### PR TITLE
Gate the JF12 beta publish on the provider matrix and disclose what it covers [#1464]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -7,11 +7,22 @@
 # dispatch exercise ONLY the canonical Keycloak harness (there is deliberately no `push` trigger - the PR
 # run already validated it, and paying the ~10-min Docker run again on the merge commit is wasteful). The
 # FULL provider matrix (one entry per shipped test/e2e/<provider>/ harness) is release-gate evidence rather
-# than a per-commit cost, and it is reached through `workflow_call`: publish-beta.yml calls this workflow as
-# a job at the commit it is about to ship, so a beta is published only behind a green seven-stack pass. A
+# than a per-commit cost, and it is reached through `workflow_call`: publish-beta.yml (JF10.11, #1462) and
+# publish-jf12-beta.yml (JF12, #1464) each call this workflow as a job at the commit they are about to
+# ship, so neither beta is published except behind a green seven-stack pass. A
 # manual dispatch with `providers: all` is the other way in, and is how a newly added harness is proven
 # green before a publish. This runs on the GitHub runners' working Docker; it also runs locally once Docker
 # is restored (see test/e2e/README.md).
+#
+# WHAT A PASS HERE IS ABOUT, and it is one target framework rather than both (#1464). The build step
+# below packages `dotnet-target: net9.0` and every test/e2e/*/docker-compose.yml boots
+# `jellyfin/jellyfin:10.11.11`, so the artifact this harness installs is the JF10.11 one. For the
+# JF10.11 caller that is the shipped artifact exactly; for the JF12 caller it is not - that release
+# carries the net10.0 build at targetAbi 12.0.0.0, which will not load into a 10.11 server at all, and
+# what its pass covers is the provider-facing source of the one multi-target tree rather than its
+# bytes. The caller carries that disclosure at the job it gates; this note is the same bound stated
+# where the two pins live, so a later change to either does not have to be traced back from there.
+# Running the matrix against a JF12 server is #1466.
 name: E2E Login Harness
 
 on:

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -78,9 +78,60 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
         fi
 
+  # The full seven-stack provider matrix, on the exact commit this beta ships (#1464). Until this job
+  # existed the JF12 line published daily behind no cross-provider evidence at all: #1462 wired the
+  # matrix into the JF10.11 leg and left this one covered only by the `release:` trigger it removed,
+  # which had never once started a run. Calling the harness as a job runs it INSIDE this run, so the
+  # pass belongs to the commit being published rather than to whatever main held when a cron last fired.
+  #
+  # WHAT THIS PASS IS NOT EVIDENCE ABOUT, stated here because the job name cannot carry it. The harness
+  # builds and installs a net9.0 package into a Jellyfin 10.11.11 server:
+  #
+  #     git grep -c 'dotnet-target: "net9[.]0"' -- .github/workflows/e2e-login.yml
+  #     .github/workflows/e2e-login.yml:1
+  #     git grep -c 'dotnet-target: "net10[.]0"' -- .github/workflows/publish-jf12-beta.yml
+  #     .github/workflows/publish-jf12-beta.yml:1
+  #     grep -rln 'image: jellyfin/jellyfin:10.11.11' test/e2e/ | wc -l
+  #     7
+  #
+  # while the release this job goes on to publish is the net10.0 build at targetAbi 12.0.0.0 that
+  # build-jf12.yaml declares. So the seven stacks exercise the provider-facing SOURCE at this commit -
+  # one multi-target tree since #954 - and not the bytes in the artifact. What the split can break on
+  # its own is outside the pass: the two build metadata files ship different closures, and a packaged
+  # load failure of the #181/#590 class is precisely what a pass on the other target framework cannot
+  # see.
+  #
+  # WHY THAT IS ACCEPTED HERE rather than parameterising the harness. A net10.0 package at ABI 12.0
+  # will not load into the 10.11.11 server every compose file pins, so pointing the harness at the JF12
+  # target means standing up a JF12 server too. One exists to try, read 2026-08-30:
+  #
+  #     curl -sS 'https://hub.docker.com/v2/repositories/jellyfin/jellyfin/tags?page_size=100&ordering=last_updated' \
+  #       | grep -o '12[.]0-rc6' | head -1
+  #     12.0-rc6
+  #
+  # That is a harness of its own - seven compose files, a second build-metadata swap, and a driver
+  # nobody has yet watched pass against a 12.0 server - and gating the daily JF12 publish on it while
+  # it is unproven would stop this line rather than gate it. #1466 carries that work. Until it lands
+  # the choice is between this pass, disclosed, and no cross-provider pass at all.
+  #
+  # AHEAD of the build job, so a red stack stops the publish instead of documenting it afterwards, and
+  # gated on the same output as the build, so an unchanged main still costs nothing.
+  provider-matrix:
+    name: Provider matrix (net9.0 build - see the note above)
+    needs: gate
+    if: needs.gate.outputs.changed == 'true'
+    # A called workflow can hold no more than the calling job grants it. e2e-login.yml denies everything
+    # at its top level and its harness job asks for `contents: read` to check out and build the plugin,
+    # so that is granted here and nothing else is - this job publishes nothing.
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-login.yml
+    with:
+      providers: all
+
   build:
     name: Build & publish JF12 beta
-    needs: gate
+    needs: [gate, provider-matrix]
     if: needs.gate.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -17,6 +17,11 @@ name: Publish JF12 Stable
 # (ignorePrereleases: true) - the same stable pages branch publish.yml writes. Each release ships its own
 # build.yaml, so Jellyfin filters client-side by targetAbi: a 12.0 server installs the 5.0 build, a 10.11
 # server the 4.x build, from one stable manifest - no separate JF12 stable manifest is needed.
+#
+# NO PROVIDER MATRIX HERE, DELIBERATELY, FOR THE SAME REASON AS publish.yml (#1464). The two beta legs
+# are gated on the seven-stack harness because they publish daily; both stable legs write the empty
+# `manifest-release` branch and have published nothing since #954, so a gate added here would be one no
+# run has ever started. It is wired in the change that cuts the first stable tag of this line.
 on:
   push:
     tags:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,14 @@ name: Publish Release
 # `-stable` tags, never the beta prereleases (`X.Y.Z-beta.*`). The upload job CREATES
 # and publishes the release from the tag in CI - never minted out of band, because a
 # deleted immutable release permanently burns its tag.
+#
+# NO PROVIDER MATRIX HERE, DELIBERATELY, AND IT IS A PROMISE RATHER THAN A GATE (#1464). #1462 wired the
+# seven-stack harness into publish-beta.yml and #1464 into publish-jf12-beta.yml, both of which publish
+# daily. This leg has published nothing since #954 retired the stable channel - `manifest-release` is
+# empty and the first `-stable` tag re-opens it - so wiring a gate in now would add a job no run has
+# ever started, which is the defect #1462 was about rather than a fix for it. It is wired when the
+# stable channel re-opens, in the same change that cuts the first stable tag, and this sentence is the
+# whole of the coverage this leg has until then.
 on:
   push:
     tags:


### PR DESCRIPTION
# What & why

The JF12 beta line publishes daily from `main` and was gated by nothing. #1462 wired the
seven-stack provider matrix into `publish-beta.yml` as a called job and removed the `release:`
trigger that had covered both legs on paper - a trigger that had never once started a run,
because a publish seals its release with the run's own automation credential and an event raised
with that credential starts no further workflow run. This leg was left uncovered rather than
newly uncovered, and this change covers it.

`publish-jf12-beta.yml` now calls `e2e-login.yml` with `providers: all`, ahead of the build job
and gated on the same `gate.outputs.changed` output. The job body is identical to #1462's apart
from its name:

```
$ npx --yes js-yaml .github/workflows/publish-jf12-beta.yml > a.json
$ npx --yes js-yaml .github/workflows/publish-beta.yml    > b.json
$ node -e "const s=o=>JSON.stringify({needs:o.needs,if:o.if,permissions:o.permissions,uses:o.uses,with:o.with});
           console.log(s(require('./a.json').jobs['provider-matrix'])===s(require('./b.json').jobs['provider-matrix']))"
true
```

Closes #1464.

## What this pass is NOT evidence about, and why the change says so out loud

The harness packages `net9.0` and every compose file boots `jellyfin/jellyfin:10.11.11`, while
this leg ships the `net10.0` build at `targetAbi 12.0.0.0`:

```
$ git grep -c 'dotnet-target: "net9[.]0"' -- .github/workflows/e2e-login.yml
.github/workflows/e2e-login.yml:1
$ git grep -c 'dotnet-target: "net10[.]0"' -- .github/workflows/publish-jf12-beta.yml
.github/workflows/publish-jf12-beta.yml:1
$ grep -rln 'image: jellyfin/jellyfin:10.11.11' test/e2e/ | wc -l
7
```

So the seven stacks exercise the provider-facing source of the one multi-target tree at the
commit being published, and not the bytes in the zip. The two build metadata files ship different
closures, and a packaged load failure of the #181/#590 class is precisely what a pass on the other
target framework cannot see. #1464 says a silent copy of #1462's job "would look like coverage",
and that is why the disclosure sits in the workflow at the job it gates, and once more in
`e2e-login.yml` where the two pins live, rather than only here.

This takes the second branch of #1464's first Done-when clause. The first branch - a pass against
the target framework the release contains - is #1466, opened with the three parts it needs
(`dotnet-target`, the `build.yaml` / `build-jf12.yaml` swap, and the server image in seven compose
files) and the reason it is not this change: nobody has watched the driver pass against a 12.0
server, and gating a daily publish on that unproven would stop the line rather than gate it. A
12.0 server image does exist to build it against, read 2026-08-30:

```
$ curl -sS 'https://hub.docker.com/v2/repositories/jellyfin/jellyfin/tags?page_size=100&ordering=last_updated' \
    | grep -o '12[.]0-rc6' | head -1
12.0-rc6
```

## The two stable legs

`publish.yml` and `publish-jf12-stable.yml` each get a sentence saying the matrix is deliberately
absent until the stable channel re-opens. Both write the empty `manifest-release` branch and have
published nothing since #954, so a gate added there today would be one no run has ever started -
the defect #1462 was about, not a fix for it. That is #1464's second Done-when clause, taken on
its stated alternative.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Filled in because this touches the release pipeline.

- [x] Fail-closed preserved: `build` carries no `always()` / `!cancelled()`, so a failed or
      skipped `provider-matrix` short-circuits it and no beta is published. When `gate` reports
      `changed=false` both jobs skip together, since both carry the same `if`. No new way to reach
      `build` was added.
- [x] No secrets logged; secrets are redacted on config export. No secret is touched: the new job
      grants `contents: read` and nothing else, under a workflow that denies everything by default.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or
      the release pipeline. **NO SECOND READER LOOKED AT THIS.** What exists is the reasoning in
      the line above and the checks below, written by the author of the change, and that is not a
      review.
- [x] Review record: one reader, no lenses run, **CONFIRMED 0 / PLAUSIBLE 0** raised. The residual
      is named under Notes rather than hidden inside a tick.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added or moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. The job is a
      `workflow_call` to the existing harness - not a second copy of it.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comments say why, not what.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes
      is locked in as a rule in `ArchitectureConformanceTests`. No C# changed; this diff leaves the
      suite untouched.
- [x] Docs impact considered: workflow-internal, no README or wiki surface changes.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. **NOT RUN** - this diff changes four
      workflow YAML files and no C#, so a local build judges nothing about it. CI's `build` check
      runs it on this head.
- [ ] `dotnet test` is green. **NOT RUN**, same reason.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. There are none in this
      diff; `prettier_options` in `prettier.yml` is `--check **/*.{js,html,md,css,scss}` and
      matches no changed file.

What was verified instead, since no suite here reaches a workflow file:

```
$ for f in publish-jf12-beta.yml e2e-login.yml publish.yml publish-jf12-stable.yml; do
    npx --yes js-yaml ".github/workflows/$f" > /dev/null && echo "$f parses"; done
publish-jf12-beta.yml parses
e2e-login.yml parses
publish.yml parses
publish-jf12-stable.yml parses
```

and every command quoted in the added comments was re-run against this head and reproduced its
pasted output.

## Notes

**The new gate has never had a first run, and neither has #1462's.** `publish-beta.yml`'s newest
run predates the merge that added its matrix job:

```
$ gh run list --repo Flowfin/jellyfin-plugin-sso --workflow publish-beta.yml --limit 1 \
    --json createdAt,conclusion --jq '.[] | "\(.createdAt)\t\(.conclusion)"'
2026-08-30T09:52:42Z	success
$ gh issue view 1462 --repo Flowfin/jellyfin-plugin-sso --json closedAt --jq .closedAt
2026-08-30T17:33:35Z
```

So the calling pattern this change copies is unexercised in a publish run. Both legs' first real
exercise is the 04:00 UTC nightly. Dispatching `publish-jf12-beta.yml` by hand to prove it sooner
would mint and publish a real beta release, which is not a thing to do to prove a workflow, so it
was not done. If the call is wrong the failure mode is a publish that does not happen, surfaced by
"Publish failure alert", rather than a bad artifact.

**This doubles the daily seven-stack Docker cost, normally for one commit.** `nightly-betas.yml`
dispatches both legs `--ref main` from one run, so in the ordinary case both matrices run the same
seven stacks at the same commit. Reading the other leg's result instead was rejected: a gate that
trusts a different run's verdict is the paper coverage #1462 removed, and the two dispatches can
land on different commits whenever `main` moves between them or either leg is run by hand.

**The harness is healthy right now, checked rather than assumed.** Two full-matrix dispatches
today were green on real branches; every red one was a `probe/*` falsifier branch built to be red:

```
$ gh run list --repo Flowfin/jellyfin-plugin-sso --workflow e2e-login.yml --limit 12 \
    --json conclusion,event,headBranch --jq '.[] | select(.event=="workflow_dispatch")
      | "\(.conclusion)\t\(.headBranch)"'
failure	probe/1440-control-arm-falsifier-2
failure	probe/1440-provisioned-account-falsifier-2
success	harden/provisioned-account-every-provider-1440
failure	probe/1440-control-arm-falsifier
failure	probe/1440-provisioned-account-falsifier
success	harden/provisioned-account-every-provider-1440
```

**Availability trade, stated rather than buried:** a red stack now blocks the JF12 nightly beta,
as it already does the JF10.11 one. That is the trade #1464 asked for. #1465 is open on the
Zitadel harness redding in a gap; if it fires, both beta legs stall until it is fixed.

**Out of scope, and left alone deliberately:** the release-note text in `publish-jf12-beta.yml`
says the 5.0 line "clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is
available". An RC is available, as the `12.0-rc6` reading above shows, so that condition has been
met and nothing has acted on it. It is recorded on #1466 rather than edited here, because acting
on it is that issue's work and rewording it without acting would only move the claim.
