### PR TITLE
Let the E2E harness build and boot the JF12 generation [#1466]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -47,6 +47,15 @@ on:
         description: "Which provider harnesses to run"
         type: string
         default: canonical
+      generation:
+        # Which Jellyfin generation the harness builds and boots (#1466). `jf10.11` packages the
+        # net9.0 build and boots a 10.11 server - the artifact publish-beta.yml ships. `jf12`
+        # packages the net10.0 build from build-jf12.yaml and boots a 12.0 server - the artifact
+        # publish-jf12-beta.yml ships. The default is jf10.11, so every existing caller and every
+        # other trigger keeps exactly the stack it had.
+        description: "Which Jellyfin generation to build and boot: jf10.11 or jf12"
+        type: string
+        default: jf10.11
   # On-demand from any branch. `providers: all` runs the FULL matrix, which is the only way to exercise a
   # newly-added provider harness before a publish actually happens - without it a new entry's first-ever
   # run would be on publish day.
@@ -59,6 +68,13 @@ on:
           - canonical
           - all
         default: canonical
+      generation:
+        description: "Which Jellyfin generation to build and boot"
+        type: choice
+        options:
+          - jf10.11
+          - jf12
+        default: jf10.11
 
 # Deny-all at the workflow level; the e2e job reads the repo to build the plugin and needs nothing else.
 permissions: {}
@@ -89,7 +105,53 @@ jobs:
       # can be gated on the TRIGGER without being gated on which provider it is looking at, and the
       # full-matrix-only phases below need exactly that (#1140).
       full: ${{ steps.pick.outputs.full }}
+      # The four facts the generation decides (#1466), derived once here rather than re-branched at
+      # every step that needs one.
+      dotnet_target: ${{ steps.gen.outputs.dotnet_target }}
+      build_metadata: ${{ steps.gen.outputs.build_metadata }}
+      jellyfin_image_tag: ${{ steps.gen.outputs.jellyfin_image_tag }}
+      dotnet_sdks: ${{ steps.gen.outputs.dotnet_sdks }}
     steps:
+      - id: gen
+        env:
+          # Handled exactly like INPUT_ALL below: the value reaches the shell only through env, never
+          # interpolated into the script body, and it is empty on the schedule and pull-request
+          # routes - which is the jf10.11 default rather than a missing answer.
+          INPUT_GENERATION: ${{ inputs.generation }}
+        run: |
+          set -euo pipefail
+          # THE SERVER TAG IS PINNED TO THE VERSION THE PLUGIN COMPILES AGAINST, for the reason the
+          # canonical compose file gives at its own image line: .NET will not bind an assembly
+          # reference DOWN, so a server older than the referenced Jellyfin assemblies refuses to load
+          # the plugin. SSO-Auth.csproj pins 12.0.0-rc2 for net10.0, so the tag here is 12.0-rc2 and
+          # deliberately not the newest 12.0 image; moving one without the other reintroduces exactly
+          # the mismatch that pin exists to prevent.
+          #
+          #     git grep -n "JellyfinVersion Condition" -- SSO-Auth/SSO-Auth.csproj
+          #
+          # Anything other than the literal jf12 - including the empty value the schedule and
+          # pull-request routes carry - is jf10.11. An unrecognised value is the DEFAULT stack rather
+          # than a failure, because the alternative is a typo in a caller silently publishing behind a
+          # matrix that never ran.
+          if [ "${INPUT_GENERATION:-}" = "jf12" ]; then
+            target=net10.0; metadata=build-jf12.yaml; image=12.0-rc2; needs_net10=yes
+          else
+            target=net9.0; metadata=build.yaml; image=10.11.11; needs_net10=no
+          fi
+          echo "generation ${INPUT_GENERATION:-(unset)} resolves to: $target, $metadata, jellyfin:$image"
+          echo "dotnet_target=$target" >> "$GITHUB_OUTPUT"
+          echo "build_metadata=$metadata" >> "$GITHUB_OUTPUT"
+          echo "jellyfin_image_tag=$image" >> "$GITHUB_OUTPUT"
+          # setup-dotnet takes one version per line, so this output is multi-line and needs the
+          # delimiter form. net9.0 is installed for BOTH generations: the multi-target restore needs
+          # it even when the package being built is the net10.0 one.
+          {
+            echo "dotnet_sdks<<SDKS_EOF"
+            echo "9.0.x"
+            if [ "$needs_net10" = "yes" ]; then echo "10.0.x"; fi
+            echo "SDKS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - id: pick
         env:
           # A manual dispatch or a reusable-workflow call may opt into the full matrix. The input is a
@@ -128,6 +190,12 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    # Job-level, so every `docker compose` invocation in this job names the same stack. Set on only
+    # some of them, the run would bring one server up and the log read and the teardown would address
+    # another. Each compose file defaults the tag when the variable is unset, so a local
+    # `docker compose up` on any of them is unchanged (#1466).
+    env:
+      JELLYFIN_IMAGE_TAG: ${{ needs.select.outputs.jellyfin_image_tag }}
     strategy:
       # One provider's failure must not cancel the others in the release matrix.
       fail-fast: false
@@ -141,13 +209,31 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "9.0.x"
+          # One SDK for jf10.11, both for jf12 - see the note where this output is derived.
+          dotnet-version: ${{ needs.select.outputs.dotnet_sdks }}
+
+      - name: Use the JF12 build metadata
+        # JPRM reads build.yaml, and for the jf12 generation the shipped metadata is build-jf12.yaml:
+        # version 5.0, targetAbi 12.0.0.0, framework net10.0, and a shipping closure that differs from
+        # the net9 one - on .NET 10 the SAML crypto assemblies are framework-provided and must NOT be
+        # in the zip. So the harness makes the same swap publish-jf12-beta.yml makes before its own
+        # JPRM step. Without it the harness would package net10.0 binaries under the net9 artifact
+        # list and install a zip no release ships, which is the one thing this generation exists to
+        # stop. Rewrites the runner checkout only; the committed build.yaml is untouched.
+        if: needs.select.outputs.build_metadata != 'build.yaml'
+        env:
+          METADATA: ${{ needs.select.outputs.build_metadata }}
+        run: |
+          set -euo pipefail
+          cp "$METADATA" build.yaml
+          echo "build.yaml now carries $METADATA:"
+          grep -E '^(version|targetAbi|framework):' build.yaml
 
       - name: Build packaged plugin (JPRM)
         uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
         id: jprm
         with:
-          dotnet-target: "net9.0"
+          dotnet-target: ${{ needs.select.outputs.dotnet_target }}
 
       - name: Install the packaged plugin into the Jellyfin config
         # Unpack the exact packaged zip the release ships (meta.json + the plugin and its

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -179,6 +179,44 @@ docker compose -f test/e2e/docker-compose.yml down -v
 A green run prints `ALL E2E CHECKS PASSED`. In CI, container logs are dumped automatically on
 failure.
 
+### Running the JF12 generation instead (`JELLYFIN_IMAGE_TAG`)
+
+The steps above build the **net9.0** package and boot a Jellyfin **10.11** server, which is the
+artifact `publish-beta.yml` ships. The other beta line ships the **net10.0** package at
+`targetAbi 12.0.0.0`, and that one will not load into a 10.11 server at all. To exercise it, three
+things change together - the target framework, the build metadata, and the server image:
+
+```sh
+# 1. Package the net10 build from the JF12 metadata. jprm reads build.yaml, so swap it first
+#    (restore it afterwards - the committed build.yaml is the JF10.11 metadata).
+cp build.yaml build.yaml.bak && cp build-jf12.yaml build.yaml
+plugin_zip=$(jprm --verbosity=debug plugin build . --output ./artifacts --dotnet-framework net10.0)
+mv build.yaml.bak build.yaml
+
+# 2. Unpack as in step 2 above, into a WIPED plugins directory - a 10.11 drop left behind is a
+#    second copy of the same plugin GUID and the server picks one of them.
+rm -rf test/e2e/jellyfin/config/plugins/SSO-Auth
+mkdir -p test/e2e/jellyfin/config/plugins/SSO-Auth
+unzip -o "$plugin_zip" -d test/e2e/jellyfin/config/plugins/SSO-Auth
+chmod -R 0777 test/e2e/jellyfin
+
+# 3. Boot the same stack against a 12.0 server. Every compose file in this directory takes the tag
+#    from this variable and defaults to the 10.11 server when it is unset, so nothing above changes.
+JELLYFIN_IMAGE_TAG=12.0-rc2 docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+```
+
+The tag is **12.0-rc2 rather than the newest 12.0 image**, because it has to match the Jellyfin
+version the plugin compiles against - .NET will not bind an assembly reference down, so a server
+older than the referenced assemblies refuses to load the plugin. The pin lives in one place:
+
+```sh
+git grep -n "JellyfinVersion Condition" -- SSO-Auth/SSO-Auth.csproj
+```
+
+In CI this is the `generation` input on the `E2E Login Harness` workflow (`jf10.11` or `jf12`),
+which derives all three values together rather than leaving them to be set consistently by hand.
+
 ### A second pass over the same server (`RELOGIN_ONLY`)
 
 Step 3 configures everything it then asserts, which overwrites exactly the state a mutation test

--- a/test/e2e/authelia/docker-compose.yml
+++ b/test/e2e/authelia/docker-compose.yml
@@ -34,7 +34,10 @@ services:
 
   jellyfin:
     # Same server the Keycloak harness pins (see ../docker-compose.yml for the version-bind rationale).
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     # APPEND Authelia's self-signed cert to the system CA bundle (never replace it) before Jellyfin starts,
     # so the plugin's .NET/OpenSSL TLS trusts Authelia while every real system CA still validates. Replacing
     # the bundle (e.g. SSL_CERT_FILE pointing at the lone cert) breaks .NET's startup TLS instead.

--- a/test/e2e/authentik/docker-compose.yml
+++ b/test/e2e/authentik/docker-compose.yml
@@ -82,7 +82,10 @@ services:
       - ssonet
 
   jellyfin:
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     environment:
       JELLYFIN_CACHE_DIR: /cache
     volumes:

--- a/test/e2e/dex/docker-compose.yml
+++ b/test/e2e/dex/docker-compose.yml
@@ -26,7 +26,10 @@ services:
 
   jellyfin:
     # Same server the Keycloak harness pins (see ../docker-compose.yml for the version-bind rationale).
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     environment:
       JELLYFIN_CACHE_DIR: /cache
     volumes:

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -37,7 +37,10 @@ services:
     # will not bind an assembly reference DOWN to an older patch, so an older 10.11.0 server refuses to
     # load the plugin. targetAbi (10.11.0.0) governs the API surface the abi-floor job checks, not the
     # embedded reference version the runtime binds against.
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     environment:
       # A container-local cache/data root keeps the writable state off the bind-mounted /config
       # so only the plugin drop and the plugin's own configuration live under ./jellyfin/config.

--- a/test/e2e/kanidm/docker-compose.yml
+++ b/test/e2e/kanidm/docker-compose.yml
@@ -37,7 +37,10 @@ services:
 
   jellyfin:
     # Same server the Keycloak harness pins (see ../docker-compose.yml for the version-bind rationale).
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     # APPEND Kanidm's self-signed cert to the system CA bundle (never replace it) before Jellyfin starts, so
     # the plugin's TLS trusts Kanidm while every real system CA still validates - the same reasoning as the
     # Authelia harness, where replacing the bundle broke .NET's startup TLS instead.

--- a/test/e2e/pocket-id/docker-compose.yml
+++ b/test/e2e/pocket-id/docker-compose.yml
@@ -44,7 +44,10 @@ services:
 
   jellyfin:
     # Same server the Keycloak harness pins (see ../docker-compose.yml for the version-bind rationale).
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     environment:
       JELLYFIN_CACHE_DIR: /cache
     volumes:

--- a/test/e2e/zitadel/docker-compose.yml
+++ b/test/e2e/zitadel/docker-compose.yml
@@ -81,7 +81,10 @@ services:
 
   jellyfin:
     # Same server the Keycloak harness pins (see ../docker-compose.yml for the version-bind rationale).
-    image: jellyfin/jellyfin:10.11.11
+    # The tag is the JF10.11 server by default and is overridden to a 12.0 server when the harness
+    # runs the JF12 generation (#1466). The default keeps a bare `docker compose up` on this file
+    # exactly as it was, so a local run needs no new variable.
+    image: jellyfin/jellyfin:${JELLYFIN_IMAGE_TAG:-10.11.11}
     environment:
       JELLYFIN_CACHE_DIR: /cache
     volumes:


### PR DESCRIPTION
# What & why

The E2E harness packaged `net9.0` and booted `jellyfin/jellyfin:10.11.11` on every route. Since
#1462 and #1464 both beta publishes are gated on it, so the JF12 beta - which ships the `net10.0`
build at `targetAbi 12.0.0.0` - was gated by a pass on an artifact it does not contain. #1464
disclosed that in the workflow text rather than fixing it, and #1466 is the fix.

Three things have to move together for a JF12 pass to mean anything, and this change moves them
behind one `generation` input:

| | `jf10.11` (default) | `jf12` |
| --- | --- | --- |
| JPRM `dotnet-target` | `net9.0` | `net10.0` |
| build metadata | `build.yaml` | `build-jf12.yaml` |
| server image | `jellyfin/jellyfin:10.11.11` | `jellyfin/jellyfin:12.0-rc2` |

They are derived once in the `select` job rather than branched at each step that needs one, so a
run cannot build one generation and boot the other. Every existing caller and trigger keeps the
`jf10.11` stack byte for byte: the input defaults to it, and an unrecognised value resolves to it
too, because the alternative is a typo in a caller silently publishing behind a matrix that never
ran.

**The server tag is `12.0-rc2`, not the newest 12.0 image.** It has to match the Jellyfin version
the plugin compiles against - .NET will not bind an assembly reference down, which is the rule the
canonical compose file already states for `10.11.11`:

```
$ git grep -n "JellyfinVersion Condition" -- SSO-Auth/SSO-Auth.csproj
SSO-Auth/SSO-Auth.csproj:33:    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
SSO-Auth/SSO-Auth.csproj:34:    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc2</JellyfinVersion>
```

and that image exists:

```
$ curl -sS 'https://hub.docker.com/v2/repositories/jellyfin/jellyfin/tags?page_size=100&ordering=last_updated' \
    | grep -o '12[.]0-rc[0-9]' | sort -u | tr '\n' ' '
12.0-rc1 12.0-rc2 12.0-rc3 12.0-rc4 12.0-rc5 12.0-rc6
```

The seven compose files take the tag from `JELLYFIN_IMAGE_TAG` with the 10.11 server as the
default, so a bare `docker compose up` on any of them is unchanged and a local run needs no new
variable. The variable is set at **job** level rather than per step, because the run, the log reads
and the teardown all invoke `docker compose` and a tag set on only some of them would boot one
server and address another.

## What this does NOT do, and why the issue stays open

It does not flip `publish-jf12-beta.yml` to `generation: jf12`, and it does not remove the
disclosure paragraphs #1464 put in that workflow and in `e2e-login.yml`. #1466's Done-when asks for
a full seven-stack green against the JF12 stack **before** it becomes a gate, and gating a daily
publish on a harness nobody has watched pass would stop the line rather than gate it. The
capability lands here; the flip is the follow-up, on this issue, once the evidence exists.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. **NOT RUN** - no C# changed; this diff is
      one workflow, seven compose files and a README section. CI's `build` check runs it on this
      head.
- [ ] `dotnet test` is green. **NOT RUN**, same reason.
- [x] Prettier is clean for the `.md` change:

```
$ npx --yes prettier --check "test/e2e/README.md"
Checking formatting...
All matched files use Prettier code style!
```

What was verified locally instead, since no suite here reaches a workflow or a compose file:

```
$ npx --yes js-yaml .github/workflows/e2e-login.yml > e2e.json
$ node -e "const j=require('./e2e.json');
    console.log(Object.keys(j.jobs.select.outputs).join(','));
    console.log(j.jobs.select.steps.map(s=>s.id).join(','));
    console.log(JSON.stringify(j.jobs.e2e.env));"
matrix,full,dotnet_target,build_metadata,jellyfin_image_tag,dotnet_sdks
gen,pick
{"JELLYFIN_IMAGE_TAG":"${{ needs.select.outputs.jellyfin_image_tag }}"}
```

The two runs that matter are on GitHub rather than here:

- **the JF10.11 regression** - this PR touches `test/e2e/**` and the workflow, so the harness's
  `pull_request` trigger runs the canonical Keycloak stack on the default generation. A green there
  is the proof that parameterising these three values changed nothing for the existing route.
- **the JF12 pass** - dispatched by hand from this branch, `generation: jf12`,
  `providers: canonical`. Its result, and the seven-stack run and control arm that
  followed it, are written below - this section is edited rather than commented on.

### The JF12 dispatch

Run: https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33336409927

**The plugin loads and logs in on Jellyfin 12.** Canonical Keycloak stack, `generation: jf12`,
run [33336409927](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33336409927) -
**success**. The three values resolved together, the metadata swap took, and the net10 package was
loaded by a 12.0 server:

```
select    | generation jf12 resolves to: net10.0, build-jf12.yaml, jellyfin:12.0-rc2
Keycloak  | build.yaml now carries build-jf12.yaml:
Keycloak  | targetAbi: "12.0.0.0"
Keycloak  | framework: "net10.0"
Keycloak  | jellyfin-1 | Main: Jellyfin version: 12.0.0
Keycloak  | jellyfin-1 | PluginManager: Loaded assembly SSO-Auth, Version=5.0.0.0 ... from /config/plugins/SSO-Auth/SSO-Auth.dll
Keycloak  | jellyfin-1 | PluginManager: Loaded plugin: Community SSO for Jellyfin 5.0.0.0
Keycloak  | harness-1  | PASS: plugin loaded and provider 'keycloak' is listed by GetNames
```

That is the question this change existed to ask, and it is answered: nothing in the net10 artifact
stops a 12.0 server loading it, and a full OIDC + SAML login round-trip completes against one.

**The JF10.11 route is unchanged.** The `pull_request` run on this head,
[33336480069](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33336480069) - success -
takes the default generation, so parameterising the three values changed nothing for the route
every existing caller uses.

### The seven-stack run is six of seven, and the seventh is a real JF12 finding

Full matrix, `generation: jf12`,
[33336960714](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33336960714) -
**failure**: Authelia, authentik, Dex, Kanidm, Pocket ID and Zitadel all green, Keycloak red in
`test/e2e/phases/passwordless-account-sweep.sh`, the #1440 phase, which is full-matrix-only and
canonical-only and therefore never ran in the canonical dispatch above.

```
Keycloak | probe| PROBE-AFTER-SEED
Keycloak | probe| PROBE-HASPASSWORD true
Keycloak | probe| PROBE-PROVIDER Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider
Keycloak | probe| PROBE-ADMIN false
Keycloak | probe| PROBE-EMPTY-PASSWORD 200
Keycloak | ##[error]alice still holds a password after the reset (HasPassword=true), so there is
Keycloak |         nothing for the start-up pass to seal and a green result below would mean nothing.
```

The seed drops alice's administrator flag and resets her password to empty. The reset answers
**200** and `HasPassword` is **still true** afterwards, so the phase refuses to assert on a shape
it did not manage to create - which is the phase failing safe rather than the plugin failing.

**It is the generation and not this change, falsified rather than assumed.** The control arm is the
same branch, the same commit and the same seven stacks with only `generation` moved back:

```
$ gh run view 33337457496 --repo Flowfin/jellyfin-plugin-sso --json conclusion,jobs \
    --jq '(.conclusion), (.jobs[] | "  " + .name + "\t" + .conclusion)'
success
  select	success
  Zitadel (OIDC)	success
  Pocket ID (OIDC)	success
  Dex (OIDC)	success
  authentik (OIDC + SAML)	success
  Kanidm (OIDC)	success
  Authelia (OIDC)	success
  Keycloak (OIDC + SAML)	success
```

Seven of seven on `jf10.11`, six of seven on `jf12`, one commit, one dispatch apart. So the
parameterisation is not what reddened it, the #1440 phase is not broken on the line it was written
for, and what differs is Jellyfin 12's answer to an empty-password reset. Naming the cause inside
Jellyfin 12 would be a claim this run does not carry - a 200 with no effect is consistent with a
changed endpoint contract and with an asynchronous write equally well, and nothing here separates
them.

**So this pull request does not close #1466 and does not flip the gate.** The Done-when asks for a
full seven-stack green before the publish is gated on it, and six of seven is not that. The finding
is written onto #1466 with these runs, and the capability lands here so that the next attempt
starts from a stack that boots rather than from nothing.

## Notes

**No second reader looked at this.** What stands in place of one is the disclosure above and the
two runs named in it.

**The JF12 stack has never been booted in this repository before**, so a first red is a result
rather than a regression. Nothing that exists today depends on it: the default path is untouched,
and no caller passes `generation`.

Part of #1466.
