### PR TITLE
Wait on the management API before the first Zitadel seeding call [#1465]

### DIFF
--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -378,8 +378,38 @@ idp_seed() {
   # simply absent and every role-gated login is refused for the wrong reason. The project and org checks
   # stay OFF so bob can authenticate without a grant - the harness needs him to reach the PLUGIN's role
   # gate, not to be stopped at Zitadel's.
-  zapi POST /management/v1/projects '{"name":"jellyfin","projectRoleAssertion":true,"projectRoleCheck":false,"hasProjectCheck":false}' \
-    || die "zitadel: the project create failed"
+  #
+  # THIS CALL IS THE READINESS WAIT FOR THE MANAGEMENT API, and the wait is here rather than in phase 0
+  # because phase 0 probes a different surface (#1465). READINESS_URL falls back to the discovery
+  # document, which Zitadel's plain HTTP listener serves; /management/v1 is a gRPC-gateway route whose
+  # backend is a separate listener the gateway dials over loopback. The first answering does not imply
+  # the second, and the window between them is not theoretical - measured at 41ms, where the create
+  # answered HTTP 503 with the gateway's own dial refusal 41ms after the discovery document had answered:
+  #   {"code":14,"message":"connection error: desc = \"transport: Error while dialing:
+  #    dial tcp [::1]:8080: connect: connection refused\""}
+  #
+  # The other two ways to close it are shut by this stack rather than judged worse. READINESS_URL is a
+  # bare URL fetched with `curl -f` and carries no bearer token, so every /management/v1 route answers it
+  # 401 and the wait would never see a ready server. A compose healthcheck needs a binary inside the
+  # image, and this image ships no shell - the same fact that forces `user: "0:0"` there, recorded at
+  # that line in test/e2e/zitadel/docker-compose.yml.
+  #
+  # ONLY 503 is waited on, only on this one call. A 503 from the gateway is a request that never reached
+  # the backend, so this create provably did nothing and re-sending it cannot double-create - which is
+  # what makes retrying a NON-idempotent call sound here and nowhere else in this function. Every other
+  # status is the backend's real answer and stays fatal on the first one, so a genuine refusal is not
+  # slowed down and never masked.
+  zwait=0
+  while : ; do
+    zapi POST /management/v1/projects '{"name":"jellyfin","projectRoleAssertion":true,"projectRoleCheck":false,"hasProjectCheck":false}' \
+      && break
+    [ "${zout:-}" = "503" ] || die "zitadel: the project create failed"
+    zwait=$((zwait + 1))
+    [ "$zwait" -lt 24 ] \
+      || die "zitadel: the management API refused the project create for 2 minutes ($zwait attempts, HTTP 503 each) - its gRPC backend never started accepting"
+    log "zitadel: the management API is not accepting yet (attempt $zwait/24) - the gateway refused its own loopback dial; waiting"
+    sleep 5
+  done
   # Read the id from the CREATE response, never from a project search: Zitadel's own internal ZITADEL
   # project already exists and sorts first, so a search would silently seed the wrong project.
   zproject="$(jq -r '.id // empty' /tmp/z.out 2>/dev/null || true)"

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -366,11 +366,20 @@ idp_seed() {
   # died internally would be a lie here: `die` inside a `$(...)` only exits the SUBSHELL, so a failed
   # call whose output nobody read would carry on silently and be misattributed to the plugin later.
   zapi() {
+    # curl's EXIT CODE is kept beside the status, and it is not decoration. HTTP 000 means curl never read
+    # a status line, and only the exit code separates "never connected" (6 could not resolve, 7 could not
+    # connect) from "bytes were exchanged and then something failed". The wait below is allowed to re-send
+    # a NON-idempotent create, and that is sound for the first of those two and not for the second, so the
+    # distinction has to survive out of this helper. It also makes the 000 line say WHY, which the run
+    # that forced this could not: it printed `returned HTTP 000:` and an empty body (#1465).
+    # Truncate first: curl opens the output file only once it has a response to write, so on a failure to
+    # connect the body from the PREVIOUS call survives and the log line below attributes it to this one.
+    : > /tmp/z.out
     zout="$(curl -sS -o /tmp/z.out -w '%{http_code}' -X "$1" "$ZITADEL_URL$2" \
-      -H "Authorization: Bearer $zpat" -H "Content-Type: application/json" -d "$3" 2>/dev/null || true)"
+      -H "Authorization: Bearer $zpat" -H "Content-Type: application/json" -d "$3" 2>/dev/null)" && zrc=0 || zrc=$?
     case "$zout" in
       2*) return 0 ;;
-      *) log "zitadel: $1 $2 returned HTTP ${zout:-000}: $(head -c 300 /tmp/z.out 2>/dev/null)"; return 1 ;;
+      *) log "zitadel: $1 $2 returned HTTP ${zout:-000} (curl exit ${zrc:-0}): $(head -c 300 /tmp/z.out 2>/dev/null)"; return 1 ;;
     esac
   }
 
@@ -394,20 +403,36 @@ idp_seed() {
   # image, and this image ships no shell - the same fact that forces `user: "0:0"` there, recorded at
   # that line in test/e2e/zitadel/docker-compose.yml.
   #
-  # ONLY 503 is waited on, only on this one call. A 503 from the gateway is a request that never reached
-  # the backend, so this create provably did nothing and re-sending it cannot double-create - which is
-  # what makes retrying a NON-idempotent call sound here and nowhere else in this function. Every other
-  # status is the backend's real answer and stays fatal on the first one, so a genuine refusal is not
-  # slowed down and never masked.
+  # WHAT IS WAITED ON IS "THE REQUEST NEVER REACHED THE BACKEND", WHICH IS TWO ANSWERS AND NOT ONE. This
+  # waited on 503 alone until an arm that removed phase 0's discovery wait died at HTTP 000 instead - the
+  # HTTP listener itself was not up yet, so there was no gateway to answer 503. A wait that covers only
+  # the second half is still standing on phase 0 having proved the first, which is the coupling this
+  # whole change exists to remove.
+  #
+  # The two answers, and why re-sending a NON-idempotent create after either is sound:
+  #   503                - the gateway refused its own loopback dial. The request reached Zitadel's HTTP
+  #                        listener and no further, so nothing was created.
+  #   000 with curl 6/7  - curl could not resolve the host, or could not connect to it. No bytes left this
+  #                        container, so nothing was created.
+  # A 000 with ANY OTHER curl exit code means bytes were exchanged and then something failed, and there
+  # the create MAY have run - so it is fatal on the first answer, exactly like a real status. That is the
+  # line the exit code is carried out of `zapi` to draw.
+  #
+  # Every other status is the backend's own answer and stays fatal on the first one, so a Zitadel that is
+  # up and refusing is neither slowed down nor waited past. The wait is bounded and then dies.
   zwait=0
   while : ; do
     zapi POST /management/v1/projects '{"name":"jellyfin","projectRoleAssertion":true,"projectRoleCheck":false,"hasProjectCheck":false}' \
       && break
-    [ "${zout:-}" = "503" ] || die "zitadel: the project create failed"
+    case "${zout:-000}:${zrc:-0}" in
+      503:*)      zwhy="the gateway refused its own loopback dial" ;;
+      000:6|000:7) zwhy="nothing is listening on $ZITADEL_URL yet (curl exit ${zrc})" ;;
+      *)          die "zitadel: the project create failed" ;;
+    esac
     zwait=$((zwait + 1))
     [ "$zwait" -lt 24 ] \
-      || die "zitadel: the management API refused the project create for 2 minutes ($zwait attempts, HTTP 503 each) - its gRPC backend never started accepting"
-    log "zitadel: the management API is not accepting yet (attempt $zwait/24) - the gateway refused its own loopback dial; waiting"
+      || die "zitadel: the management API never accepted the project create in 2 minutes ($zwait attempts, last: $zwhy) - the instance never finished coming up"
+    log "zitadel: the management API is not accepting yet (attempt $zwait/24) - $zwhy; waiting"
     sleep 5
   done
   # Read the id from the CREATE response, never from a project search: Zitadel's own internal ZITADEL


### PR DESCRIPTION
# What & why

Closes #1465.

The Zitadel E2E harness waited on one surface and then used another. `READINESS_URL` falls back to
the discovery document, which Zitadel's plain HTTP listener serves; the seeding calls go to
`/management/v1`, a gRPC-gateway route whose backend is a separate listener the gateway dials over
loopback. The first answering does not imply the second, and the stack failed in the gap:

```
$ gh run view 33324856400 --repo Flowfin/jellyfin-plugin-sso \
    --json headSha,createdAt,conclusion,jobs \
    --jq '"head=\(.headSha[0:8]) at \(.createdAt) conclusion=\(.conclusion)", ([.jobs[]|"  \(.conclusion)\t\(.name)"]|join("\n"))'
head=671c5f61 at 2026-08-30T17:17:46Z conclusion=failure
  success	Call the harness the way publish-beta.yml does / select
  failure	Call the harness the way publish-beta.yml does / Zitadel (OIDC)
  success	Call the harness the way publish-beta.yml does / Authelia (OIDC)
  success	Call the harness the way publish-beta.yml does / Keycloak (OIDC + SAML)
  success	Call the harness the way publish-beta.yml does / Pocket ID (OIDC)
  success	Call the harness the way publish-beta.yml does / Dex (OIDC)
  success	Call the harness the way publish-beta.yml does / authentik (OIDC + SAML)
  success	Call the harness the way publish-beta.yml does / Kanidm (OIDC)
```

41 milliseconds after the discovery document answered, the project create came back
`503 {"code":14,"message":"... dial tcp [::1]:8080: connect: connection refused"}`. Under #1462 that
window reds a daily beta rather than a nightly nobody waits on.

## What the change is

The wait is the first seeding call itself, retried only while the answer proves the request never
reached the backend, bounded at 24 attempts. Two answers qualify, and each is a case where the create
provably did not run, which is what makes re-sending a **non-idempotent** create sound at this one
call and nowhere else in the function:

| answer | meaning | why re-sending is sound |
| --- | --- | --- |
| `503` | the gateway refused its own loopback dial | the request reached the HTTP listener and no further |
| `000` with curl exit 6 or 7 | could not resolve, or could not connect | no bytes left the harness container |

A `000` with **any other** curl exit code means bytes were exchanged before the failure, so the create
may have run - that stays fatal on the first answer, exactly like a real status. Drawing that line is
why the curl exit code is now carried out of `zapi` beside the HTTP status. Every other status is the
backend's own answer and is fatal on the first one, so a Zitadel that is up and refusing is neither
slowed down nor waited past.

`zapi` also truncates its body file per call. curl opens the output file only once it has a response
to write, so on a failure to connect the previous call's body survived and the log line attributed it
to this one.

The two alternatives #1465 names are shut by this stack rather than judged worse, and the comment at
the call records that instead of leaving it to be rediscovered:

- `READINESS_URL` is a bare URL fetched with `curl -f` and carries no bearer token, so every
  `/management/v1` route answers it 401 and the wait would never see a ready server.
- A compose healthcheck needs a binary inside the image, and this image ships no shell - the same fact
  that already forces `user: "0:0"` at that service.

## The first version of this fix was not enough, and the arms are what said so

The change opened here waited on `503` alone. Two arms below then died at **HTTP 000** instead - there
was no listener at all yet, so there was no gateway to answer 503, and a wait that only knew 503 fell
straight through. A wait that still leans on phase 0 having proved the HTTP listener is up is the same
coupling this change exists to remove, in a smaller form. The second commit widens it and is where
that is written down. This paragraph stays because the arms earning their keep is the point.

## Proof against a real Zitadel

Two branches carry the same probe construction: phase 0's discovery wait is removed for the Zitadel
stack and replaced by a wait for the personal access token, so the first management-API call is made
at the earliest legal moment rather than after a wait that happens to cover the backend most of the
time. They differ in exactly the bytes of this change.

**Control** - `probe/1465-control-arm`, the create as it stands on `main`, run
[33358084890](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33358084890), **failure**:

```
harness-1 | PROBE: the PAT appeared after 4s; the discovery readiness wait is SKIPPED (#1465)
harness-1 | == Seeding Zitadel (project, OIDC app, role, users) ==
harness-1 | zitadel: POST /management/v1/projects returned HTTP 000:
harness-1 | FATAL: zitadel: the project create failed
```

**Fixed** - `probe/1465-fixed-arm`, the same construction on this change, run
[33358750404](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33358750404), **success**:

```
harness-1 | PROBE: the PAT appeared after 4s; the discovery readiness wait is SKIPPED (#1465)
harness-1 | == Seeding Zitadel (project, OIDC app, role, users) ==
harness-1 | zitadel: POST /management/v1/projects returned HTTP 000 (curl exit 7):
harness-1 | zitadel: the management API is not accepting yet (attempt 1/24) - nothing is listening on http://zitadel:8080 yet (curl exit 7); waiting
harness-1 | zitadel: POST /management/v1/projects returned HTTP 000 (curl exit 7):
harness-1 | zitadel: the management API is not accepting yet (attempt 2/24) - nothing is listening on http://zitadel:8080 yet (curl exit 7); waiting
harness-1 | zitadel: POST /management/v1/projects returned HTTP 000 (curl exit 7):
harness-1 | zitadel: the management API is not accepting yet (attempt 3/24) - nothing is listening on http://zitadel:8080 yet (curl exit 7); waiting
zitadel-1 |  Health Check URL 	: http://zitadel:8080/debug/healthz
zitadel-1 | ... method=/zitadel.management.v1.ManagementService/AddProject ... httpStatus=200
harness-1 | Zitadel seeded (project=388654730756233210, client_id=388654730974402554), signing key published
```

and the run went on through the full login round-trip to a green stack. That is the Done-when's second
clause literally: the seeding call was made against a Zitadel that was not serving yet, and it was
survived rather than observed to pass. Neither branch is for `main`.

## The behaviours the CI arms cannot produce on demand

Four arms against stubs, each running the **bytes of `harness.sh`** cut out by line range at run time
rather than retyped, so the arms and the file cannot drift:

| arm | condition | control (create as on `main`) | this change |
| --- | --- | --- | --- |
| A | nothing listening, listener arrives later | `FATAL` at `HTTP 000 (curl exit 7)`, 4s | waits once, `SEEDED`, 13s |
| B | `503` twice then `200` - the gap #1465 measured | (dies at the first 503) | waits twice, `SEEDED`, 12s |
| C | a backend that is up and answering `403` | - | `FATAL` on the first answer, 2s |
| D | connection accepted then destroyed (`curl exit 52`) | - | `FATAL` on the first answer, 2s |

C and D are the ones worth reading: C is the wait not masking a real refusal, and D is the wait
refusing to re-send a create whose bytes may already have reached the backend. E is the bound - `503`
forever ends in

```
FATAL: zitadel: the management API never accepted the project create in 2 minutes (24 attempts, last: the gateway refused its own loopback dial) - the instance never finished coming up
```

so the wait fails closed rather than hanging.

## No other stack has the same gap

Three stacks seed at all:

```
$ sed -n '351,357p' test/e2e/harness/harness.sh
idp_seed() {
  case "$IDP_KIND" in
    pocket-id) seed_pocket_id; return 0 ;;
    kanidm)    seed_kanidm; return 0 ;;
    zitadel)   : ;;
    *)         return 0 ;;
  esac
```

Two of the three already wait on the surface their own seeding uses - Pocket ID on its SQLite schema,
Kanidm on its admin socket (and Kanidm is also the one stack that overrides `READINESS_URL`). Zitadel
was the third and is no longer. The four that seed nothing make the discovery fetch itself their first
identity-provider call after readiness, on the same URL the wait probed, so the fallback is the right
surface for them.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable as a whole: the diff is one shell file in the E2E test rig. It touches no login path,
no crypto, no config persistence and no release-pipeline byte, and it ships in no artifact. The lines
that do apply are answered rather than skipped.

- [x] Fail-closed preserved: the wait is bounded and then dies, and every answer that is not a proven
      non-arrival is fatal on the first one. Arms C, D and E are that property executed.
- [x] No secrets logged: the personal access token is neither read nor printed by the added lines.
- [ ] A security review was performed - **NOT RUN**, because the change is outside every surface the
      checklist names. Recorded as not run rather than ticked.
- [x] Log inputs from the IdP are sanitized inline at the log call: the added `log` lines interpolate
      the loop counter, the curl exit code and `$ZITADEL_URL`, which is set by the compose file and
      not by the provider.

## Quality checklist

- [x] No duplicated logic; the wait is one loop at the one call that needs it, deliberately not folded
      into `zapi` - putting it there would silently retry every seeding call and mask a real mid-seed
      failure, which is the opposite of what this fixes.
- [x] The change adds no more code than the problem requires; most of the diff is the comment saying
      why 503 and `000`/6/7 are waits and `000`/anything-else is not.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass - unchanged by this diff, and run as the required `build`
      check on this pull request.
- [x] Docs impact: none. `test/e2e/README.md` describes how to run the stacks, which is unchanged; the
      reason for the wait belongs at the call and is written there.

## Verification

The diff is one `.sh` file: no C#, and no `.js` / `.html` / `.md` / `.css`.

- [x] `build` - the required check on this pull request; merged only on green.
- [x] `dotnet test` - the same check; not re-run locally, because no compiled byte changes and a local
      run would be evidence about a tree the diff does not touch.
- [x] Prettier is clean: `.sh` is outside the glob it checks.
- [x] `sh -n test/e2e/harness/harness.sh` is clean at this head.

## Notes

The means is POSIX shell, because the artefact is an edit to an existing POSIX-shell harness running
in an `alpine:3.20` container that carries no other runtime; introducing a second language at this
call would add a dependency the rig does not have, for a dozen lines of control flow.

The 41-millisecond figure and the run id come from #1465's own measurement. The run is re-read above;
the 41 milliseconds is that issue's arithmetic on the two log timestamps it pasted, carried forward as
its reading rather than re-derived here.

The E2E workflow does not run the Zitadel stack on a pull request - the pull-request route is
canonical-Keycloak only, by the provider-matrix policy at the top of `e2e-login.yml`. So the
Zitadel-stack evidence for this change is the dispatched pair above and not a check on this page, and
that is a bound on what a green tick here covers.

There is no second reader on this board tonight. The arms above stand in place of one, and this
sentence says plainly that they are not the same thing.
