### PR TITLE
Precondition the sweep phase on the reset, not on what the DTO says [#1469]

### DIFF
--- a/test/e2e/phases/passwordless-account-sweep.sh
+++ b/test/e2e/phases/passwordless-account-sweep.sh
@@ -97,12 +97,35 @@ pass "alice is $ALICE_ID, routed at $PROVIDER_BEFORE with IsAdministrator=$ADMIN
 SEEDED_HASPASSWORD="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-HASPASSWORD //p' | head -1)"
 SEEDED_PROVIDER="$(printf '%s' "$SEED_OUT" | sed -n '/^PROBE-AFTER-SEED$/,$p' | sed -n 's/^PROBE-PROVIDER //p' | head -1)"
 SEEDED_EMPTY="$(field "$SEED_OUT" PROBE-EMPTY-PASSWORD)"
+SEEDED_RESET="$(field "$SEED_OUT" PROBE-RESET-STATUS)"
 
 [ "$SEEDED_PROVIDER" = "$BUILTIN_PROVIDER" ] \
     || die "alice is routed at '$SEEDED_PROVIDER' rather than the built-in password provider, so the seed did not produce the shape this phase is about"
-[ "$SEEDED_HASPASSWORD" = "false" ] \
-    || die "alice still holds a password after the reset (HasPassword=$SEEDED_HASPASSWORD), so there is nothing for the start-up pass to seal and a green result below would mean nothing. Jellyfin refuses to empty an ADMINISTRATOR's password, which is what the first run of this phase hit: the seed drops that flag and the restore puts it back"
-pass "alice is seeded: routed at the built-in password provider, holding no password"
+# THE PRECONDITION IS THE RESET, NOT WHAT THE DTO SAYS ABOUT IT (#1469). This asserted
+# HasPassword=false, and that reading does not survive the server generation: on Jellyfin 12.0-rc2 an
+# account whose stored password has just been reset away still reports HasPassword and
+# HasConfiguredPassword TRUE, while the empty password mints a session for it. Measured on run
+# 33358957106, where the sweep then sealed exactly that account:
+#
+#   PROBE-1469-READINGS seeded_haspassword=true sealed_haspassword=true seeded_empty=200 sealed_empty=401
+#   [SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password: ...
+#
+# The audit line is the plugin reporting on user.Password itself - the sweep emits it only where
+# string.IsNullOrEmpty(user.Password) was true - so the stored password IS empty on that generation and
+# the DTO derivation is what moved. The guard below therefore asserts the two things that hold on both:
+# that the reset SUCCEEDED, and (as the control, further down) that the empty password mints a session.
+#
+# 2xx rather than 204 exactly: the point is that the server accepted the reset. A 400 is the case the
+# old message named - Jellyfin refuses to empty an ADMINISTRATOR's password, which the first run of this
+# phase hit - and it is still caught here, one reading earlier than before.
+case "$SEEDED_RESET" in
+    2*) : ;;
+    *) die "the password reset on alice answered HTTP ${SEEDED_RESET:-<nothing>} rather than a 2xx, so she was never put into the shape this phase is about and a green result below would mean nothing. Jellyfin refuses to empty an ADMINISTRATOR's password, which is what the first run of this phase hit: the seed drops that flag and the restore puts it back" ;;
+esac
+# Reported, never asserted: on the JF12 line both of these read true for an account whose stored password
+# is empty, so a reader comparing two runs sees the divergence rather than meeting it as a red gate.
+printf '  dto| HasPassword=%s after the reset (not a precondition - see above)\n' "$SEEDED_HASPASSWORD"
+pass "alice is seeded: routed at the built-in password provider, and the reset was accepted (HTTP $SEEDED_RESET)"
 
 log "The control: the door is open before the restart"
 [ "$SEEDED_EMPTY" = "200" ] \
@@ -120,6 +143,11 @@ SEALED_PROVIDER="$(field "$VERIFY_OUT" PROBE-PROVIDER)"
 SEALED_EMPTY="$(field "$VERIFY_OUT" PROBE-EMPTY-PASSWORD)"
 
 log "Asserting"
+# VACUOUS ON THE JF12 LINE AND KEPT ANYWAY (#1469). On 10.11 this moves false -> true across the restart
+# and is the sealing. On 12.0 it reads true on both sides of it, so it asserts nothing there - the two
+# readings that do are the empty-password refusal and the audit line below, and both are generation-
+# independent. Kept because it still bites on the 10.11 line, which is the generation the shipped
+# artifact runs on.
 [ "$SEALED_HASPASSWORD" = "true" ] \
     || die "alice still holds no password after the restart (HasPassword=$SEALED_HASPASSWORD) - the start-up pass did not seal an account that was exactly its population"
 pass "alice holds a password again after the restart"


### PR DESCRIPTION
# What & why

Closes #1469.

#1469 asks what the sweep actually reads - `user.Password`, from inside the plugin - and says the DTO
over HTTP cannot answer it, because on Jellyfin 12.0-rc2 an account whose password has just been reset
away still reports `HasPassword: true` while the empty password mints a session for it. It names two
opposite conclusions and says nothing separates them: either the sweep skips a password-reachable
account on 12.0, and #1440's guard fails open on that generation, or the stored password really is
empty and only the harness's precondition is wrong.

## The measurement, and which of the two it is

The plugin already reports that value. `SsoAudit.PasswordlessAccountsSealed` fires once per pass and
only where the sweep found `string.IsNullOrEmpty(user.Password)` true for at least one account, and
`passwordless-account-sweep.sh` already greps the Jellyfin log for it — the JF12 run simply never got
there, because the `HasPassword` precondition killed the phase first.

`probe/1469-password-field-read` turns that precondition into a report so the run reaches the audit
line, and changes nothing in the plugin. Run
[33358957106](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33358957106), `generation:
jf12`, **success**:

```
PROBE-BEFORE-SEED
PROBE-HASPASSWORD true
PROBE-CONFIGURED true
PROBE-RESET-STATUS 204
PROBE-AFTER-SEED
PROBE-HASPASSWORD true
PROBE-CONFIGURED true
PROBE-EMPTY-PASSWORD 200
PROBE-1469 DTO-DISAGREES HasPassword=true after the reset - carrying on to the audit line anyway
...
PROBE-1469-LOG| [WRN] Jellyfin.Plugin.SSO_Auth.Api.Session.PasswordlessLinkedAccountSweepService:
  [SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password: an account with none accepts
  the empty password on the ordinary login form, so these were reachable without the identity
  provider. ...
PROBE-1469-READINGS seeded_haspassword=true sealed_haspassword=true seeded_empty=200 sealed_empty=401
```

So, on a 12.0 server:

- `user.Password` **is empty** after the reset — the sweep found it so, and said so in its own audit
  line.
- The sweep **sealed** the account, exactly one, which is the account the phase seeded.
- The empty password went from `200` to `401` across the restart, so the door the sweep exists to shut
  was shut.

**#1440's guard does not fail open on the JF12 line.** The issue's hypothesis is refuted with a
measurement rather than argued away, and what moved is the DTO derivation. That is #1469's third
Done-when branch, and the branch that would have needed a plugin fix is closed off.

## What changes here

The precondition becomes the two facts that hold on both generations:

- the reset was **accepted** — a 2xx from `POST /Users/{id}/Password`. The `400` the old message named
  (Jellyfin refuses to empty an administrator's password, which the first run of this phase hit) is
  still caught, one reading earlier than before.
- the empty password **mints a session** on the seeded account. That control was already in the phase
  and it is generation-independent; it read `200` on both 10.11 and 12.0.

`HasPassword` and `HasConfiguredPassword` are printed rather than asserted, with the measurement above
recorded at the line, so somebody comparing two runs sees the divergence instead of meeting it as a
red gate.

The post-restart `HasPassword = true` assertion is kept and its bound is now written at it: on 10.11 it
moves `false → true` across the restart and is the sealing; on 12.0 it reads `true` on both sides and
asserts nothing there. The two readings that hold on both generations — the empty-password refusal and
the audit line — were already asserted beside it and are what carry the phase on the 12.0 line.

## Proof that the new guard bites

Deleted and watched go red. The `case "$SEEDED_RESET"` block is cut out of the phase by pattern at run
time and driven with each status, so the arm runs the file's bytes rather than a copy:

```
=== the guard, with the reset ACCEPTED as on both generations ===
  204 -> PASS: the precondition let the run continue (SEEDED_RESET=204)
  200 -> PASS: the precondition let the run continue (SEEDED_RESET=200)
=== deleting the reset: the guard must bite, for the reason it names ===
  400  -> ::error::the password reset on alice answered HTTP 400 rather than a 2xx, so she was never put into the shape this phase is about ...
  401  -> ::error::the password reset on alice answered HTTP 401 rather than a 2xx, ...
  500  -> ::error::the password reset on alice answered HTTP 500 rather than a 2xx, ...
  <empty> -> ::error::the password reset on alice answered HTTP <nothing> rather than a 2xx, ...
```

The last row is the one worth having: a missing reading is a refusal, not a pass, so a probe that
printed nothing cannot be read as a successful reset.

## The seven-stack runs at this head

**JF12** - run [33359465863](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33359465863),
`providers: all, generation: jf12`, **all seven stacks green**, and the phase RAN rather than being
skipped:

```
  success	Run the E2E login harness
  success	Two clients behind one proxy are budgeted apart (#1125)
  success	The start-up pass seals a password-less SSO account (#1440)
  success	SAML signing-cert rollover, the new cert validates and the old one is refused (#1128)
```

with the new precondition doing exactly what it is for:

```
PROBE-RESET-STATUS 204
PROBE-EMPTY-PASSWORD 200
dto| HasPassword=true after the reset (not a precondition - see above)
PASS: alice is seeded: routed at the built-in password provider, and the reset was accepted (HTTP 204)
PASS: the empty password mints a session on the seeded account (HTTP 200) - the door is open
PROBE-EMPTY-PASSWORD 401
log| [SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password: ...
PASS: the pass audited exactly one sealed account
PASSWORDLESS ACCOUNT SWEEP PHASE PASSED
```

`HasPassword=true` is printed and the run is green, which is the whole change in one line.

**JF10.11** - run [33359657722](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33359657722),
`providers: all, generation: jf10.11`, **all seven stacks green**. The generation the shipped artifact
runs on is unregressed, and the phase asserts the same two facts there.

That is #1469's third and fourth Done-when clauses, and #1466's seventh stack.

### THE FIRST JF12 RUN AT THIS HEAD WAS RED, AND NOT FOR THIS PHASE

The disclosure belongs here rather than in a footnote. The first attempt at run 33359465863 failed at
the proxy phase two steps earlier, with the control request answering
`400 ... the authorization server's discovery document could not be read`, which SKIPS the sweep phase
and the rollover phase behind it. The same phase was green on the two most recent JF12 runs before it
on trees whose bytes for that phase are identical, so it is intermittent rather than caused by this
change - and the failed job alone was re-run, which is what the green above is. The race is real and
is filed as #1473, with the evidence and the reading of why it happens; it is not fixed here.

So the green above is a green after a re-run, not a green first time, and one flake stands between this
phase and the beta gate until #1473 lands.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff is one shell file in the E2E test rig. No plugin byte changes, and nothing ships in an
artifact. The reason the issue carried the `security` label is answered rather than sidestepped:

- [x] Fail-closed preserved: the precondition refuses a missing or non-2xx reading rather than passing
      it, which the `<empty>` arm above executes. The phase's own fail-closed property — that a green
      result is attributable to the sweep — is now carried by two generation-independent assertions
      instead of one that silently stopped holding.
- [x] The fail-open this issue suspected in the plugin was **measured and is not there**: the sweep
      seals on 12.0. That is the finding, and it is stated as measured rather than as reassurance.
- [x] No secrets logged; nothing in this diff writes a credential.
- [ ] A security review was performed — **NOT RUN**. The plugin is unchanged by this diff, so the
      surfaces the checklist names are untouched. Recorded as not run rather than ticked.
- [x] Log inputs from the IdP are sanitized inline at the log call: the added `printf` interpolates a
      DTO boolean and an HTTP status read from the server, not provider-supplied text.

## Quality checklist

- [x] No duplicated logic; the control that already existed is used instead of a second reading of the
      same thing.
- [x] The change adds no more code than the problem requires; most of the diff is the comment carrying
      the measurement that justifies the swap.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass — unchanged by this diff, and run as the required `build`
      check here.
- [x] Docs impact: none. The behaviour of the plugin is unchanged and the finding lives on the issue
      and in the comment at the line.

## Verification

The diff is one `.sh` file: no C#, and no `.js` / `.html` / `.md` / `.css`.

- [x] `build` and `dotnet test` — the required checks on this pull request; merged only on green. Not
      re-run locally: no compiled byte changes.
- [x] Prettier is clean: `.sh` is outside the glob it checks.
- [x] `bash -n test/e2e/phases/passwordless-account-sweep.sh` is clean at this head.
- [x] The precondition arms above.
- [ ] The seven-stack JF12 run — **recorded in the section above once it lands**, not before.

## Notes

The means is bash, because the artefact is an edit to an existing bash phase script that already runs
`docker compose` on the runner; nothing here needs a runtime the rig does not carry.

`probe/1469-password-field-read` is not for `main`. It exists to produce the reading above and weakens
an assertion to do it.

There is no second reader on this board tonight. The arms and the two dispatched runs stand in place of
one, and this sentence says plainly that they are not the same thing.
