### PR TITLE
Wait for the identity provider before the proxy phase's control request [#1473]

### DIFF
--- a/test/e2e/phases/probe-proxy-client-budget.sh
+++ b/test/e2e/phases/probe-proxy-client-budget.sh
@@ -30,6 +30,13 @@ PROXY_URL="${PROXY_URL:-http://proxy}"
 CLIENT_A="${CLIENT_A:-11.0.9.11}"
 CLIENT_B="${CLIENT_B:-11.0.9.22}"
 MAX_TRIES="${MAX_TRIES:-8}"
+# The surface the plugin's challenge reads server-to-server, derived the way harness.sh derives it so
+# the two cannot disagree: the canonical stack sets no DISCOVERY_URL and takes this same default.
+# Reached DIRECTLY rather than through the proxy - the proxy sits in front of Jellyfin, and the read
+# being waited on is Jellyfin's own outbound one.
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://keycloak:8080}"
+REALM="${REALM:-e2e}"
+DISCOVERY_URL="${DISCOVERY_URL:-$KEYCLOAK_URL/realms/$REALM/.well-known/openid-configuration}"
 
 if ! apk add --no-cache curl >/tmp/apk.out 2>&1; then
     say "PROBE-ERROR could not install curl:"
@@ -52,6 +59,32 @@ until curl -fsS -o /dev/null -H "X-Test-Client: $CLIENT_A" "$PROXY_URL/sso/OID/G
     sleep 2
 done
 say "PROBE-STAGE ready after $i retries ($((i * 2))s)"
+
+# AND THE IDENTITY PROVIDER, WHICH THE WAIT ABOVE DOES NOT IMPLY (#1473). /sso/OID/GetNames lists the
+# configured provider names out of the plugin's own configuration and reaches Keycloak for nothing, so
+# it answers exactly as readily while Keycloak is still coming up. The challenge below does reach it:
+# the plugin reads the discovery document server-to-server to build the authorize URL, and a Keycloak
+# that is not serving yet makes that challenge answer
+#
+#   400 Error preparing login: the authorization server's discovery document could not be read.
+#
+# which is the control, so the phase refuses the whole run for a race. Measured on run 33359465863,
+# where the plugin answered through the proxy after 6s and Keycloak was not serving yet.
+#
+# The phase starts Keycloak with `docker compose start`, and that returns when the container is
+# RUNNING rather than when the server is listening - which the phase already records at its own
+# `up` line for Jellyfin and did not apply to the identity provider.
+k=0
+until curl -fsS -o /dev/null "$DISCOVERY_URL" 2>/tmp/idp.err; do
+    k=$((k + 1))
+    if [ "$k" -ge 150 ]; then
+        say "PROBE-ERROR the identity provider did not serve $DISCOVERY_URL within 300s, so the challenge below could not have been built:"
+        sed 's/^/  /' /tmp/idp.err
+        exit 0
+    fi
+    sleep 2
+done
+say "PROBE-STAGE identity provider ready after $k retries ($((k * 2))s)"
 
 # No -L: the healthy answer is the redirect itself, and following it would report the identity
 # provider's status instead of the plugin's.


### PR DESCRIPTION
# What & why

Closes #1473.

`proxy-client-attribution.sh` waits on one surface and then uses another. Its probe's readiness wait is
the plugin's own route through the proxy; its control request is an OpenID challenge, which the plugin
builds by reading the identity provider's discovery document server-to-server. The first answering does
not imply the second.

`/sso/OID/GetNames` answers out of the plugin's configuration and reaches Keycloak for nothing:

```
$ sed -n '813,833p' SSO-Auth/Api/Http/SSOController.cs
    [HttpGet("OID/GetNames")]
    public ActionResult OidProviderNames()
    ...
        return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.OidConfigs)));
```

so it answers exactly as readily while Keycloak is still coming up. The challenge does reach it, and
where the read fails it returns the 400 the failing run printed:

```
$ git grep -n "discovery document could not be read" -- SSO-Auth/Api/Flows/OidcLoginService.cs
SSO-Auth/Api/Flows/OidcLoginService.cs:212:            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login: the authorization server's discovery document could not be read.");
```

The control is what refuses the run, correctly - but the whole phase then reds for a race:

```
probe| PROBE-STAGE ready after 3 retries (6s)
probe| PROBE-CONTROL 400
probe| PROBE-CONTROL-BODY Error preparing login: the authorization server's discovery document could not be read.
##[error]the control request through the proxy answered 400 rather than a redirect - the stack is not healthy through the proxy, so a 429 afterwards would not be attributable to the limiter
```

Six seconds of readiness, and what those six seconds proved was that the plugin answers.

## Why it matters more than one red job

The phases after it are gated on `if: success()`, so one flake here silently removes the
passwordless-sweep and SAML-rollover phases from the run rather than reporting them - which is exactly
what happened on run 33359465863, where both were skipped. And under #1462 and #1464 the full matrix
gates a beta publish, so an intermittent red here stops a daily beta for a reason that is not about the
plugin.

## The phase already knew both halves

Its own comment records that this exact 400 was once caused by Keycloak being down, and that the repair
was to start it:

```
$ sed -n '152,159p' test/e2e/phases/proxy-client-attribution.sh
# KEYCLOAK IS STARTED TOO, AND FORGETTING IT COST A RUN. ... Starting only Jellyfin left the
# identity provider down, the challenge answered 400 with "the authorization server's discovery
# document could not be read", and the control refused to let the run mean anything ...
docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
```

and a second comment in the same file records what `start` is worth:

```
$ sed -n '207,209p' test/e2e/phases/proxy-client-attribution.sh
# STOPPED above and brought up by this `up`, rather than started separately first. `start` returns
# when the container is running, not when it is listening ...
```

The fix for "Keycloak is down" was applied and the fix for "`start` is not readiness" was applied to
Jellyfin and not to the identity provider. What is left is those two facts meeting.

## What the change is

The probe gains a second wait, on the surface the challenge actually reads. Directly rather than
through the proxy: the proxy sits in front of Jellyfin, and the read being waited on is Jellyfin's own
outbound one. `DISCOVERY_URL` is derived exactly as `harness.sh` derives it, so the two cannot disagree
about which document that is, and the canonical stack (which sets no `DISCOVERY_URL`) takes the same
default on both sides. A failure to serve it inside 300 seconds prints `PROBE-ERROR` rather than
exiting non-zero, like every other answer this probe gives, so a broken probe cannot be read as a
proven rate limit.

## Proof that it bites

Two branches carry the same probe construction, differing in exactly the bytes of this change:

```
$ git diff --stat probe/1473-control-arm-2..probe/1473-fixed-arm-2
 test/e2e/phases/probe-proxy-client-budget.sh | 33 ++++++++++++++++++++++++++++
 1 file changed, 33 insertions(+)
```

The construction holds Keycloak DOWN for a fixed 30 seconds and brings it back in the background, so
the control request is certainly made against an identity provider that is not serving.

**Control** - `probe/1473-control-arm-2`, the probe as it stands on `main`, run
[33361117489](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33361117489), **failure**:

```
probe| PROBE-STAGE ready after 4 retries (8s)
probe| PROBE-CONTROL 400
probe| PROBE-CONTROL-BODY Error preparing login: the authorization server's discovery document could not be read.
##[error]the control request through the proxy answered 400 rather than a redirect - the stack is not healthy through the proxy, so a 429 afterwards would not be attributable to the limiter
```

**Fixed** - `probe/1473-fixed-arm-2`, the same construction on this change, run
[33361126508](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33361126508), **success**:

```
probe| PROBE-STAGE ready after 4 retries (8s)
probe| PROBE-STAGE identity provider ready after 14 retries (28s)
probe| PROBE-CONTROL 302
probe| PROBE-EXHAUST-STATUSES 302 429
probe| PROBE-OTHER-CLIENT 302
PASS: client B, through the SAME proxy, is not throttled and gets its own redirect (302) - the two clients are budgeted apart
```

The plugin answered after 8 seconds on BOTH arms, which is what makes the pair a comparison: the only
thing that differs afterwards is whether anything waited for the identity provider. It needed 28
seconds, and the control arm spent none of them.

### THE FIRST PAIR PROVED NOTHING, AND SAYING SO IS PART OF THE PROOF

The construction above is the second. The first restarted Keycloak rather than holding it down, and
**both arms passed** - runs
[33360677226](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33360677226) (control) and
[33360684749](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33360684749) (fixed). The
readings say why:

```
control: PROBE-STAGE ready after 5 retries (10s)   -> PROBE-CONTROL 302
fixed:   PROBE-STAGE ready after 2 retries (4s)
         PROBE-STAGE identity provider ready after 1 retries (2s) -> PROBE-CONTROL 302
```

The fixed arm's new wait DID fire, once, at 4 seconds - so the gap was real in that run too. The
control arm simply took 10 seconds to reach the plugin and covered the gap by accident. Two waits of
the same order of magnitude, and a green control that means nothing. That pair is left standing rather
than deleted, because a falsifier that could not have failed is the thing this repository's rules are
against, and the first one nearly was.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable as a whole: the diff is one shell file in the E2E test rig. It touches no login path, no
crypto, no config persistence and no release-pipeline byte, and it ships in no artifact.

- [x] Fail-closed preserved: the added wait is bounded at 300 seconds and reports `PROBE-ERROR`, which
      the caller treats as a missing answer rather than a pass. It makes no assertion weaker - the
      control that refuses an unhealthy stack is untouched, and what changes is only that the stack is
      given the chance to be healthy first.
- [x] No secrets logged; the added lines print a URL from the compose environment and a retry count.
- [ ] A security review was performed - **NOT RUN**, because the change is outside every surface the
      checklist names. Recorded as not run rather than ticked.
- [x] Log inputs from the IdP are sanitized inline at the log call: nothing provider-supplied is logged
      by the added lines.

## Quality checklist

- [x] No duplicated logic; the wait is the same shape as the readiness wait directly above it, on the
      other surface, and sits beside it.
- [x] The change adds no more code than the problem requires: nine lines of shell, the rest comment.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass - unchanged by this diff, and run as the required `build`
      check here.
- [x] Docs impact: none. The plugin is unchanged and the reason for the wait belongs at the wait.

## Verification

The diff is one `.sh` file: no C#, and no `.js` / `.html` / `.md` / `.css`.

- [x] `build` and `dotnet test` - the required checks on this pull request; merged only on green. Not
      re-run locally: no compiled byte changes.
- [x] Prettier is clean: `.sh` is outside the glob it checks.
- [x] `sh -n test/e2e/phases/probe-proxy-client-budget.sh` is clean at this head.
- [x] The paired arms - recorded above, control red and fixed green on the second construction, and the
      first inconclusive pair kept rather than dropped.
- [x] The seven-stack run at this head WITHOUT the probe construction - run
      [33361534578](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33361534578),
      `providers: all, generation: jf10.11`, all seven green. The added wait costs the ordinary run
      nothing.

## Notes

The means is POSIX shell, because the artefact is an edit to an existing POSIX-shell probe that runs in
an `alpine:3.20` container carrying no other runtime.

This does not claim the flake is the only one in this phase, and it makes no claim about the other
phases that `stop`/`start` the stack and then drive it. #1473's third Done-when clause asks for that
reading and it is a separate pass; what this closes is the one gap that was measured.

There is no second reader on this board tonight. The arms stand in place of one, and this sentence says
plainly that they are not the same thing.
