### PR TITLE
Wait for the identity provider before the KEK-loss probe's challenge [#1475]

### DIFF
--- a/test/e2e/phases/probe-oid-start.sh
+++ b/test/e2e/phases/probe-oid-start.sh
@@ -39,6 +39,37 @@ until curl -fsS -o /dev/null "$JELLYFIN_URL/sso/OID/GetNames" 2>/tmp/ready.err; 
 done
 say "PROBE-STAGE ready after $i retries ($((i * 2))s)"
 
+# AND THE IDENTITY PROVIDER, WHICH THE WAIT ABOVE DOES NOT IMPLY (#1475). The route just waited on
+# reads the provider names out of the plugin's configuration and reaches the identity provider for
+# nothing, so it answers exactly as readily while that server is still coming up. The challenge below
+# does reach it: the plugin reads the discovery document server-to-server to build the authorize URL,
+# and where it cannot it answers 400 "the authorization server's discovery document could not be read".
+#
+# BOTH USES OF THIS PROBE NEED IT, and the second is the one that misleads. The caller takes the first
+# answer as its CONTROL and requires a 3xx, so a race reds the phase saying the stack is unhealthy;
+# it takes the second as the fail-closed assertion and requires a 500 naming an undecryptable secret,
+# and a 400 from an identity provider that is not serving would send the next reader to the secret
+# store. Neither is what this phase is about.
+#
+# The caller starts the identity provider with `docker compose start`, which returns when the
+# container is RUNNING rather than when the server is listening. probe-saml-rollover.sh already
+# carries this same second wait on its own surface; this is that pattern, on the surface the OpenID
+# challenge reads. Reported as PROBE-ERROR rather than exiting non-zero, like every other answer here.
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://keycloak:8080}"
+REALM="${REALM:-e2e}"
+DISCOVERY_URL="${DISCOVERY_URL:-$KEYCLOAK_URL/realms/$REALM/.well-known/openid-configuration}"
+k=0
+until curl -fsS -o /dev/null "$DISCOVERY_URL" 2>/tmp/idp.err; do
+  k=$((k + 1))
+  if [ "$k" -ge 150 ]; then
+    say "PROBE-ERROR the identity provider did not serve $DISCOVERY_URL within 300s, so the challenge below could not have been built:"
+    sed 's/^/  /' /tmp/idp.err
+    exit 0
+  fi
+  sleep 2
+done
+say "PROBE-STAGE identity provider ready after $k retries ($((k * 2))s)"
+
 # No -L: the healthy answer is the redirect itself, and following it would report the identity
 # provider's status instead of the plugin's.
 code="$(curl -sS -o /tmp/probe.body -w '%{http_code}' "$JELLYFIN_URL/sso/OID/start/$PROVIDER" 2>/tmp/probe.err)" || {


### PR DESCRIPTION
# What & why

Closes #1475.

`probe-oid-start.sh` waits on `/sso/OID/GetNames` and then requests `/sso/OID/start/{provider}`, and the
first answering does not imply the second. `GetNames` answers out of the plugin's own configuration and
reaches the identity provider for nothing (`SSOController.cs:833`); the challenge reads the discovery
document server-to-server, and where it cannot it answers
`400 Error preparing login: the authorization server's discovery document could not be read.`
(`OidcLoginService.cs:212`). Its only caller starts the identity provider with `docker compose start`,
which returns when the container is running rather than when the server is listening.

This is the gap #1473 measured, in a neighbouring probe. It was found by that issue's third Done-when
clause — the reading over all four phases that start the stack and then drive it is on
[#1473](https://github.com/Flowfin/jellyfin-plugin-sso/issues/1473#issuecomment-5474326652).

## Both uses need it, and the second is the one that misleads

`kek-loss-fails-closed.sh` runs this probe twice. It takes the first answer as its **control** and
requires a 3xx, so a race reds the phase saying the stack is unhealthy. It takes the second as the
**fail-closed assertion** and requires a 500 naming an undecryptable secret — and a 400 from an identity
provider that is not serving would send the next reader to the secret store.

## Not a new pattern

`probe-saml-rollover.sh:96` already waits for Keycloak's SAML descriptor on exactly this shape, and
#1474 added the same wait to `probe-proxy-client-budget.sh`. This is the last probe without it.

## Proof that it bites

Two branches carry the same construction — Keycloak is held down for a fixed 30 seconds and brought back
in the background, so the control challenge is certainly made against an identity provider that is not
serving. They differ in exactly the bytes of this change:

```
$ git diff --stat probe/1475-control-arm..probe/1475-fixed-arm
 test/e2e/phases/probe-oid-start.sh | 31 +++++++++++++++++++++++++++++++
 1 file changed, 31 insertions(+)
```

**Control** — `probe/1475-control-arm`, the probe as it stands on `main`, run
[33362206432](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33362206432), **failure**:

```
probe| PROBE-STAGE ready after 1 retries (2s)
probe| PROBE-STATUS 400
probe| PROBE-BODY Error preparing login: the authorization server's discovery document could not be read.
##[error]the control probe did not redirect (400) - the stack is not healthy, so a refusal after the key is destroyed would not be attributable to the key
```

**Fixed** — `probe/1475-fixed-arm`, the same construction on this change, run
[33362208730](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33362208730), **success**, and
it covers both uses:

```
probe| PROBE-STAGE ready after 1 retries (2s)
probe| PROBE-STAGE identity provider ready after 17 retries (34s)
probe| PROBE-STATUS 302
PASS: the OpenID challenge redirects to the identity provider (302)

probe| PROBE-STAGE ready after 6 retries (12s)
probe| PROBE-STAGE identity provider ready after 0 retries (0s)
probe| PROBE-STATUS 500
probe| PROBE-BODY Could not process login; the OpenID client secret could not be decrypted.
PASS: the refusal names the undecryptable client secret rather than failing for some other reason
```

The plugin answered after 2 seconds on **both** arms, which is what makes the pair a comparison: the
only thing that differs afterwards is whether anything waited for the identity provider. It needed 34
seconds, and the control arm spent none of them.

`identity provider ready after 0 retries (0s)` on the second use is the other half worth reading: where
the provider is already serving the wait costs nothing, so the ordinary run pays no time for it.

The predicted failure in #1475 was the control going 400 and the phase dying with "the stack is not
healthy". That is the control arm's output verbatim, which is the issue's claim reproduced rather than
merely made plausible — and #1475 was filed saying no failing run had been observed. One has now.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable as a whole: the diff is one shell file in the E2E test rig. It touches no login path, no
crypto, no config persistence and no release-pipeline byte, and it ships in no artifact.

- [x] Fail-closed preserved, and this is the point of the change rather than a side effect. The phase's
      fail-closed assertion requires a 500 naming an undecryptable secret; without the wait a 400 from
      an unserving identity provider could stand where that reading belongs. The `PASS: the refusal
      names the undecryptable client secret` line in the fixed arm is that assertion reached for the
      right reason. The added wait is itself bounded at 300 seconds and reports `PROBE-ERROR`, which the
      caller treats as a missing answer rather than a pass.
- [x] No secrets logged; the added lines print a URL from the compose environment and a retry count.
- [ ] A security review was performed — **NOT RUN**, because the change is outside every surface the
      checklist names: it is a test-rig probe and the plugin is unchanged. Recorded as not run rather
      than ticked.
- [x] Log inputs from the IdP are sanitized inline at the log call: nothing provider-supplied is logged
      by the added lines.

## Quality checklist

- [x] No duplicated logic in the sense that matters — this is the third instance of one wait, and that
      is deliberate: each probe is a standalone file bind-mounted into a throwaway container, with no
      shared library between them, and inventing one for nine lines would add a load path that three
      files' worth of duplication does not justify. Named here rather than left for a reader to notice.
- [x] The change adds no more code than the problem requires: nine lines of shell, the rest comment.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass — unchanged by this diff, and run as the required `build`
      check here.
- [x] Docs impact: none. The plugin is unchanged and the reason for the wait belongs at the wait.

## Verification

The diff is one `.sh` file: no C#, and no `.js` / `.html` / `.md` / `.css`.

- [x] `build` and `dotnet test` — the required checks on this pull request; merged only on green. Not
      re-run locally: no compiled byte changes.
- [x] Prettier is clean: `.sh` is outside the glob it checks.
- [x] `sh -n test/e2e/phases/probe-oid-start.sh` is clean at this head.
- [x] The paired arms above: control red, fixed green, both uses of the probe covered.
- [x] The seven-stack run at this head without the probe construction — run
      [33362226799](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33362226799),
      `providers: all, generation: jf10.11`, all seven green.

## Notes

The means is POSIX shell, because the artefact is an edit to an existing POSIX-shell probe that runs in
an `alpine:3.20` container carrying no other runtime.

`DISCOVERY_URL` is derived exactly as `harness.sh` derives it, so the two cannot disagree about which
document is meant, and the canonical stack — which sets no `DISCOVERY_URL` — takes the same default on
both sides.

There is no second reader on this board tonight. The arms stand in place of one, and this sentence says
plainly that they are not the same thing.
