### PR TITLE
Write about myself in the first person instead of naming a role [#1470]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Code owners for jellyfin-plugin-sso.
 #
-# Sole maintainer. This documents ownership; it does not auto-request a review,
+# I own this alone. This documents ownership; it does not auto-request a review,
 # since GitHub never requests a pull request's own author and every change is
 # authored by me. The review layer is the adversarial multi-lens
 # review gate (see the README's note on AI-assisted development).

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -147,7 +147,7 @@ jobs:
             }
 
             // --- Check 1b: every commit subject carries [#N] refs (#817) ---------
-            // Maintainer rule: traceability must survive down to the single commit -
+            // My rule: traceability must survive down to the single commit -
             // blame/bisect/log show a commit's SUBJECT line without its PR, so the
             // PR-body link (check 1) is not enough. The reference lives in the
             // subject, bracketed, one bracket per issue: `Fix the thing [#12][#34]`.

--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -5,7 +5,7 @@ name: Publish failure alert
 #  - the 2026-07-23 beta.12 incident, where the GitHub release was created but the manifest commit failed
 #    on a jq arg-length error and the build silently never reached Jellyfin until a user noticed;
 #  - `Wiki Lint` failing on `main` nine times in a row over fifteen hours (#1015), surfaced only because
-#    the maintainer happened to open the run log.
+#    I happened to open the run log.
 #
 # The first version of this file was event-driven and watched an ENUMERATED list of six workflow names,
 # which is why the second incident went unseen: `Wiki Lint` was not on the list, and neither was any other

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -1,10 +1,10 @@
 name: Publish JF12 Stable
 
 # The Jellyfin 12.0 (.NET 10) STABLE channel - the 5.0 line's GA publish leg (#607). Counterpart to
-# publish.yml (JF10.11 stable, X.Y.Z-stable) and publish-jf12-beta.yml (JF12 beta). Triggered ONLY by a
-# maintainer pushing an X.Y.Z-JF12-stable tag (e.g. 5.0.0-JF12-stable): publish.yml's
+# publish.yml (JF10.11 stable, X.Y.Z-stable) and publish-jf12-beta.yml (JF12 beta). Triggered ONLY by me
+# pushing an X.Y.Z-JF12-stable tag (e.g. 5.0.0-JF12-stable): publish.yml's
 # [0-9]+.[0-9]+.[0-9]+-stable glob deliberately does NOT match -JF12-stable, so the two stable legs never
-# cross-fire. Like the JF11 stable tag, this tag is MAINTAINER-GATED (guard-git.ps1) and pushed by hand.
+# cross-fire. Like the JF11 stable tag, this tag is GATED ON MY EXPLICIT GO (guard-git.ps1) and pushed by hand.
 #
 # DORMANT until Jellyfin 12.0 reaches GA: no X.Y.Z-JF12-stable tag is pushed until a real 12.0 stable
 # server exists, so this workflow does not run before then - but the pipeline is ready so the 5.0 line can

--- a/.github/workflows/stryker-mutation.yml
+++ b/.github/workflows/stryker-mutation.yml
@@ -47,7 +47,7 @@ on:
     # scheduled runs do not contend for a runner at the same minute. Re-enabled
     # with the VSTest twin (#899) after the MTP migration had paused it.
     - cron: "41 5 * * 1"
-  # Let a maintainer run it on demand from the Actions tab.
+  # Let me run it on demand from the Actions tab.
   workflow_dispatch:
 
 # Read-only: this job only reads the code and uploads a run artifact. It never

--- a/SSO-Auth.Fuzz/DiscoveryDifferential.cs
+++ b/SSO-Auth.Fuzz/DiscoveryDifferential.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Fuzz;
 /// one tokenizer agreeing with a list of expectations is evidence about the list.
 ///
 /// It is NOT coverage-guided and does not need libFuzzer, so it runs anywhere the harness builds - which is
-/// what makes it re-runnable on the maintainer's Windows box rather than only in the Linux weekly job.
+/// what makes it re-runnable on my Windows box rather than only in the Linux weekly job.
 ///
 /// Triage rule, inherited from the harness README and not softened here: a divergence is a FINDING. It is
 /// reported, with the document that produced it, and it is filed - never patched away inside this driver.

--- a/SSO-Auth.Fuzz/Program.cs
+++ b/SSO-Auth.Fuzz/Program.cs
@@ -70,7 +70,7 @@ internal static class Program
 
         // Smoke mode replays the seed corpus through the selected target once and exits, WITHOUT libFuzzer.
         // It proves the dispatch + parse wiring runs and that every seed is handled fail-closed (no unmapped
-        // throw), so the harness can be validated on any platform - including the maintainer's Windows box,
+        // throw), so the harness can be validated on any platform - including my Windows box,
         // where the Linux-only libFuzzer runtime is unavailable - and as a cheap CI sanity check. The real
         // coverage-guided run is the default path below.
         if (Environment.GetEnvironmentVariable("SSO_FUZZ_SMOKE") == "1")

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -70,11 +70,11 @@ value is the fuzzing itself, which the scheduled job delivers regardless of whet
 
 ## Feasibility: local Windows vs CI Linux (honest)
 
-- The **managed harness compiles cross-platform** - it builds cleanly on the maintainer's Windows box
+- The **managed harness compiles cross-platform** - it builds cleanly on my Windows box
   (validated in Debug and Release under `--warnaserror`), so it cannot silently bitrot when touched.
 - **Actual fuzzing is Linux-only.** The `sharpfuzz` instrumentation CLI and the libFuzzer runtime are
-  Linux-oriented; a coverage-guided run on Windows is impractical. So the _run_ lives in CI, never on the
-  maintainer's machine. This is expected and is why #174 is a scheduled Linux job.
+  Linux-oriented; a coverage-guided run on Windows is impractical. So the _run_ lives in CI, never on my
+  machine. This is expected and is why #174 is a scheduled Linux job.
 - The project is not in the solution, so nothing that works from the solution builds it. Since #1132 the
   gating `build` job compiles it by path on every PR, which is what keeps it from bitrotting; the weekly
   job is what keeps it _running_.

--- a/SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj
+++ b/SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <!-- SharpFuzz instruments the target IL and drives it under libFuzzer. The managed package
-         compiles cross-platform (so this project builds on the maintainer's Windows box); the
+         compiles cross-platform (so this project builds on my Windows box); the
          `sharpfuzz` instrumentation CLI and libFuzzer runtime are Linux-only, so the actual fuzzing
          runs in CI. -->
     <PackageReference Include="SharpFuzz" Version="2.3.0" />

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,8 +140,8 @@ recording them.
 
 | Surface                             | Decision                                                                                               | Status                                                                                                              |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `awesome-jellyfin` list ([#1086])   | Repoint the existing entry rather than add a second one beside it, as a pull request against that list | drafted, awaiting maintainer                                                                                        |
-| Upstream Jellyfin threads ([#1087]) | One factual note that a maintained continuation exists, and not on the open native-OIDC pull request   | drafted, awaiting maintainer                                                                                        |
+| `awesome-jellyfin` list ([#1086])   | Repoint the existing entry rather than add a second one beside it, as a pull request against that list | drafted, awaiting me                                                                                                |
+| Upstream Jellyfin threads ([#1087]) | One factual note that a maintained continuation exists, and not on the open native-OIDC pull request   | drafted, awaiting me                                                                                                |
 | Archived `9p4` repository ([#1088]) | Nothing is lodged there                                                                                | not actionable - the repository is archived, so it is read-only for issues, pull requests, comments and discussions |
 
 Nothing in the table has been posted. How this plugin sits beside Jellyfin's

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/Flowfin/jellyfin-plugin-sso/security/vex/openvex.json",
   "author": "iderex",
-  "role": "Maintainer",
+  "role": "Document Creator",
   "timestamp": "2026-08-26T00:00:00Z",
   "version": 2,
   "statements": []


### PR DESCRIPTION
# What & why

The text this project carries described me from outside. I write in the first person here, so the prose sites now say "I", "my" or "me", and the one machine-readable site takes a value out of its own specification instead of one I invented.

What changed, site by site:

| File | Was | Is |
| --- | --- | --- |
| `.github/CODEOWNERS` | a note describing the owner in the third person | "I own this alone." |
| `.github/workflows/pr-hygiene.yml` | a rule attributed to a role | "My rule: traceability must survive down to the single commit" |
| `.github/workflows/publish-failure-alert.yml` | somebody happened to open the run log | "I happened to open the run log." |
| `.github/workflows/publish-jf12-stable.yml` | triggered by a role pushing the tag; the tag gated on that role | "Triggered ONLY by me pushing an X.Y.Z-JF12-stable tag"; "GATED ON MY EXPLICIT GO" |
| `.github/workflows/stryker-mutation.yml` | let a role run it on demand | "Let me run it on demand from the Actions tab." |
| `SSO-Auth.Fuzz/DiscoveryDifferential.cs`, `Program.cs`, `README.md`, `SSO-Auth.Fuzz.csproj` | four notes about a role's Windows box and machine | "my Windows box", "my machine" |
| `docs/ROADMAP.md` | two outreach rows awaiting a role | "drafted, awaiting me" |
| `security/vex/openvex.json` | an optional `role` field carrying a value I invented | `"Document Creator"` |

The OpenVEX field is the one site that is not prose. `role` is optional, the specification defines it as describing the role of the document author, and the two example values it gives are "Document Creator" and "Project Release Bot". The document now uses the first of those, which says the same thing about who wrote the file in the schema's vocabulary rather than in mine. The gate still passes:

```
$ python scripts/check-vex.py security/vex/openvex.json
ok: security/vex/openvex.json is a valid OpenVEX document with 0 statement(s), checked structurally (no SBOM given)
```

**Two files keep the word deliberately, and this is the "text I did not write" bucket the issue names.** `CODE_OF_CONDUCT.md` is the Contributor Covenant 1.4 adopted verbatim and attributed at its foot; `CONTRIBUTING.md` is based on contributing-gen and attributed at line 307. In both the word is their vocabulary describing a general project role, not a description of me. Nothing else is left:

```
$ git grep -il maintainer -- .
CODE_OF_CONDUCT.md
CONTRIBUTING.md
```

**The population was thirteen files, not the nine the issue lists.** Read at `044a375c`, which was the mainline when the issue was written:

```
$ git grep -il maintainer 044a375c -- . | wc -l
13
```

The four the issue misses are `publish-failure-alert.yml`, `DiscoveryDifferential.cs`, `docs/ROADMAP.md` and `security/vex/openvex.json`, and each gained the word before the issue was opened, so the list was short when it was made rather than overtaken afterwards:

```
$ for g in .github/workflows/publish-failure-alert.yml SSO-Auth.Fuzz/DiscoveryDifferential.cs \
           docs/ROADMAP.md security/vex/openvex.json; do
    git log origin/main -i -S maintainer --format="%h %ci $g" -- "$g" | tail -1
  done
e8fb35da 2026-08-04 23:07:59 +0200 .github/workflows/publish-failure-alert.yml
71898225 2026-08-07 10:24:38 +0200 SSO-Auth.Fuzz/DiscoveryDifferential.cs
a552a96c 2026-08-22 08:30:06 +0200 docs/ROADMAP.md
df7595ef 2026-08-05 14:32:30 +0200 security/vex/openvex.json
```

That is why the set here is derived from the head rather than taken from the issue body.

Closes #1470

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable in the sense the section asks for: every change is a comment, a document line, or one optional metadata value. No executable line, no login path, no crypto, no config persistence, and no release-pipeline behaviour is touched. The one file inside the release pipeline's reach is `security/vex/openvex.json`, and it is shipped by the publish legs rather than executed by them; its gate is run above.

- [ ] Fail-closed preserved: no fail-open/fail-closed decision is in this diff.
- [x] No secrets logged; secrets are redacted on config export. Unchanged - no logging is touched.
- [ ] A security review was performed. **No.** No second reader looked at this change. The diff is comments, document prose and one optional metadata value; the whole of it is reproduced above and in the commit message.
- [ ] Review record: none, for the reason on the line above.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged - no log call is touched.

## Quality checklist

- [x] No duplicated logic; no logic at all.
- [x] The change adds no more code than the problem requires - it adds none.
- [x] The code is self-documenting and matches the target architecture; only comments changed, and each still says why.
- [x] Architecture-conformance tests pass, inside the full suite below.
- [x] Docs impact considered: `docs/ROADMAP.md` and `SSO-Auth.Fuzz/README.md` are updated here. Neither the README nor the wiki carries the word, so nothing is left to file.

## Verification

- [x] `dotnet build --warnaserror` is green on the fuzz harness and on both test frameworks.

```
$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
```

- [x] The full suite is green on both frameworks, run from the built executables with the whole output kept:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3496, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 30,071s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3497, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 27,914s
```

The four skips are the documented ones: binding a listener off loopback raises the Windows firewall consent dialog, which needs an administrator (#1227). They are skipped rather than worked around.

- [x] Prettier is clean for both touched Markdown files, and its verdict is the same before and after:

```
$ npx prettier --check docs/ROADMAP.md SSO-Auth.Fuzz/README.md
All matched files use Prettier code style!
$ npx prettier --check <the same two files as at origin/main>
All matched files use Prettier code style!
```

## Notes

The roadmap row sits in an aligned table and the replacement is eight characters shorter, so the cell is repadded to the width it had. The line lengths are byte-identical to `origin/main`:

```
$ awk 'NR>=141 && NR<=145 {print length($0)}' docs/ROADMAP.md   # 262 x5
$ git show origin/main:docs/ROADMAP.md | awk 'NR>=141 && NR<=145 {print length($0)}'   # 262 x5
```

Out of scope: the locally installed Prettier 3.9.6 reports formatting differences in 22 files this change does not touch, none of them among the eleven here. That is a version gap against the pinned action rather than a defect this change introduces, and it is left alone.

No second reader looked at any of this.
