### PR TITLE
Gate the JF12 beta on a matrix that boots a Jellyfin 12 server [#1466]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -14,15 +14,18 @@
 # green before a publish. This runs on the GitHub runners' working Docker; it also runs locally once Docker
 # is restored (see test/e2e/README.md).
 #
-# WHAT A PASS HERE IS ABOUT, and it is one target framework rather than both (#1464). The build step
-# below packages `dotnet-target: net9.0` and every test/e2e/*/docker-compose.yml boots
-# `jellyfin/jellyfin:10.11.11`, so the artifact this harness installs is the JF10.11 one. For the
-# JF10.11 caller that is the shipped artifact exactly; for the JF12 caller it is not - that release
-# carries the net10.0 build at targetAbi 12.0.0.0, which will not load into a 10.11 server at all, and
-# what its pass covers is the provider-facing source of the one multi-target tree rather than its
-# bytes. The caller carries that disclosure at the job it gates; this note is the same bound stated
-# where the two pins live, so a later change to either does not have to be traced back from there.
-# Running the matrix against a JF12 server is #1466.
+# WHAT A PASS HERE IS ABOUT, and it is now one target framework PER CALLER rather than one for both
+# (#1464/#1466). This note said the build step packaged net9.0 and every test/e2e/*/docker-compose.yml
+# booted `jellyfin/jellyfin:10.11.11`, which made the JF12 caller's pass evidence about the shared
+# source of the one multi-target tree and not about the bytes it ships. The `generation` input decides
+# all three pins together instead - the target framework, the build metadata and the server image - so
+# each caller's pass is about its own artifact:
+#
+#     git grep -n 'target=net10[.]0;\|target=net9[.]0;' -- .github/workflows/e2e-login.yml
+#
+# The default is `jf10.11`, so the schedule, the pull-request trigger and a default dispatch keep
+# exactly the stack they had. What no generation covers is a 12.0 server later than the rc the
+# net10.0 build compiles against; the JF12 caller states that bound at the job it gates.
 name: E2E Login Harness
 
 on:

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -84,40 +84,28 @@ jobs:
   # which had never once started a run. Calling the harness as a job runs it INSIDE this run, so the
   # pass belongs to the commit being published rather than to whatever main held when a cron last fired.
   #
-  # WHAT THIS PASS IS NOT EVIDENCE ABOUT, stated here because the job name cannot carry it. The harness
-  # builds and installs a net9.0 package into a Jellyfin 10.11.11 server:
+  # WHAT THIS PASS IS EVIDENCE ABOUT, stated here because the job name cannot carry it. Until #1466 the
+  # harness built a net9.0 package and installed it into a Jellyfin 10.11.11 server on both callers, so
+  # for this one the pass covered the provider-facing SOURCE of the one multi-target tree and not the
+  # bytes in the artifact. It is the bytes now: `generation: jf12` below moves the target framework, the
+  # build metadata and the server image together, and the three are derived rather than typed twice.
   #
-  #     git grep -c 'dotnet-target: "net9[.]0"' -- .github/workflows/e2e-login.yml
-  #     .github/workflows/e2e-login.yml:1
-  #     git grep -c 'dotnet-target: "net10[.]0"' -- .github/workflows/publish-jf12-beta.yml
-  #     .github/workflows/publish-jf12-beta.yml:1
-  #     grep -rln 'image: jellyfin/jellyfin:10.11.11' test/e2e/ | wc -l
-  #     7
+  #     git grep -n 'metadata=build-jf12[.]yaml' -- .github/workflows/e2e-login.yml
+  #     .github/workflows/e2e-login.yml:140:            target=net10.0; metadata=build-jf12.yaml; image=12.0-rc2; needs_net10=yes
   #
-  # while the release this job goes on to publish is the net10.0 build at targetAbi 12.0.0.0 that
-  # build-jf12.yaml declares. So the seven stacks exercise the provider-facing SOURCE at this commit -
-  # one multi-target tree since #954 - and not the bytes in the artifact. What the split can break on
-  # its own is outside the pass: the two build metadata files ship different closures, and a packaged
-  # load failure of the #181/#590 class is precisely what a pass on the other target framework cannot
-  # see.
+  # So a packaged load failure of the #181/#590 class - the thing a pass on the other target framework
+  # could not see, because the two build metadata files ship different closures - is inside this pass.
   #
-  # WHY THAT IS ACCEPTED HERE rather than parameterising the harness. A net10.0 package at ABI 12.0
-  # will not load into the 10.11.11 server every compose file pins, so pointing the harness at the JF12
-  # target means standing up a JF12 server too. One exists to try, read 2026-08-30:
-  #
-  #     curl -sS 'https://hub.docker.com/v2/repositories/jellyfin/jellyfin/tags?page_size=100&ordering=last_updated' \
-  #       | grep -o '12[.]0-rc6' | head -1
-  #     12.0-rc6
-  #
-  # That is a harness of its own - seven compose files, a second build-metadata swap, and a driver
-  # nobody has yet watched pass against a 12.0 server - and gating the daily JF12 publish on it while
-  # it is unproven would stop this line rather than gate it. #1466 carries that work. Until it lands
-  # the choice is between this pass, disclosed, and no cross-provider pass at all.
+  # WHAT IS STILL OUTSIDE IT, and it is a real bound rather than a formality. The server is 12.0-rc2, the
+  # version SSO-Auth.csproj compiles net10.0 against, so the harness proves the artifact against the
+  # server it was built for and against no later 12.0 build. rc3 onward and GA are untested here, and a
+  # 12.0 server that has moved under the plugin would not be caught by this job. #1466 records that as
+  # the residual it leaves rather than as one it closed.
   #
   # AHEAD of the build job, so a red stack stops the publish instead of documenting it afterwards, and
   # gated on the same output as the build, so an unchanged main still costs nothing.
   provider-matrix:
-    name: Provider matrix (net9.0 build - see the note above)
+    name: Provider matrix (net10.0 into a Jellyfin 12 server)
     needs: gate
     if: needs.gate.outputs.changed == 'true'
     # A called workflow can hold no more than the calling job grants it. e2e-login.yml denies everything
@@ -128,6 +116,10 @@ jobs:
     uses: ./.github/workflows/e2e-login.yml
     with:
       providers: all
+      # The whole of #1466. Without it the call takes e2e-login.yml's default, which is jf10.11
+      # and is correct for every other caller - so the artifact this leg publishes was the one
+      # stack the harness never booted.
+      generation: jf12
 
   build:
     name: Build & publish JF12 beta
@@ -252,7 +244,7 @@ jobs:
             Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
             https://raw.githubusercontent.com/${{ github.repository }}/manifest-beta/manifest.json
 
-            Scope note (#743): the JF12/5.0 line is **not validated against a live Jellyfin 12.0 server yet** - no 12.0 GA server exists to run the E2E checklist against. It is CI-built and unit/conformance-tested only, and it is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate; the 5.0 line clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available. Use these betas for testing, not production.
+            Scope note (#743/#1466): the JF12/5.0 line has **had no manual Release-QA pass against a live Jellyfin 12.0 server** - no 12.0 GA server exists to run the E2E checklist against, and this line is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate. What it does carry since #1466 is the automated seven-stack provider matrix that gates this publish: it boots a live `jellyfin/jellyfin:12.0-rc2` server, installs the net10.0 artifact this release ships into it, and drives OIDC and SAML login round-trips against seven identity providers. That is the rc the net10.0 build compiles against and no later 12.0 build. The 5.0 line clears its own live-validation gate when a Jellyfin 12.0 GA build exists and the manual checklist has been run against it. Use these betas for testing, not production.
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish the draft release


### PR DESCRIPTION
# What & why

The seven-stack provider matrix has gated this publish since #1464, but it took `e2e-login.yml`'s default generation, which builds net9.0 and boots a Jellyfin 10.11.11 server. The release this leg publishes is the net10.0 build at `targetAbi 12.0.0.0`, which will not load into a 10.11 server at all - so the pass was evidence about the provider-facing source of the one multi-target tree and about nothing in the zip. #1468 parameterised the harness; this passes the parameter.

```yaml
    with:
      providers: all
      generation: jf12
```

`generation: jf12` moves the target framework, the build metadata and the server image together, derived in one place rather than typed three times:

```
$ git grep -n 'target=net10[.]0;\|target=net9[.]0;' -- .github/workflows/e2e-login.yml
.github/workflows/e2e-login.yml:140:            target=net10.0; metadata=build-jf12.yaml; image=12.0-rc2; needs_net10=yes
.github/workflows/e2e-login.yml:142:            target=net9.0; metadata=build.yaml; image=10.11.11; needs_net10=no
```

Closes #1466

## The seven-stack run, dispatched by hand from this branch before it becomes a gate

That is the Done-when's second clause, and it is the clause that was not met. [Run 33378910186](https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/33378910186), `providers: all`, `generation: jf12`, at this branch head `289c9eef055238ae41c2846bc363fa6ca665758a`:

```
$ gh run view 33378910186 --repo Flowfin/jellyfin-plugin-sso --json conclusion,headSha,jobs \
    --jq '(.conclusion), (.jobs[] | "  " + .name + "\t" + .conclusion)'
success
  select	success
  Authelia (OIDC)	success
  Dex (OIDC)	success
  Keycloak (OIDC + SAML)	success
  Zitadel (OIDC)	success
  Pocket ID (OIDC)	success
  Kanidm (OIDC)	success
  authentik (OIDC + SAML)	success
```

The stack it was green on, read out of the run's own log rather than from the input:

```
select    | generation jf12 resolves to: net10.0, build-jf12.yaml, jellyfin:12.0-rc2
Authelia  | targetAbi: "12.0.0.0"
Authelia  | framework: "net10.0"
Authelia  | jellyfin-1 | Main: Jellyfin version: 12.0.0
Authelia  | jellyfin-1 | PluginManager: Loaded plugin: Community SSO for Jellyfin 5.0.0.0
```

**Seven of seven, where the last recorded attempt was six of seven.** The stack that reddened on 2026-08-30 was Keycloak, in `test/e2e/phases/passwordless-account-sweep.sh`, on a precondition that read `HasPassword` once and got `true` on a 12.0 server. That was #1469; it is closed as completed and its fix merged as `6e9dd852c2278383944e8e94114e146adca7e273`. This run is the first seven-stack `jf12` pass and it is at the head being merged, not at an older one.

**The `blocked-on-dependency` label on the issue named #1469 and is stale.** #1469 closed at `2026-08-31T05:25:05Z`; the issue was not re-read afterwards. It comes off with this merge.

## The two disclosure paragraphs, narrowed rather than deleted

The third Done-when clause. Both are kept as narrowed text so a reader learns what the gate does and where it stops, instead of finding a caveat gone with no trace.

- **`e2e-login.yml`** said the build step packaged net9.0 and every compose file booted 10.11.11. That stopped being true at #1468 and the paragraph had not caught up - so it was already a stale claim before this change, independent of the gate flip. It now says the `generation` input decides all three pins per caller, that the default is `jf10.11` so every other trigger keeps its stack, and what no generation covers.
- **`publish-jf12-beta.yml`** said the pass was about the source and not the bytes, and argued why parameterising was not yet paid for. It now states the reach - a packaged load failure of the #181/#590 class is inside the gate, because the two metadata files ship different closures - and then the bound.

**The bound is stated as a residual this leaves, not as one it closed.** The server is `12.0-rc2`, the version `SSO-Auth.csproj` compiles net10.0 against. rc3 onward and GA are not exercised, and a 12.0 server that has moved under the plugin would not be caught by this job.

Both quoted commands are written so they do not match their own text - the trap a literal in a comment sets for the grep beside it - and both reproduce at this head, which is the pasted output above.

## The release scope note

Narrowed too, and every negative in it survives. It said the JF12 line is "not validated against a live Jellyfin 12.0 server yet". For the automated matrix that stops being true the moment this lands. For the thing the note was really about - a manual Release-QA pass - it is still true, and no GA server exists to run it against. So the note now says that in those words and states the automated pass beside it as what is measured. No negative disclosure became a positive one.

## Type of change

- [x] Security hardening / vulnerability fix — in the sense that the release gate now exercises the artifact it gates. No plugin code changes.
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff is two workflow files: one job input, one job name, three comment blocks and one release-note string. No plugin byte changes.

- [x] Fail-closed preserved: the matrix stays AHEAD of the build job and gated on the same output, so a red stack stops the publish. This change makes it harder to publish, never easier — the gate now runs against the artifact rather than a proxy for it.
- [x] No secrets logged; no credential is touched. The job's granted permission is unchanged at `contents: read`.
- [ ] A security review was performed — **NOT RUN.** No second reader looked at this change. What stands in place of one is the dispatched run above, which is the evidence the change exists to produce.
- [x] Log inputs from the IdP are sanitized inline at the log call — unchanged; no log call is touched.

## Quality checklist

- [x] No duplicated logic; the generation pins stay derived in the one place `e2e-login.yml` holds them.
- [x] The change adds no more code than the problem requires — one input line.
- [x] Comments explain why, not what, and each quoted command reproduces at this head.
- [x] Architecture-conformance tests pass, as the required `build` check on this pull request.
- [x] Docs impact: the release scope note this publish writes is updated here. No README or wiki page describes the gate's generation, so nothing is left to file.

## Verification

- [x] Both workflow files parse:

```
$ python -c "import yaml;[yaml.safe_load(open(f,encoding='utf-8')) for f in ['.github/workflows/publish-jf12-beta.yml','.github/workflows/e2e-login.yml']]"
```

- [x] The seven-stack `jf12` run above, at this head.
- [x] `build`, `dotnet test`, `zizmor` and the rest are the required checks here; merged only on green.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` in this diff.
- [ ] No local `dotnet` run: this diff compiles nothing.

## Notes

This does not touch `publish-beta.yml`. The JF10.11 leg keeps its own `jf10.11` stack, so both generations stay exercised rather than one replacing the other.

There is no second reader on this board tonight, and the dispatched run stands in place of one. That is not the same thing, and this sentence says so rather than implying otherwise.
