### PR TITLE
Map provider roles onto the account's SyncPlay access [#827]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **A group can decide who may start a SyncPlay session (#827).** Everything else
+  the identity provider decides about an account is re-read at every login -
+  administrator rights, folder access, Live TV, the permission surface, the
+  parental-rating ceiling - but SyncPlay was not among them, so a deployment that
+  expresses its access model in groups had one setting it could only manage by
+  hand, per account, forever. A provider can now map its roles onto the account's
+  SyncPlay access, and the mapping is re-asserted at every sign-in, so a group
+  withdrawn at the identity provider withdraws the access with it. It is off
+  until it is configured, and it is under the same authorization master switch as
+  every other role-derived grant: turning that off leaves SyncPlay exactly as it
+  was. A login that matches nothing changes nothing - an unmapped or misspelled
+  claim can never widen access, only leave it where it stood. Where a login
+  belongs to several mapped groups the STRICTEST of them wins, which is worth
+  saying out loud because Jellyfin numbers its SyncPlay levels the other way
+  round from its parental ratings: "least privilege" here is the highest value,
+  not the lowest, and the plugin states the ranking itself rather than inheriting
+  it from an order upstream is free to change. A level is written by name -
+  `CreateAndJoinGroups`, `JoinGroups` or `None`, spelled exactly - and any other
+  spelling, a number among them, is refused when the configuration is saved
+  rather than silently ignored at the next login.
 - **One action checks every configured provider at once (#1084).** The settings
   page could say whether the provider currently open in the editor looks
   complete, and nothing could say it about the others: an administrator with six

--- a/SSO-Auth.Tests/Authz/SyncPlayAccessPolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/SyncPlayAccessPolicyTests.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SyncPlayAccessPolicy"/> - the role → SyncPlay-access reducer (#827). Fail closed
+/// toward the LESS permissive outcome: the feature off, no mapping matched, an empty role list or an
+/// unparseable level all yield null (leave the existing level), and when several mappings match the MOST
+/// RESTRICTIVE level wins, never the loosest.
+/// </summary>
+public class SyncPlayAccessPolicyTests
+{
+    private static OidConfig Config(bool enabled, params SyncPlayAccessRoleMap[] maps) => new OidConfig
+    {
+        EnableSyncPlayAccessRoles = enabled,
+        SyncPlayAccessRoleMappings = new List<SyncPlayAccessRoleMap>(maps),
+    };
+
+    private static SyncPlayAccessRoleMap Map(string? access, params string[] roles) => new SyncPlayAccessRoleMap { Access = access, Roles = roles };
+
+    [Fact]
+    public void Resolve_FeatureOff_ReturnsNull()
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: false, Map("CreateAndJoinGroups", "hosts"))));
+
+    [Fact]
+    public void Resolve_NullMappings_ReturnsNull()
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, new OidConfig { EnableSyncPlayAccessRoles = true, SyncPlayAccessRoleMappings = null }));
+
+    [Fact]
+    public void Resolve_NoRoleMatches_ReturnsNull()
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "guests" }, Config(enabled: true, Map("JoinGroups", "hosts"))));
+
+    [Fact]
+    public void Resolve_SingleMatch_ReturnsItsLevel()
+        => Assert.Equal(SyncPlayUserAccessType.JoinGroups, SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("JoinGroups", "hosts"))));
+
+    [Fact]
+    public void Resolve_MultipleMatches_ReturnsTheMostRestrictive()
+    {
+        // THE TRAP THIS TEST EXISTS FOR. SyncPlayUserAccessType numbers the LOOSEST level zero
+        // (CreateAndJoinGroups = 0, JoinGroups = 1, None = 2), the opposite way round from the parental-rating
+        // score ParentalRatingPolicy reduces. So the Math.Min shape copied from that policy would resolve this
+        // login to CreateAndJoinGroups - the WIDEST access its groups allow - and read as correct while doing
+        // it. Deleting the ranking in SyncPlayAccessPolicy.Restrictiveness, or replacing it with the enum's
+        // own ordering, turns this assertion red.
+        var resolved = SyncPlayAccessPolicy.Resolve(
+            new[] { "hosts", "guests" },
+            Config(enabled: true, Map("CreateAndJoinGroups", "hosts"), Map("None", "guests")));
+
+        Assert.Equal(SyncPlayUserAccessType.None, resolved);
+    }
+
+    [Fact]
+    public void Resolve_MatchAcrossSeparateEntries_TakesTheStricter_EvenWhenTheLooserComesFirst()
+        => Assert.Equal(
+            SyncPlayUserAccessType.JoinGroups,
+            SyncPlayAccessPolicy.Resolve(new[] { "a", "b" }, Config(enabled: true, Map("CreateAndJoinGroups", "a"), Map("JoinGroups", "b"))));
+
+    [Fact]
+    public void Resolve_MatchAcrossSeparateEntries_TakesTheStricter_EvenWhenTheStricterComesFirst()
+        => Assert.Equal(
+            SyncPlayUserAccessType.JoinGroups,
+            SyncPlayAccessPolicy.Resolve(new[] { "a", "b" }, Config(enabled: true, Map("JoinGroups", "a"), Map("CreateAndJoinGroups", "b"))));
+
+    [Fact]
+    public void Resolve_NullEntry_IsSkipped_OtherMatchesStillApply()
+        => Assert.Equal(
+            SyncPlayUserAccessType.None,
+            SyncPlayAccessPolicy.Resolve(new[] { "guests" }, Config(enabled: true, null!, Map("None", "guests"))));
+
+    [Fact]
+    public void Resolve_MappingWithNoRoles_NeverMatches()
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("JoinGroups"))));
+
+    [Fact]
+    public void Resolve_ConfiguredRoleIsTrimmed()
+        => Assert.Equal(SyncPlayUserAccessType.JoinGroups, SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("JoinGroups", "  hosts  "))));
+
+    [Fact]
+    public void Resolve_MatchingIsOrdinalCaseSensitive()
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("JoinGroups", "Hosts"))));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("joingroups")]
+    [InlineData("Join Groups")]
+    [InlineData("Everything")]
+    public void Resolve_UnparseableLevel_IsSkipped(string? access)
+        => Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map(access, "hosts"))));
+
+    [Fact]
+    public void Resolve_NumericLevel_IsSkipped_NotCastToAnUndeclaredMember()
+    {
+        // Both numerals are refused, and they were refused by DIFFERENT checks - which is why this test has
+        // two lines rather than one. "57" parses to an undeclared (SyncPlayUserAccessType)57 that Enum.IsDefined
+        // rejects. "1" parses to the DECLARED JoinGroups, so IsDefined passed it: this assertion was red on the
+        // first run and the name round-trip in TryParseAccess is what was added to answer it. A level is a name
+        // here, so a reorder of the enum upstream cannot silently change what a stored "1" means.
+        Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("1", "hosts"))));
+        Assert.Null(SyncPlayAccessPolicy.Resolve(new[] { "hosts" }, Config(enabled: true, Map("57", "hosts"))));
+    }
+
+    [Fact]
+    public void Resolve_UnparseableLevelBesideAValidOne_LeavesTheValidOneStanding()
+        => Assert.Equal(
+            SyncPlayUserAccessType.None,
+            SyncPlayAccessPolicy.Resolve(new[] { "hosts", "guests" }, Config(enabled: true, Map("nonsense", "hosts"), Map("None", "guests"))));
+
+    [Fact]
+    public void EveryDeclaredLevelIsRanked()
+    {
+        // The ranking is hand-written, so a member added upstream would fall to the fail-closed default arm
+        // and be treated as maximally restrictive. This asserts the three members the plugin was built
+        // against are each reachable by name, so a rename upstream is a red test rather than a silent
+        // fall-through to "most restrictive" on every mapping.
+        foreach (var name in new[] { "CreateAndJoinGroups", "JoinGroups", "None" })
+        {
+            Assert.True(SyncPlayAccessPolicy.TryParseAccess(name, out var level), name);
+            Assert.Equal(name, level.ToString());
+        }
+    }
+}

--- a/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
@@ -323,6 +323,40 @@ public class ConfigXmlLifecycleTests
         Assert.Contains("GuestAccessDurationRoleMappings", json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SyncPlayAccessMappings_SurviveTheDiskCycle_AndStayVisibleToTheAdminSurface()
+    {
+        // The same two silent failures as the mapping above, for the #827 list: a populated list has to come
+        // back off disk nested inside its provider, and it has to stay in the JSON the admin page fetches -
+        // a [JsonIgnore] added here by analogy with the server-managed maps beside it would make the page
+        // post back a provider without the mappings and erase them on the next unrelated settings change.
+        var original = new PluginConfiguration();
+        original.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known/openid-configuration",
+            EnableSyncPlayAccessRoles = true,
+            SyncPlayAccessRoleMappings = new System.Collections.Generic.List<SyncPlayAccessRoleMap>
+            {
+                new SyncPlayAccessRoleMap { Access = "CreateAndJoinGroups", Roles = new[] { "hosts" } },
+                new SyncPlayAccessRoleMap { Access = "None", Roles = new[] { "guests", "visitors" } },
+            },
+        };
+
+        var back = RoundTripXml(original);
+
+        Assert.True(back.OidConfigs["kc"].EnableSyncPlayAccessRoles);
+        var mappings = back.OidConfigs["kc"].SyncPlayAccessRoleMappings;
+        Assert.NotNull(mappings);
+        Assert.Equal(2, mappings!.Count);
+        Assert.Equal("CreateAndJoinGroups", mappings[0].Access);
+        Assert.Equal(new[] { "hosts" }, mappings[0].Roles);
+        Assert.Equal("None", mappings[1].Access);
+        Assert.Equal(new[] { "guests", "visitors" }, mappings[1].Roles);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(original.OidConfigs["kc"]);
+        Assert.Contains("SyncPlayAccessRoleMappings", json, StringComparison.Ordinal);
+    }
+
     private static string Serialize<T>(T value)
     {
         var serializer = new XmlSerializer(typeof(T));

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -81,6 +81,70 @@ public class ProviderConfigValidatorTests
         }));
     }
 
+
+    // --- ValidateSyncPlayAccessMappings (#827): reject an unknown level or an entry with no roles ---
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("joingroups")] // right member, wrong case: the level is spelled exactly
+    [InlineData("Everything")]
+    [InlineData("1")] // a numeral onto a DECLARED member: refused by the name round-trip
+    [InlineData("57")] // a numeral onto an undeclared one: refused by Enum.IsDefined
+    public void ValidateSyncPlayAccessMappings_UnknownLevel_Throws(string? access)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateSyncPlayAccessMappings(
+            "OpenID", "kc", new[] { new SyncPlayAccessRoleMap { Access = access, Roles = new[] { "hosts" } } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("kc", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("SyncPlay access level", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateSyncPlayAccessMappings_ControlCharactersInTheLevel_AreNotEchoedIntoTheMessage()
+    {
+        // The rejected level is echoed back, and it is administrator-supplied text that reaches a log through
+        // the thrown exception - so it is stripped of control characters and line endings the way the
+        // provisioning-template guard strips SubtitleMode.
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateSyncPlayAccessMappings(
+            "OpenID", "kc", new[] { new SyncPlayAccessRoleMap { Access = "None\r\nADMIN LOGIN OK", Roles = new[] { "hosts" } } }));
+
+        Assert.DoesNotContain("\r", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateSyncPlayAccessMappings_NullRoles_Throws()
+        => AssertSyncPlayNoRolesRejected(null);
+
+    [Fact]
+    public void ValidateSyncPlayAccessMappings_EmptyRoles_Throws()
+        => AssertSyncPlayNoRolesRejected(Array.Empty<string>());
+
+    private static void AssertSyncPlayNoRolesRejected(string[]? roles)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateSyncPlayAccessMappings(
+            "SAML", "idp", new[] { new SyncPlayAccessRoleMap { Access = "None", Roles = roles! } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("no roles", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateSyncPlayAccessMappings_ValidOrNullOrEmpty_DoesNotThrow()
+    {
+        Assert.Null(Record.Exception(() =>
+        {
+            foreach (var level in new[] { "CreateAndJoinGroups", "JoinGroups", "None" })
+            {
+                ProviderConfigValidator.ValidateSyncPlayAccessMappings("OpenID", "kc", new[] { new SyncPlayAccessRoleMap { Access = level, Roles = new[] { "hosts" } } });
+            }
+
+            ProviderConfigValidator.ValidateSyncPlayAccessMappings("OpenID", "kc", new SyncPlayAccessRoleMap[] { null! }); // a null entry is tolerated
+            ProviderConfigValidator.ValidateSyncPlayAccessMappings("OpenID", "kc", null); // no mappings at all
+        }));
+    }
     // --- ValidateGuestAccessDurations (#1146): reject a non-positive or overflowing duration, or no roles ---
 
     [Theory]

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
@@ -277,6 +278,49 @@ public class OidcAuthorizeStateBuilderTests
             config);
 
         Assert.Null(result.MaxParentalRatingScore);
+    }
+
+    [Fact]
+    public void SyncPlayAccess_MatchedRole_CarriesTheMostRestrictiveLevelOnTheState()
+    {
+        // #827 wiring on the OpenID side: the SAME role list the other reductions read resolves the SyncPlay
+        // level, and the most restrictive matched level wins - the LARGER enum value, not the smaller one.
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnableSyncPlayAccessRoles = true;
+            c.SyncPlayAccessRoleMappings = new System.Collections.Generic.List<SyncPlayAccessRoleMap>
+            {
+                new SyncPlayAccessRoleMap { Access = "CreateAndJoinGroups", Roles = new[] { "hosts" } },
+                new SyncPlayAccessRoleMap { Access = "JoinGroups", Roles = new[] { "guests" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "hosts"), ("role", "guests")),
+            config);
+
+        Assert.Equal(SyncPlayUserAccessType.JoinGroups, result.SyncPlayAccess);
+    }
+
+    [Fact]
+    public void SyncPlayAccess_FeatureOff_LeavesTheLevelNull()
+    {
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnableSyncPlayAccessRoles = false;
+            c.SyncPlayAccessRoleMappings = new System.Collections.Generic.List<SyncPlayAccessRoleMap>
+            {
+                new SyncPlayAccessRoleMap { Access = "None", Roles = new[] { "guests" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "guests")),
+            config);
+
+        Assert.Null(result.SyncPlayAccess);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -129,6 +130,43 @@ public class SamlAuthorizeStateBuilderTests
         var result = SamlAuthorizeStateBuilder.Build(new List<string> { "kids" }, config);
 
         Assert.Null(result.MaxParentalRatingScore);
+    }
+
+    [Fact]
+    public void SyncPlayAccess_MatchedRole_CarriesTheMostRestrictiveLevelOnTheState()
+    {
+        // #827 wiring on the SAML side: the role→SyncPlay level is carried on the derived state, and the
+        // most restrictive matched level wins - which is the LARGER enum value, not the smaller one.
+        var config = Config(c =>
+        {
+            c.EnableSyncPlayAccessRoles = true;
+            c.SyncPlayAccessRoleMappings = new List<SyncPlayAccessRoleMap>
+            {
+                new SyncPlayAccessRoleMap { Access = "CreateAndJoinGroups", Roles = new[] { "hosts" } },
+                new SyncPlayAccessRoleMap { Access = "JoinGroups", Roles = new[] { "guests" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "hosts", "guests" }, config);
+
+        Assert.Equal(SyncPlayUserAccessType.JoinGroups, result.SyncPlayAccess);
+    }
+
+    [Fact]
+    public void SyncPlayAccess_FeatureOff_LeavesTheLevelNull()
+    {
+        var config = Config(c =>
+        {
+            c.EnableSyncPlayAccessRoles = false;
+            c.SyncPlayAccessRoleMappings = new List<SyncPlayAccessRoleMap>
+            {
+                new SyncPlayAccessRoleMap { Access = "None", Roles = new[] { "guests" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "guests" }, config);
+
+        Assert.Null(result.SyncPlayAccess);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Session/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/Session/SessionMinterTests.cs
@@ -53,7 +53,8 @@ public class SessionMinterTests
         string? avatarUrl = null,
         string? defaultProvider = null,
         IReadOnlyList<PermissionGrant>? permissionGrants = null,
-        int? maxParentalRatingScore = null) => new SessionParameters
+        int? maxParentalRatingScore = null,
+        SyncPlayUserAccessType? syncPlayAccess = null) => new SessionParameters
         {
             UserId = UserId,
             IsAdmin = isAdmin,
@@ -65,6 +66,7 @@ public class SessionMinterTests
             EnableLiveTvManagement = enableLiveTvManagement,
             PermissionGrants = permissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = maxParentalRatingScore,
+            SyncPlayAccess = syncPlayAccess,
             AvatarUrl = avatarUrl,
             DefaultProvider = defaultProvider,
             AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
@@ -379,5 +381,49 @@ public class SessionMinterTests
         await minter.MintAsync(Params(enableAuthorization: true, maxParentalRatingScore: null), () => "203.0.113.7", () => true);
 
         Assert.Equal(3, user.MaxParentalRatingScore); // existing ceiling untouched
+    }
+
+    [Fact]
+    public async Task MintAsync_EnableAuthorization_AppliesTheSyncPlayLevel()
+    {
+        // #827: with the master switch on, the resolved SyncPlay level is written to the user.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, SyncPlayAccess = SyncPlayUserAccessType.CreateAndJoinGroups };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: true, syncPlayAccess: SyncPlayUserAccessType.None), () => "203.0.113.7", () => true);
+
+        Assert.Equal(SyncPlayUserAccessType.None, user.SyncPlayAccess);
+    }
+
+    [Fact]
+    public async Task MintAsync_NoAuthorization_LeavesTheSyncPlayLevelUntouched()
+    {
+        // The level respects the same EnableAuthorization master switch (#215/#827): with it off, a resolved
+        // level is NOT applied - the account's existing value survives.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, SyncPlayAccess = SyncPlayUserAccessType.JoinGroups };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: false, syncPlayAccess: SyncPlayUserAccessType.None), () => "203.0.113.7", () => true);
+
+        Assert.Equal(SyncPlayUserAccessType.JoinGroups, user.SyncPlayAccess); // seed left untouched
+    }
+
+    [Fact]
+    public async Task MintAsync_NullSyncPlayLevel_LeavesTheExistingValueUntouched()
+    {
+        // #827 fail-safe: a null level (no mapping matched) never widens or clears the existing value - an
+        // unmapped or malformed claim leaves SyncPlayAccess exactly as it was, even with RBAC on.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, SyncPlayAccess = SyncPlayUserAccessType.None };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: true, syncPlayAccess: null), () => "203.0.113.7", () => true);
+
+        Assert.Equal(SyncPlayUserAccessType.None, user.SyncPlayAccess); // existing level untouched
     }
 }

--- a/SSO-Auth/Api/Authz/SyncPlayAccessPolicy.cs
+++ b/SSO-Auth/Api/Authz/SyncPlayAccessPolicy.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+/// <summary>
+/// Reduces a login's roles to a SyncPlay access level (#827), the enumerated-policy counterpart of the
+/// scalar <see cref="ParentalRatingPolicy"/> and the boolean <see cref="PermissionRolePolicy"/>. When
+/// <c>EnableSyncPlayAccessRoles</c> is on, each configured mapping whose roles the login holds contributes
+/// its level and the MOST RESTRICTIVE one wins - never the loosest. A login that matches no mapping (or the
+/// feature being off) yields null, so the mint leaves the account's existing level untouched: an unmapped or
+/// malformed claim never widens SyncPlay access.
+/// <para>
+/// SyncPlay is not a <c>PermissionKind</c>, so <see cref="PermissionRolePolicy"/> cannot express it however
+/// it is spelled: it is a three-valued level on the account
+/// (<see cref="SyncPlayUserAccessType"/>), which is why it needs a reducer of its own.
+/// </para>
+/// </summary>
+internal static class SyncPlayAccessPolicy
+{
+    /// <summary>
+    /// The SyncPlay access level the login's roles resolve to, or null when the feature is off or no mapping
+    /// matched (leave the existing level untouched).
+    /// </summary>
+    /// <param name="roles">The login's role values.</param>
+    /// <param name="config">The provider configuration carrying the mappings.</param>
+    /// <returns>The most restrictive matched level, or null when nothing applies.</returns>
+    internal static SyncPlayUserAccessType? Resolve(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        // Master switch off (the default) or no mappings configured: SSO manages no SyncPlay level, so the
+        // mint leaves User.SyncPlayAccess exactly as it was - byte-for-byte the pre-#827 behavior.
+        if (!config.EnableSyncPlayAccessRoles || config.SyncPlayAccessRoleMappings is null)
+        {
+            return null;
+        }
+
+        var loginRoles = roles as IReadOnlyCollection<string> ?? new List<string>(roles);
+
+        SyncPlayUserAccessType? resolved = null;
+        foreach (var mapping in config.SyncPlayAccessRoleMappings)
+        {
+            // Fail closed toward the LESS permissive outcome: a null entry, an entry naming no roles and an
+            // entry whose level does not parse all contribute nothing (each is rejected at config-save
+            // validation; at runtime we skip rather than throw so a single bad entry cannot 500 the login).
+            if (mapping is null || !MatchesAnyRole(mapping.Roles, loginRoles) || !TryParseAccess(mapping.Access, out var level))
+            {
+                continue;
+            }
+
+            // Most-restrictive-wins, so a login matching several groups never ends up looser than the
+            // strictest group allows - the same direction #736 chose for a ceiling.
+            resolved = resolved is { } current && Restrictiveness(current) >= Restrictiveness(level) ? current : level;
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// Parses a configured SyncPlay level name, refusing anything that is not a DECLARED member of
+    /// <see cref="SyncPlayUserAccessType"/>.
+    /// </summary>
+    /// <param name="access">The configured level name.</param>
+    /// <param name="level">The parsed level when the name is a declared member.</param>
+    /// <returns>True when the name parsed to a declared member.</returns>
+    internal static bool TryParseAccess(string? access, out SyncPlayUserAccessType level)
+    {
+        // ignoreCase: false matches the SubtitleMode idiom already in the tree - a configured level is an
+        // exact enum name, so a lowercase spelling is a mis-set to be reported rather than guessed at.
+        // The two checks after it are what MEASUREMENT added rather than reasoning: Enum.TryParse also
+        // accepts a bare numeral, and the two arms of that fail differently. "57" parses to an undeclared
+        // (SyncPlayUserAccessType)57 - IsDefined refuses it. "1" parses to a declared member and IsDefined
+        // waves it through, so the name round-trip is what refuses it: a numeral pins the configuration to
+        // the ORDER upstream happens to declare the enum in, and a reorder there would silently change what
+        // an administrator's stored level means. A level is a NAME here, and it is one because a run said
+        // IsDefined alone was not enough.
+        return Enum.TryParse(access, ignoreCase: false, out level)
+            && Enum.IsDefined(level)
+            && string.Equals(level.ToString(), access, StringComparison.Ordinal);
+    }
+
+    // How restrictive a level is, LARGER being stricter. Declared here rather than read off the enum's
+    // numeric values on purpose: SyncPlayUserAccessType runs the other way round (CreateAndJoinGroups = 0 is
+    // the LOOSEST and None = 2 the strictest), so the Math.Min shape ParentalRatingPolicy uses for a score
+    // would silently resolve a multi-role login to the WIDEST access its groups allow. An unranked value
+    // cannot reach here - Resolve admits only declared members - and the default arm is the fail-closed one
+    // anyway, so a member added upstream is treated as maximally restrictive until it is ranked by hand.
+    private static int Restrictiveness(SyncPlayUserAccessType level) => level switch
+    {
+        SyncPlayUserAccessType.CreateAndJoinGroups => 0,
+        SyncPlayUserAccessType.JoinGroups => 1,
+        SyncPlayUserAccessType.None => 2,
+        _ => int.MaxValue,
+    };
+
+    // A login holding any of the mapping's roles matches. The configured role is trimmed and compared
+    // ordinally to the (verbatim) login roles, null-safe - the same matching the sibling policies use.
+    private static bool MatchesAnyRole(string[]? mappingRoles, IReadOnlyCollection<string> loginRoles)
+    {
+        if (mappingRoles is null)
+        {
+            return false;
+        }
+
+        foreach (var role in mappingRoles)
+        {
+            var trimmed = role?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var loginRole in loginRoles)
+            {
+                if (string.Equals(loginRole, trimmed, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -173,6 +173,7 @@ internal sealed class LoginCompletionService
             EnableLiveTvManagement = identity.EnableLiveTvManagement,
             PermissionGrants = identity.PermissionGrants,
             MaxParentalRatingScore = identity.MaxParentalRatingScore,
+            SyncPlayAccess = identity.SyncPlayAccess,
             AuthResponse = response,
             DefaultProvider = enforcement.DefaultProvider,
             AvatarUrl = identity.AvatarUrl,

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -741,6 +741,9 @@ public class SSOController : ControllerBase
         // Reject an invalid parental-rating mapping (#736) at the door too (negative score / no roles), like
         // the permission-role guard above - the Add endpoints bypass the config-page save-time validation.
         ProviderConfigValidator.ValidateParentalRatingMappings(OpenIdProtocol, provider, config.ParentalRatingRoleMappings);
+        // And an invalid SyncPlay-access mapping (#827): a level the resolver cannot parse would map nothing
+        // at login, so it is refused at every write door rather than only at the config page.
+        ProviderConfigValidator.ValidateSyncPlayAccessMappings(OpenIdProtocol, provider, config.SyncPlayAccessRoleMappings);
         // And an invalid access-duration mapping (#1146), for the same reason: a non-positive or out-of-range
         // duration reaching the login path would silently stamp nothing, so it is refused at every write door
         // rather than only at the config page.
@@ -1262,6 +1265,7 @@ public class SSOController : ControllerBase
         ProviderConfigValidator.ValidatePermissionRoleMappings(SamlProtocol, provider, newConfig.PermissionRoleMappings);
         ProviderConfigValidator.ValidateParentalRatingMappings(SamlProtocol, provider, newConfig.ParentalRatingRoleMappings);
         ProviderConfigValidator.ValidateGuestAccessDurations(SamlProtocol, provider, newConfig.GuestAccessDurationRoleMappings);
+        ProviderConfigValidator.ValidateSyncPlayAccessMappings(SamlProtocol, provider, newConfig.SyncPlayAccessRoleMappings);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Identity;
@@ -65,4 +66,7 @@ internal sealed record ValidatedLogin
 
     /// <summary>Gets the provisioning-profile name the login's roles selected (#1106), or null when the provider configures no role rows or the login matched none (fall through to the provider's own default). A NAME, not a template: it is resolved against the profile set inside the create arm's own locked configuration read, and it is read on that arm only.</summary>
     internal string? ProvisioningProfile { get; init; }
+
+    /// <summary>Gets the SyncPlay access level the login resolves (#827), or null when the feature is off or no mapping matched (leave the existing level untouched).</summary>
+    internal SyncPlayUserAccessType? SyncPlayAccess { get; init; }
 }

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 
@@ -58,7 +59,8 @@ internal sealed record VerifiedIdentity
         int? maxParentalRatingScore,
         DateTime? expiresAtUtc,
         TimeSpan? guestAccessDuration,
-        string? provisioningProfile)
+        string? provisioningProfile,
+        SyncPlayUserAccessType? syncPlayAccess)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -77,6 +79,7 @@ internal sealed record VerifiedIdentity
         ExpiresAtUtc = expiresAtUtc;
         GuestAccessDuration = guestAccessDuration;
         ProvisioningProfile = provisioningProfile;
+        SyncPlayAccess = syncPlayAccess;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -166,6 +169,13 @@ internal sealed record VerifiedIdentity
     internal string? ProvisioningProfile { get; }
 
     /// <summary>
+    /// Gets the SyncPlay access level the login resolves (#827): the MOST RESTRICTIVE of the matched
+    /// role→level mappings, applied at the mint under EnableAuthorization. Null when the feature is off or
+    /// no mapping matched, so the account's existing level is left untouched.
+    /// </summary>
+    internal SyncPlayUserAccessType? SyncPlayAccess { get; }
+
+    /// <summary>
     /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
     /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
     /// promoted (role-gate-passed) state - so a raw or unvalidated login can never reach it.
@@ -205,5 +215,6 @@ internal sealed record VerifiedIdentity
             login.MaxParentalRatingScore,
             login.ExpiresAtUtc,
             login.GuestAccessDuration,
-            login.ProvisioningProfile);
+            login.ProvisioningProfile,
+            login.SyncPlayAccess);
 }

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -157,6 +157,7 @@ internal abstract class AuthorizeSession
                 ExpiresAtUtc = derived.ExpiresAtUtc,
                 GuestAccessDuration = derived.GuestAccessDuration,
                 ProvisioningProfile = derived.ProvisioningProfile,
+                SyncPlayAccess = derived.SyncPlayAccess,
             });
 
             // Carry the OpenID logout material (#727, SLO-1b) alongside the keystone rather than inside it:

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
@@ -102,6 +103,11 @@ internal static class OidcAuthorizeStateBuilder
         // mapping matched, so the mint leaves the account's existing ceiling untouched.
         var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
 
+        // Reduce the SAME role set to a SyncPlay access level (#827): null when the feature is off or no
+        // mapping matched, so the mint leaves the account's existing level untouched. Enumerated rather than
+        // boolean, so it cannot ride the PermissionKind grants above.
+        var syncPlayAccess = SyncPlayAccessPolicy.Resolve(roles, config);
+
         // Reduce the SAME role set to a fixed access duration (#1146): null when the provider maps no role
         // to a duration or this login held none, in which case a provisioned account gets no deadline. It is
         // resolved here, beside the other role reductions, so no second role read is added to the callback.
@@ -133,7 +139,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc, guestAccessDuration, provisioningProfile);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc, guestAccessDuration, provisioningProfile, syncPlayAccess);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -428,6 +434,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="ExpiresAtUtc">The account-expiry instant the configured expiry claim resolved (#1143), in UTC; null when no claim is configured, the claim is absent, or its value is not a shape the reader understands.</param>
     /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
     /// <param name="ProvisioningProfile">The provisioning-profile name the login's roles selected (#1106); null when the provider configures no role rows or the login matched none, in which case the provider's own default resolution decides. Read only on the arm that provisions a brand-new account.</param>
+    /// <param name="SyncPlayAccess">The SyncPlay access level the login's roles resolved (#827); null when the feature is off or no mapping matched (leave the existing level untouched).</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -443,7 +450,8 @@ internal static class OidcAuthorizeStateBuilder
         int? MaxParentalRatingScore = null,
         DateTime? ExpiresAtUtc = null,
         TimeSpan? GuestAccessDuration = null,
-        string? ProvisioningProfile = null)
+        string? ProvisioningProfile = null,
+        SyncPlayUserAccessType? SyncPlayAccess = null)
     {
         /// <summary>
         /// Gets the raw OpenID <c>id_token</c>, captured at the callback for a later RP-initiated logout

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -259,6 +259,7 @@ internal sealed class SamlAssertionValidator
             ExpiresAtUtc = ReadExpiry(config, samlResponse),
             GuestAccessDuration = derived.GuestAccessDuration,
             ProvisioningProfile = derived.ProvisioningProfile,
+            SyncPlayAccess = derived.SyncPlayAccess,
         });
         return true;
     }

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
@@ -40,6 +41,11 @@ internal static class SamlAuthorizeStateBuilder
         // mapping matched, so the mint leaves the account's existing ceiling untouched.
         var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
 
+        // Reduce the SAME role set to a SyncPlay access level (#827): null when the feature is off or no
+        // mapping matched, so the mint leaves the account's existing level untouched. Enumerated rather than
+        // boolean, so it cannot ride the PermissionKind grants above.
+        var syncPlayAccess = SyncPlayAccessPolicy.Resolve(roles, config);
+
         // Reduce the SAME role set to a fixed access duration (#1146): null when the provider maps no role to
         // a duration or this login held none, in which case a provisioned account gets no deadline. Resolved
         // here, beside the other role reductions, so no second attribute read is added to the callback.
@@ -51,7 +57,7 @@ internal static class SamlAuthorizeStateBuilder
         // beside the other role reductions, so no second attribute read is added to the callback.
         var provisioningProfile = ProvisioningProfilePolicy.Resolve(roles, config);
 
-        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore, guestAccessDuration, provisioningProfile);
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore, guestAccessDuration, provisioningProfile, syncPlayAccess);
     }
 
     /// <summary>
@@ -65,6 +71,7 @@ internal static class SamlAuthorizeStateBuilder
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
     /// <param name="ProvisioningProfile">The provisioning-profile name the login's roles selected (#1106); null when the provider configures no role rows or the login matched none, in which case the provider's own default resolution decides. Read only on the arm that provisions a brand-new account.</param>
+    /// <param name="SyncPlayAccess">The SyncPlay access level the login's roles resolved (#827); null when the feature is off or no mapping matched (leave the existing level untouched).</param>
     internal readonly record struct SamlAuthorizeState(
         bool Admin,
         bool EnableLiveTv,
@@ -73,5 +80,6 @@ internal static class SamlAuthorizeStateBuilder
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
         int? MaxParentalRatingScore = null,
         TimeSpan? GuestAccessDuration = null,
-        string? ProvisioningProfile = null);
+        string? ProvisioningProfile = null,
+        SyncPlayUserAccessType? SyncPlayAccess = null);
 }

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -119,6 +119,15 @@ internal sealed class SessionMinter
             {
                 user.MaxParentalRatingScore = parameters.MaxParentalRatingScore;
             }
+
+            // SyncPlay access level (#827): applied only when the login resolved one (a role matched a
+            // configured mapping); a null leaves the account's existing SyncPlayAccess untouched, so an
+            // unmapped or malformed claim never widens it. Under the same EnableAuthorization master switch
+            // as the grants above. Not a PermissionKind, so it cannot ride the grant loop.
+            if (parameters.SyncPlayAccess.HasValue)
+            {
+                user.SyncPlayAccess = parameters.SyncPlayAccess.Value;
+            }
         }
 
         await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);

--- a/SSO-Auth/Api/Session/SessionParameters.cs
+++ b/SSO-Auth/Api/Session/SessionParameters.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
@@ -73,6 +74,13 @@ internal sealed class SessionParameters
     /// other role-derived grants. Optional (defaults null) so an unconfigured provider changes nothing.
     /// </summary>
     public int? MaxParentalRatingScore { get; init; }
+
+    /// <summary>
+    /// Gets the SyncPlay access level to apply at the mint (#827), or null to leave the account's existing
+    /// level untouched. Applied only when <see cref="EnableAuthorization"/> is on, exactly like the other
+    /// role-derived grants. Optional (defaults null) so an unconfigured provider changes nothing.
+    /// </summary>
+    public SyncPlayUserAccessType? SyncPlayAccess { get; init; }
 
     /// <summary>
     /// Gets the client identity (app, version, device) the session is bound to.

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -544,6 +544,33 @@ public abstract class ProviderConfigBase
     public List<ParentalRatingRoleMap>? ParentalRatingRoleMappings { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the role-to-SyncPlay-access mapping
+    /// (<see cref="SyncPlayAccessRoleMappings"/>) is applied at login (#827). Off by default (fail closed):
+    /// a deployment that does not set it sees no change on upgrade. Gated additionally by
+    /// <see cref="EnableAuthorization"/> at the mint, exactly like the other role-derived grants, so turning
+    /// RBAC off leaves the level untouched.
+    /// </summary>
+    public bool EnableSyncPlayAccessRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the role-to-SyncPlay-access mappings applied at login when
+    /// <see cref="EnableSyncPlayAccessRoles"/> is on (#827): each entry names a SyncPlay access level and the
+    /// roles it applies to (e.g. a <c>hosts</c> group → <c>CreateAndJoinGroups</c>). SyncPlay is not a
+    /// Jellyfin permission but a three-valued level on the account, so it is not expressible through
+    /// <see cref="PermissionRoleMappings"/> however it is spelled. When a login matches several entries the
+    /// MOST RESTRICTIVE level wins, never the loosest - and "most restrictive" is declared by the resolver
+    /// rather than taken from the enum's numeric order, which runs the other way. A login that matches no
+    /// entry leaves the account's existing level untouched. A login that DOES match is authoritative,
+    /// exactly like the admin/folder/Live TV grants: the matched level is written even if it is wider than a
+    /// value an administrator set by hand, so keep the mappings in sync with the intended policy. Validated
+    /// fail-closed on save (an entry with no roles, or a level that is not a declared member of Jellyfin's
+    /// SyncPlay access enum, is rejected before it is persisted).
+    /// </summary>
+    [XmlArray("SyncPlayAccessRoleMappings")]
+    [XmlArrayItem(typeof(SyncPlayAccessRoleMap), ElementName = "SyncPlayAccessRoleMappings")]
+    public List<SyncPlayAccessRoleMap>? SyncPlayAccessRoleMappings { get; set; }
+
+    /// <summary>
     /// Gets or sets the authentication provider id written to the user's Jellyfin account
     /// (<c>User.AuthenticationProviderId</c>) after a successful SSO login. This is a Jellyfin-native
     /// user attribute; SSO logins themselves always resolve through the per-provider canonical-link maps,
@@ -1147,6 +1174,30 @@ public class ParentalRatingRoleMap
     /// <summary>
     /// Gets or sets the roles the ceiling applies to. A login holding any of these roles is capped at
     /// <see cref="Score"/>; a login holding none is left untouched.
+    /// </summary>
+    public string[]? Roles { get; set; }
+}
+
+/// <summary>
+/// Maps a set of provider roles to a SyncPlay access level (#827): a login holding any of the listed roles
+/// has its Jellyfin <c>SyncPlayAccess</c> set to <see cref="Access"/>. When a login matches several entries
+/// the MOST RESTRICTIVE level wins - which is NOT the smallest value, because Jellyfin's enum numbers the
+/// loosest level zero. The level is validated fail-closed on save (it must be a declared member of the
+/// SyncPlay access enum, spelled exactly; the role list must be non-empty).
+/// </summary>
+public class SyncPlayAccessRoleMap
+{
+    /// <summary>
+    /// Gets or sets the SyncPlay access level granted to the listed roles, as the exact name of a Jellyfin
+    /// <c>SyncPlayUserAccessType</c> member - <c>CreateAndJoinGroups</c>, <c>JoinGroups</c> or <c>None</c>.
+    /// Held as a string rather than as the enum itself so a mis-set value is reported by save-time
+    /// validation instead of failing the whole configuration document at deserialization.
+    /// </summary>
+    public string? Access { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles the level applies to. A login holding any of these roles is set to
+    /// <see cref="Access"/>; a login holding none is left untouched.
     /// </summary>
     public string[]? Roles { get; set; }
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -68,6 +68,7 @@ internal static class ProviderConfigValidator
                 ValidatePostLogoutRedirectUri("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride, kvp.Value?.PostLogoutRedirectUri);
                 ValidatePermissionRoleMappings("OpenID", kvp.Key, kvp.Value?.PermissionRoleMappings);
                 ValidateParentalRatingMappings("OpenID", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
+                ValidateSyncPlayAccessMappings("OpenID", kvp.Key, kvp.Value?.SyncPlayAccessRoleMappings);
                 ValidateGuestAccessDurations("OpenID", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("OpenID", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
                 ValidateProvisioningProfileReference("OpenID", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
@@ -92,6 +93,7 @@ internal static class ProviderConfigValidator
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
                 ValidatePermissionRoleMappings("SAML", kvp.Key, kvp.Value?.PermissionRoleMappings);
                 ValidateParentalRatingMappings("SAML", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
+                ValidateSyncPlayAccessMappings("SAML", kvp.Key, kvp.Value?.SyncPlayAccessRoleMappings);
                 ValidateGuestAccessDurations("SAML", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("SAML", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
                 ValidateProvisioningProfileReference("SAML", kvp.Key, kvp.Value, incoming.ProvisioningProfiles);
@@ -629,6 +631,51 @@ internal static class ProviderConfigValidator
             {
                 throw new ArgumentException(
                     $"{protocol} provider '{echoName}' has a parental-rating mapping with no roles: each mapping must list at least one role the ceiling applies to.",
+                    nameof(mappings));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rejects a SyncPlay-access mapping (#827) whose level is not a declared member of Jellyfin's
+    /// <c>SyncPlayUserAccessType</c> (spelled exactly), or which lists no roles - the former would silently
+    /// map nothing at login, the latter would never apply. Both are caught at save so a mis-set is found
+    /// before it takes effect. A null mappings collection or a null entry maps nothing and is tolerated.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="mappings">The SyncPlay-access mappings to check.</param>
+    /// <exception cref="ArgumentException">An entry names an unknown level or lists no roles.</exception>
+    internal static void ValidateSyncPlayAccessMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<SyncPlayAccessRoleMap>? mappings)
+    {
+        if (mappings == null)
+        {
+            return;
+        }
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping == null)
+            {
+                continue;
+            }
+
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+
+            // One parse, shared with the login path: the validator refuses exactly what the resolver would
+            // skip, so a saved mapping is one the mint can act on rather than one it silently drops.
+            if (!SyncPlayAccessPolicy.TryParseAccess(mapping.Access, out _))
+            {
+                var echoAccess = string.Concat((mapping.Access ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has an invalid SyncPlay-access mapping: '{echoAccess}' is not a SyncPlay access level. Use the exact spelling CreateAndJoinGroups, JoinGroups or None.",
+                    nameof(mappings));
+            }
+
+            if (mapping.Roles == null || mapping.Roles.Length == 0)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has a SyncPlay-access mapping with no roles: each mapping must list at least one role the level applies to.",
                     nameof(mappings));
             }
         }


### PR DESCRIPTION
# What & why

Closes #827.

Every other authority the identity provider holds over an account is re-read at
every login - administrator rights, folder access, Live TV, the whole boolean
permission surface, the parental-rating ceiling. SyncPlay was not among them,
because it is not a `PermissionKind`: it is a three-valued level on the account,
so `PermissionRolePolicy` cannot reach it however it is spelled. A deployment
that expresses its access model in groups had one setting it could only manage
by hand, per account, forever.

`SyncPlayAccessPolicy` reduces the SAME role set the other reductions already
read to a `SyncPlayUserAccessType`; both protocols resolve it at the authorize
step beside `ParentalRatingPolicy`, and the mint writes it under
`EnableAuthorization`. Null means no mapping matched, and null leaves the
account's level untouched, so an unmapped or misspelled claim can never widen
access.

This is the residual scope the issue's 2026-08-31 comment measured and left:

```
$ git grep -c 'SyncPlay' origin/main -- '*.cs'; echo "exit=$?"
exit=1
```

The two scalars the issue also once named are out of scope by the decision
recorded on it on 2026-08-31: the provisioning template owns
`RemoteClientBitrateLimit` and `MaxActiveSessions`, and nothing here touches
them.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing in this change touches assertion
      or token validation. Its own fail-closed direction: the feature is off
      until configured, a null resolution leaves the account's level untouched,
      and a mapping that does not parse contributes nothing rather than
      defaulting to a level.
- [x] No secrets logged; secrets are redacted on config export. No secret is
      read or written here.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second
      reader ran on this change. The box stays unticked, and the evidence below
      stands in place of one rather than as a substitute claiming to be one.
- [ ] Review record: per lens, its verdict and its findings. **NONE EXISTS.** No
      lens ran, so there are no verdicts to record and no CONFIRMED/PLAUSIBLE
      counts to give. Recording a zero here would read as "reviewed, nothing
      found", which is the opposite of what happened.
- [x] Log inputs from the IdP are sanitized inline at the log call. The one piece
      of untrusted text this change echoes is administrator-supplied rather than
      IdP-supplied - the rejected level in the validator message, which reaches a
      log through the thrown exception. It is stripped of control characters and
      line endings inline at the throw, the way the provisioning-template guard
      strips `SubtitleMode`, and
      `ValidateSyncPlayAccessMappings_ControlCharactersInTheLevel_AreNotEchoedIntoTheMessage`
      pins it.

### What I ran instead of a review, and what it found

Each guard was proven by deleting it and re-running, and one of the four was
found by a red test rather than foreseen.

| Guard removed | Suite result |
| --- | --- |
| `Restrictiveness` ranking replaced by the enum's own numeric order | 5 red: the two state-builder wirings and three `SyncPlayAccessPolicyTests` |
| the `.HasValue` skip at the mint (write `GetValueOrDefault()`) | 1 red: `MintAsync_NullSyncPlayLevel_LeavesTheExistingValueUntouched` |
| the write moved outside the `EnableAuthorization` gate | 1 red: `MintAsync_NoAuthorization_LeavesTheSyncPlayLevelUntouched` |

Removing the `.HasValue` guard outright does not compile - `CS8629` - so the
falsifier for it writes the default level instead, which is the dangerous
version of the same mistake.

**Most-restrictive-wins is NOT the minimum here, and that is the trap.** Read off
the bound assembly rather than assumed:

```
CreateAndJoinGroups = 0
JoinGroups = 1
None = 2
```

(reflected out of `Jellyfin.Database.Implementations.dll` at `10.11.11`, and the
same three values at `12.0.0-rc2`.) So the `Math.Min` shape
`ParentalRatingPolicy` uses for a score would have resolved a multi-group login
to the WIDEST access its groups allow, and read as correct while doing it. The
ranking is declared in the plugin rather than taken from the enum's order, so a
reorder upstream cannot silently invert the rule.

**A level is a name, and half of that was found by a red test.**
`Enum.TryParse` accepts a bare numeral, and its two arms fail differently: `"57"`
becomes an undeclared `(SyncPlayUserAccessType)57` that `Enum.IsDefined` refuses,
while `"1"` becomes the declared `JoinGroups` and `IsDefined` waved it through.
`Resolve_NumericLevel_IsSkipped_NotCastToAnUndeclaredMember` was red on the first
run for exactly that half; the name round-trip in `TryParseAccess` is what
answers it, and it keeps a stored level from meaning something else after an
upstream reorder.

**The validator refuses exactly what the resolver would skip**, sharing the one
parse, on every write door - the config-page save and an import (both through
`ProviderConfigValidator.Validate`) and both `Add` endpoints - so a saved mapping
is one the mint can act on rather than one it silently drops at the next login.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. `SyncPlayAccessPolicy` is one file beside its three siblings in
      `Api/Authz/`, and the validator calls its parse rather than carrying a
      second copy of the rule.
- [x] The change adds no more code than the problem requires. It is the shape
      #736 already cut, made once more for an enumerated value; the deltas
      outside the new file and its tests are one line each at nine plumbing
      sites.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. This change establishes no new
      structural property, so no rule is added: it uses the existing
      role-reduction shape at the existing sites.
- [ ] Docs impact considered. **A `documentation` issue is owed and is linked in
      Notes.** The sibling role maps are documented only on the wiki, which is
      outside this repository - grepping `README.md`, `providers.md` and `docs/`
      for `ParentalRatingRoleMappings`, `EnableParentalRatingRoles` and
      `PermissionRoleMappings` returns nothing - so there is no in-repo page for
      this one to update, and the box stays unticked until that issue is closed.

## Verification

- [x] `dotnet build --warnaserror` is green on BOTH target frameworks, 0
      warnings: `net9.0` and `net10.0`.
- [x] `dotnet test` is green on both. `net9.0`: 3535 total, 0 failed, 4 skipped.
      `net10.0`: 3536 total, 0 failed, 4 skipped. The four skips are the
      pre-existing loopback-bind skips that would raise a Windows firewall
      consent dialog (#1227); they are unrelated to this change and are skipped
      on `main` too.
- [x] Prettier is clean for the one `.md` file this touches:
      `npx prettier --check "CHANGELOG.md"` - "All matched files use Prettier
      code style!".

## Notes

**No second reader.** Said once more here because it is the thing most easily
lost between two checklists: nothing but the suite and the falsifiers above has
looked at this change.

**Not on the configuration page.** None of the role-mapping features is - a
repo-wide count of `ParentalRatingRoleMappings`, `GuestAccessDurationRoleMappings`
and `PermissionRoleMappings` over `SSO-Auth/Web/` is zero for all three - so this
one is configured the same way they are: through the admin API, a configuration
file, or an import. Putting it on the page alone would make it the odd one out
rather than an improvement.

**What is deliberately not here.** The two scalar limits, per the decision
recorded on the issue; and no migration, because an existing configuration
carries no mappings and provisions byte-identically to before.

The documentation issue this owes is **#1481**, on the current milestone.
