### PR TITLE
Refuse a numeric SubtitleMode at both sites that read one [#1482]

### DIFF
--- a/SSO-Auth.Tests/Linking/ProvisioningPolicyTemplateTests.cs
+++ b/SSO-Auth.Tests/Linking/ProvisioningPolicyTemplateTests.cs
@@ -367,6 +367,35 @@ public class ProvisioningPolicyTemplateTests
         Assert.Equal(SubtitlePlaybackMode.Always, created.SubtitleMode);
     }
 
+    [Theory]
+    [InlineData("57")]
+    [InlineData("1")]
+    public async Task ANumericSubtitleMode_IsRefusedAtSaveAndWritesNothing(string mode)
+    {
+        // #1482: Enum.TryParse also accepts a bare NUMERAL, and the two rows fail differently. "57" parsed
+        // to an undeclared (SubtitlePlaybackMode)57 and landed on a brand-new account from a save that
+        // reported success. "1" parses to a DECLARED member, so IsDefined waves it through and only the name
+        // round-trip refuses it - a numeral pins the stored preference to the order upstream declares the
+        // enum in, and a reorder there would silently change what the administrator configured.
+        //
+        // The account is pre-set to OnlyForced, which is neither of the two values these rows would parse to,
+        // so the writer's skip is asserted on both rows rather than only on the undeclared one. Somebody
+        // reading Jellyfin's own API, where the mode is a number on the wire, is how a numeral gets typed in.
+        Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateProvisioningTemplate(
+            "OpenID",
+            "kc",
+            new ProvisioningPolicyTemplate { SubtitleMode = mode }));
+
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { SubtitleMode = mode };
+        var created = Provisionable(users, "alice");
+        created.SubtitleMode = SubtitlePlaybackMode.OnlyForced;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(SubtitlePlaybackMode.OnlyForced, created.SubtitleMode);
+    }
+
     [Fact]
     public void EverySubtitleModeJellyfinDefines_IsAccepted_AndTheRefusalNamesRealOnes()
     {

--- a/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
@@ -149,7 +149,7 @@ internal static class ProvisioningPolicy
         // an unknown name; this is the same second refusal the permission entries get above, for the same
         // reason - a config file edited by hand around the validator still reaches this writer. Falling back
         // to the enum's zero value would quietly set a mode nobody asked for.
-        if (Enum.TryParse<SubtitlePlaybackMode>(template.SubtitleMode, ignoreCase: false, out var subtitleMode))
+        if (TryParseSubtitleMode(template.SubtitleMode, out var subtitleMode))
         {
             user.SubtitleMode = subtitleMode;
             written++;
@@ -174,6 +174,28 @@ internal static class ProvisioningPolicy
         }
 
         return written;
+    }
+
+    /// <summary>
+    /// Parses a configured subtitle-mode name, refusing anything that is not a DECLARED member of
+    /// <see cref="SubtitlePlaybackMode"/> spelled exactly (#1482).
+    /// </summary>
+    /// <param name="mode">The configured mode name.</param>
+    /// <param name="parsed">The parsed mode when the name is a declared member.</param>
+    /// <returns>True when the name parsed to a declared member.</returns>
+    internal static bool TryParseSubtitleMode(string? mode, out SubtitlePlaybackMode parsed)
+    {
+        // ignoreCase: false so a mis-cased spelling is reported rather than guessed at. The two checks after
+        // it are what a MEASUREMENT added rather than reasoning, and they are the ones the permission
+        // entries and SyncPlayAccessPolicy.TryParseAccess already carry: Enum.TryParse also accepts a bare
+        // numeral, and the two arms fail differently. "57" parses to an undeclared (SubtitlePlaybackMode)57
+        // - IsDefined refuses it. "1" parses to a declared member and IsDefined waves it through, so the
+        // name round-trip is what refuses it: a numeral pins the stored preference to the ORDER upstream
+        // happens to declare the enum in, and a reorder there would silently change what an administrator
+        // configured. A mode is a NAME here, on both sites that read one.
+        return Enum.TryParse(mode, ignoreCase: false, out parsed)
+            && Enum.IsDefined(parsed)
+            && string.Equals(parsed.ToString(), mode, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -432,8 +432,11 @@ internal static class ProviderConfigValidator
         // administrator would get a setting they never chose and nothing would say so. The two language
         // fields are deliberately NOT checked against a list - Jellyfin stores what it is given, and a
         // plugin-side allow-list would drift against it and begin refusing codes Jellyfin accepts.
+        // One parse for both sites (#1482), so the validator refuses exactly what the writer would skip:
+        // a bare numeral walked through Enum.TryParse here and landed on the account as an undeclared
+        // (SubtitlePlaybackMode)57, from a save that reported success.
         if (template.SubtitleMode != null
-            && !Enum.TryParse<SubtitlePlaybackMode>(template.SubtitleMode, ignoreCase: false, out _))
+            && !ProvisioningPolicy.TryParseSubtitleMode(template.SubtitleMode, out _))
         {
             var echoMode = string.Concat(template.SubtitleMode.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
             throw new ArgumentException(


### PR DESCRIPTION
# What & why

`ProvisioningPolicyTemplate.SubtitleMode` is the one closed-vocabulary field in the
provisioning template, and both sites that read it parsed it with a bare `Enum.TryParse`,
which also accepts a NUMERAL. So `"57"` passed save-time validation and
`ProvisioningPolicy.ApplyAtProvisioning` wrote `(SubtitlePlaybackMode)57` onto a brand-new
account, from a route that reported success and told the administrator nothing.

`TryParseSubtitleMode` is now one parse shared by the writer and by
`ProviderConfigValidator.ValidateProvisioningTemplate`, so the validator refuses exactly
what the writer would skip. It carries the round-trip the permission entries and
`SyncPlayAccessPolicy.TryParseAccess` already have, and the round-trip rather than
`IsDefined` alone is what the second row of the new theory needs: `"1"` parses to a
DECLARED member, and accepting it would pin an administrator's stored preference to the
order upstream happens to declare the enum in.

The refusal message is untouched, so the misspelling case it already reported reads
exactly as before, and `ignoreCase: false` still refuses `smart`.

Closes #1482

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This does not touch the login path, crypto, config persistence or the release pipeline: it
tightens what an already-elevated config write may store. A numeric `SubtitleMode` grants
no access and widens nothing - unlike a numeric `PermissionKind`, which would parse onto
`IsAdministrator` and is refused by name elsewhere. So the boxes below are answered as not
applicable rather than ticked.

- [ ] Fail-closed preserved: not applicable - no signature, time-bound or audience is read
      here. The direction of the change is nonetheless toward refusal: a value that was
      accepted is now rejected, and the writer keeps its independent skip.
- [ ] No secrets logged: not applicable - no secret is read on this path. The rejected
      value is echoed into the exception message and was already stripped of control
      characters and line endings inline; that code is unchanged.
- [ ] A security review was performed: **no.** No second reader looked at this change.
- [ ] Review record: none, per the line above.
- [ ] Log inputs from the IdP are sanitized inline at the log call: not applicable - the
      value is administrator-supplied config, not IdP input, and no log call was added.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
      The two sites now share one parse, which is what #1482 left to the implementer.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
      `ProviderConfigValidator` already calls into `Api.Authz` for exactly this shape
      (`SyncPlayAccessPolicy.TryParseAccess`), so no new edge is introduced.
- [x] Architecture-conformance tests pass (they are in the full suite runs below).
- [x] Docs impact considered: none. The refusal message an operator sees is unchanged,
      and no documented option changes meaning.

## Verification

- [x] Build green on both target frameworks with `--warnaserror`, 0 warnings:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
```

- [x] Full suite green on both, whole output kept rather than filtered to the summary:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3543, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,755s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3544, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,951s
```

  The four skips on each are `SsoHttpTests` binding a listener off loopback, which this
  host does not permit. They are disclosed rather than worked around:

```
Jellyfin.Plugin.SSO_Auth.Tests.SsoHttpTests.CompositionRoot_GivesEachOutboundName_ItsOwnTier [SKIP]
Jellyfin.Plugin.SSO_Auth.Tests.SsoHttpTests.PrivatePermittedHandler_ConnectsToAnRfc1918Address_WhereTheStrictOneRefuses [SKIP]
Jellyfin.Plugin.SSO_Auth.Tests.SsoHttpTests.PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback [SKIP]
Jellyfin.Plugin.SSO_Auth.Tests.SsoHttpTests.PrivatePermittedHandler_StopsAtTheRedirectBoundTheHandlerSets [SKIP]
```

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

### The guard is proven by deleting it, at each site separately

Not one falsification but two, because the Done-when asks that the writer's refusal stay a
real second refusal rather than a formality behind the validator's.

Dropping the two extra conditions from the helper - back to a bare
`Enum.TryParse(mode, ignoreCase: false, out parsed)` - reddens both rows at the validator:

```
Jellyfin.Plugin.SSO_Auth.Tests.ProvisioningPolicyTemplateTests.ANumericSubtitleMode_IsRefusedAtSaveAndWritesNothing(mode: "57") [FAIL]
  Assert.Throws() Failure: No exception was thrown
Jellyfin.Plugin.SSO_Auth.Tests.ProvisioningPolicyTemplateTests.ANumericSubtitleMode_IsRefusedAtSaveAndWritesNothing(mode: "1") [FAIL]
  Assert.Throws() Failure: No exception was thrown
   SSO-Auth.Tests  Total: 7, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,493s
```

Restoring the helper and replacing only the WRITER's call with the bare `Enum.TryParse`
reddens both rows at the writer instead, on the other assertion:

```
Jellyfin.Plugin.SSO_Auth.Tests.ProvisioningPolicyTemplateTests.ANumericSubtitleMode_IsRefusedAtSaveAndWritesNothing(mode: "57") [FAIL]
  Assert.Equal() Failure: Values differ
Jellyfin.Plugin.SSO_Auth.Tests.ProvisioningPolicyTemplateTests.ANumericSubtitleMode_IsRefusedAtSaveAndWritesNothing(mode: "1") [FAIL]
  Assert.Equal() Failure: Values differ
   SSO-Auth.Tests  Total: 7, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,402s
```

Both falsifications reddened only the new theory; the other five `*SubtitleMode*` tests
stayed green in each, which is what says the near-miss is this defect and not a
neighbouring one. The account is pre-set to `OnlyForced`, which is neither of the values
the two rows parse to, so neither row is vacuous at the writer.

## Notes

`"1"` is the row worth keeping: it is legal today, it lands on a real mode, and only the
name round-trip refuses it. Without that row the theory would pass against an `IsDefined`
check that the SyncPlay measurement already showed to be insufficient.

Nothing here changes the two language preference fields beside it, which are deliberately
not checked against a list.

No second reader looked at this change.
