### PR TITLE
Publish the mappable permission vocabulary from one producer [#1484]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -89,6 +89,13 @@ public partial class ArchitectureConformanceTests
         // provider Test routes - those are throttled, share one bucket, and a fan-out would empty it - so
         // throttling this one would guard a surface that spends nothing.
         "Config/Check",
+        // Elevated read-only permission vocabulary (#1484): Jellyfin's compiled PermissionKind names minus
+        // this plugin's compiled exclusion set. It reads no configuration, holds no lock, makes no outbound
+        // request, writes nothing and takes no caller-supplied id - the answer is identical on every
+        // installation and on every request, so there is no per-request cost and no server fact for a
+        // throttle to protect. Exempt for a STRONGER reason than the two neighbours above, which at least
+        // read this server's providers.
+        "Config/Permissions",
         // Elevated read-only counter exposition (#1139): in-memory tallies rendered to text, no outbound
         // fetch and no write. Exempt for a reason the neighbours above do not have - a scraper is SUPPOSED to
         // poll this route, every fifteen seconds forever, so a throttle here would break the one caller it

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -63,6 +63,10 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The pre-provision link write (#1133): it grants an identity-provider subject the ability to sign
         // in as an account other than the caller's, with no identity-provider response behind it.
         "PreprovisionCanonicalLink",
+        // The mappable permission vocabulary (#1484): read-only and installation-independent, and
+        // elevation-gated because the config page is the only caller it exists for - an anonymous route
+        // would be a new unauthenticated surface bought for nothing.
+        "PermissionVocabulary",
         // The auth-path counter exposition (#1139): read-only, and elevation-gated because the counters name
         // which providers the server has and how often logins against them fail, which is reconnaissance for
         // an unauthenticated caller and would let one watch their own attempts land.

--- a/SSO-Auth.Tests/Http/SSOControllerMappablePermissionsTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerMappablePermissionsTests.cs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of <c>GET sso/Config/Permissions</c> (#1484) through <see cref="SsoControllerHarness"/>.
+/// What is pinned here is the property the endpoint exists for: the vocabulary it publishes is DERIVED from
+/// the same classification the save-time validator refuses by, so a page reading it can never offer a name
+/// the save would reject, and can never omit one the save would accept.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerMappablePermissionsTests
+{
+    // The dedicated permissions, stated INDEPENDENTLY of the production set rather than read from it. This
+    // is what makes the checks below able to fail: a derivation replaced by a literal keeps agreeing with
+    // itself, and only a second statement of the rule can disagree with it. It is a rule, not a snapshot -
+    // the first four have their own configuration surface, and IsDisabled is excluded because no SSO role
+    // mapping may ever disable an account (#165, Finding H1).
+    private static readonly string[] DedicatedPermissionNames =
+    {
+        nameof(PermissionKind.IsAdministrator),
+        nameof(PermissionKind.EnableAllFolders),
+        nameof(PermissionKind.EnableLiveTvAccess),
+        nameof(PermissionKind.EnableLiveTvManagement),
+        nameof(PermissionKind.IsDisabled),
+    };
+
+    private static MappablePermissionDocument Published(SsoControllerHarness harness) =>
+        Assert.IsType<MappablePermissionDocument>(
+            Assert.IsType<OkObjectResult>(harness.Controller.PermissionVocabulary().Result).Value);
+
+    [Fact]
+    public void ThePublishedSet_IsJellyfinsEnumMinusTheDedicatedPermissions()
+    {
+        // Derived on both sides of the assertion, from the enum rather than from names typed out here, so a
+        // permission Jellyfin adds is published the day it lands instead of being measured against a
+        // vocabulary that drifted. The expectation subtracts the dedicated names by the RULE above; the
+        // endpoint subtracts them through PermissionRolePolicy.Classify. The two agreeing is the property.
+        var expected = Enum.GetNames<PermissionKind>()
+            .Where(name => !DedicatedPermissionNames.Contains(name, StringComparer.Ordinal))
+            .OrderBy(name => name, StringComparer.Ordinal);
+
+        Assert.Equal(expected, Published(new SsoControllerHarness()).Permissions);
+    }
+
+    [Fact]
+    public void NoDedicatedPermission_IsOffered()
+    {
+        // The half that matters most, asserted on its own so it cannot be lost in a set comparison: a page
+        // offering IsDisabled would let an administrator build the mapping that a single SSO login turns into
+        // a whole-org lockout, and the save would refuse it only after they had chosen it.
+        var published = Published(new SsoControllerHarness()).Permissions;
+
+        foreach (var dedicated in DedicatedPermissionNames)
+        {
+            Assert.DoesNotContain(dedicated, published, StringComparer.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void EveryPublishedName_IsAcceptedByTheSaveTimeValidator()
+    {
+        // The round trip in the direction a picker is used: every name offered must survive the refusal the
+        // administrator would otherwise meet after choosing it. This is what "one producer" buys, and it is
+        // stated against the validator rather than against the derivation it shares.
+        foreach (var name in Published(new SsoControllerHarness()).Permissions)
+        {
+            ProviderConfigValidator.ValidatePermissionRoleMappings(
+                "OpenID",
+                "kc",
+                new[] { new PermissionRoleMap { Permission = name, Roles = new[] { "staff" } } });
+        }
+    }
+
+    [Fact]
+    public void TheAnswer_ReadsNoConfiguration()
+    {
+        // Two harnesses whose configurations have nothing in common answer identically, because the set is
+        // Jellyfin's compiled enum minus this plugin's compiled exclusion set. That is the property the
+        // rate-limit exemption rests on, and it is asserted rather than argued.
+        var bare = Published(new SsoControllerHarness()).Permissions;
+        var loaded = Published(new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { OidClientId = "client-1" };
+            c.SamlConfigs["adfs"] = new SamlConfig { SamlEndpoint = "https://adfs.example.invalid/sso" };
+        })).Permissions;
+
+        Assert.Equal(bare, loaded);
+    }
+
+    [Fact]
+    public void TheNamesAreOrdinallySorted_SoAConsumerNeedNotSortThem()
+    {
+        var published = Published(new SsoControllerHarness()).Permissions;
+
+        Assert.Equal(published.OrderBy(name => name, StringComparer.Ordinal), published);
+        Assert.NotEmpty(published);
+    }
+}

--- a/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
@@ -156,6 +156,25 @@ internal static class PermissionRolePolicy
     }
 
     /// <summary>
+    /// The permission names an administrator may put in a mapping or a provisioning template (#1484): every
+    /// declared <see cref="PermissionKind"/> that <see cref="Classify"/> answers
+    /// <see cref="PermissionNameStatus.Valid"/> for, in ordinal order.
+    /// </summary>
+    /// <remarks>
+    /// Derived through <see cref="Classify"/> rather than listed, and that is the whole point of it existing:
+    /// a consumer that kept its own copy would drift in three silent directions - a member upstream adds is
+    /// mappable here and invisible there, a member upstream removes stays offerable and is refused at save,
+    /// and a name added to the dedicated set keeps being offered. Going through the same classification the
+    /// save-time validator uses means the vocabulary cannot disagree with the refusal by construction.
+    /// </remarks>
+    /// <returns>The mappable permission names.</returns>
+    internal static IReadOnlyList<string> MappablePermissionNames() =>
+        Enum.GetNames<PermissionKind>()
+            .Where(name => Classify(name) == PermissionNameStatus.Valid)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
     /// Resolves a configured permission name to its <see cref="PermissionKind"/> when it is valid and
     /// mappable, failing closed (returns false, grants nothing) for a blank, unknown, or dedicated name.
     /// </summary>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1433,6 +1433,27 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Publishes the permission names an administrator may map (#1484), so the config page can offer them
+    /// instead of letting one be typed and meet a save-time refusal. Requires administrator privileges, like
+    /// the other config endpoints. Read-only - it changes nothing, and it reads no configuration at all.
+    /// </summary>
+    /// <remarks>
+    /// The answer is derived by <see cref="MappablePermissions"/> from the same classification the save-time
+    /// validator refuses by, so the vocabulary and the refusal cannot disagree. The alternative - a list written into the page - drifts silently in three directions the
+    /// moment Jellyfin adds a permission, removes one, or this plugin excludes one more.
+    /// </remarks>
+    /// <returns>The mappable permission names.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Config/Permissions")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult<MappablePermissionDocument> PermissionVocabulary()
+    {
+        // No config read and no lock: the set is Jellyfin's compiled enum minus this plugin's compiled
+        // exclusion set, so it is the same answer on every installation and on every request.
+        return Ok(MappablePermissions.Build());
+    }
+
+    /// <summary>
     /// Answers, for every configured OpenID and SAML provider at once, whether a login against it would get
     /// past the configuration and why not (#1084) - the aggregate "Configuration check" the redesigned
     /// settings page dropped. Requires administrator privileges, like the other config endpoints. Read-only:

--- a/SSO-Auth/Config/MappablePermissionDocument.cs
+++ b/SSO-Auth/Config/MappablePermissionDocument.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The permission names an administrator may put in a <c>PermissionRoleMappings</c> entry or in a
+/// provisioning template's permission list (#1484), so a page offering them has ONE producer to read
+/// instead of a second copy of the vocabulary.
+/// </summary>
+/// <remarks>
+/// <para>
+/// NAMES ONLY, and they are the same names on every installation: the set is Jellyfin's own
+/// <c>PermissionKind</c> minus the permissions this plugin refuses to map generically, both compiled in.
+/// Nothing here is a fact about the server that answers - no provider, no account, no configured value -
+/// which is why it is the least sensitive document this controller returns.
+/// </para>
+/// <para>
+/// It is nonetheless elevation-gated like its neighbours, because the only caller it exists for is the
+/// admin configuration page and an unauthenticated route would be a new anonymous surface bought for
+/// nothing.
+/// </para>
+/// </remarks>
+public class MappablePermissionDocument
+{
+    /// <summary>
+    /// Gets the mappable permission names, in ordinal order. Ordered rather than enum-declaration order so
+    /// a consumer can render them without sorting and the answer does not move when upstream reorders the
+    /// enum.
+    /// </summary>
+    public IReadOnlyList<string> Permissions { get; init; } = new List<string>();
+}

--- a/SSO-Auth/Config/MappablePermissions.cs
+++ b/SSO-Auth/Config/MappablePermissions.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Builds the published vocabulary of permission names an administrator may map (#1484), so a page offering
+/// them reads ONE producer instead of keeping a second copy of the set.
+/// </summary>
+/// <remarks>
+/// <para>
+/// REUSES THE SAVE-TIME CLASSIFICATION RATHER THAN RESTATING IT, the way
+/// <see cref="ProviderCheck"/> reuses the save gate. The names come from
+/// <see cref="PermissionRolePolicy.MappablePermissionNames"/>, which is the classification
+/// <see cref="ProviderConfigValidator.ValidatePermissionRoleMappings"/> refuses by, so the vocabulary and the
+/// refusal cannot disagree - a name this publishes is a name the save accepts, on the same commit, without
+/// anybody keeping the two in step.
+/// </para>
+/// <para>
+/// A copy of the list on the page would drift in three directions and each is silent: a permission Jellyfin
+/// adds is mappable on the server and invisible on the page, one Jellyfin removes stays offerable and is
+/// refused at save - which is the failure a picker exists to prevent, moved rather than removed - and a name
+/// added to the dedicated set keeps being offered until somebody remembers the second list.
+/// </para>
+/// <para>
+/// It takes no configuration, because the set is a fact about the two compiled vocabularies and not about
+/// this server.
+/// </para>
+/// </remarks>
+internal static class MappablePermissions
+{
+    /// <summary>
+    /// Builds the published vocabulary.
+    /// </summary>
+    /// <returns>The mappable permission names, in ordinal order.</returns>
+    internal static MappablePermissionDocument Build() =>
+        new MappablePermissionDocument { Permissions = PermissionRolePolicy.MappablePermissionNames() };
+}


### PR DESCRIPTION
# What & why

The mappable Jellyfin permission set - the names an administrator may put in a
`PermissionRoleMappings` entry or in a provisioning template's permission list - was
computed on the server and published nowhere. `PermissionRolePolicy` is `internal`, its
exclusion set `private`, and no endpoint carried the information in another shape, so any
page wanting to OFFER those names rather than let one be typed and meet a save-time
refusal had to keep a second copy of the vocabulary.

`GET sso/Config/Permissions` publishes them, elevation-gated and shaped like
`Config/Managed` beside it. The answer is derived through `PermissionRolePolicy.Classify`,
which is the same classification `ValidatePermissionRoleMappings` refuses by, so the
vocabulary and the refusal cannot disagree by construction.

Consuming the endpoint is out of scope here, as #1484 says: the pickers that read it are
#1367's and whatever follows it. This change ends at the route and its proof.

Closes #1484

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

A new elevation-gated read on the admin config surface, so the boxes are answered rather
than skipped.

- [x] Fail-closed preserved: the endpoint cannot widen anything. It publishes names, and
      the one name class that would matter if it leaked into a picker - the dedicated
      permissions, `IsDisabled` above all - is excluded by the same set that makes a
      mapping naming one refuse at save. `NoDedicatedPermission_IsOffered` asserts that
      half on its own so it cannot be lost inside a set comparison.
- [x] No secrets logged; nothing is logged at all and no secret is read. The document
      carries no configured value: two harnesses whose configurations have nothing in
      common answer identically, asserted in `TheAnswer_ReadsNoConfiguration`.
- [ ] A security review was performed: **no.** No second reader looked at this change.
- [ ] Review record: none, per the line above.
- [x] Log inputs from the IdP are sanitized inline at the log call: not applicable - no
      input reaches this route at all. It takes no parameter, no body and no
      caller-supplied id.

### Authorization and throttling, which is the Done-when clause worth reading carefully

#1484 asks for an endpoint "rate-limited and authorized like its neighbours on that
controller". Authorization is `[Authorize(Policy = Policies.RequiresElevation)]`, and the
action is added to `ExpectedElevationActions`, so the live routing table is compared
against the known admin surface and a guard silently lost fails
`CoversExactlyTheKnownElevationSurface`.

Throttling is where the tree already holds an answer, and it is not "add a limiter". Every
controller route must sit in exactly one of two enforced lists - throttled, or explicitly
exempt with a written reason - and the read-only admin reads beside this one are all in
the second:

```
$ git grep -n '"Config/Managed",\|"Config/Check",\|"Metrics",\|"Links/Roster",' origin/main -- SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
origin/main:SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs:85:        "Config/Managed",
origin/main:SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs:91:        "Config/Check",
origin/main:SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs:98:        "Metrics",
origin/main:SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs:101:        "Links/Roster", // elevated read-only link roster (#1119), in-memory, no outbound fetch, takes no caller-supplied id
```

So `Config/Permissions` is registered in that same register, with its reason, and
`EverySensitiveRoute_IsClassified_AsThrottledOrExplicitlyExempt` is what makes the
registration mandatory rather than optional. Its grounds are stronger than either
neighbour's: it reads no configuration, holds no lock, makes no outbound request, writes
nothing and takes no caller-supplied id, so there is no per-request cost and no server
fact for a throttle to protect. Minting a new limiter class for a constant answer would
put a load-bearing constant in the tree for pressure nobody has measured, and reusing an
existing budget is the mistake `ProviderCheckDocument` already warns about in prose.

Stated plainly so it is not read as an omission: **this endpoint is not rate-limited**, by
the same rule and for a stronger reason than the four read-only admin routes beside it.

## Quality checklist

- [x] No duplicated logic: the vocabulary has exactly one producer, which is the point of
      the issue. Nothing here re-implements a predicate.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting and matches the target architecture. The builder sits in the
      `Config` tier rather than in the controller because the `Http` module may NOT import
      `Api.Authz` - it is absent from that module's allowed list - while `Config` already
      reaches `PermissionRolePolicy` for the save-time refusal:

```
$ git grep -n 'InlineData("Http"' origin/main -- SSO-Auth.Tests/ArchitectureConformanceTests.Modules.cs | grep -c Authz
0
$ git grep -n 'using Jellyfin.Plugin.SSO_Auth.Api.Authz;' origin/main -- SSO-Auth/Config/ProviderConfigValidator.cs
origin/main:SSO-Auth/Config/ProviderConfigValidator.cs:8:using Jellyfin.Plugin.SSO_Auth.Api.Authz;
```

  So this adds no edge to the module DAG, and the routing follows `ProviderCheck.Build` /
  `LinkRoster.Build`, which the controller already calls the same way.
- [x] Architecture-conformance tests pass, and the two structural registers this change
      touches are updated in this same PR: the elevation surface and the rate-limit
      classification.
- [x] Docs impact considered: no operator-facing surface changes. The route has no
      consumer yet - #1484 puts consumption out of scope and #1367 is the consumer - so
      what a user would read about is the picker, in the change that builds it. Nothing on
      the wiki states a fact this makes wrong.

## Verification

- [x] Build green on both target frameworks with `--warnaserror`, 0 warnings:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
```

- [x] Full suite green on both, whole output kept rather than filtered to the summary:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3548, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,850s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3549, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 36,367s
```

  The four skips on each are `SsoHttpTests` binding a listener off loopback, which this
  host does not permit. Disclosed rather than worked around.

- [x] No permission name is written into `SSO-Auth/Web/` by this change:

```
$ git diff --name-only origin/main...HEAD
SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
SSO-Auth.Tests/Http/SSOControllerMappablePermissionsTests.cs
SSO-Auth/Api/Authz/PermissionRolePolicy.cs
SSO-Auth/Api/Http/SSOController.cs
SSO-Auth/Config/MappablePermissionDocument.cs
SSO-Auth/Config/MappablePermissions.cs
```

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

### The derivation is proven live, in the direction a literal would survive

The Done-when asks for a test that goes red when the derivation is replaced with a
literal. A test cannot see the difference while nothing else moves - a literal equal to
today's answer agrees with itself - so the proof is run against a moved exclusion set,
which is the condition under which the two stop agreeing. The test states the five
dedicated names INDEPENDENTLY, as a rule rather than a snapshot, which is what gives it
something to disagree with.

**Take `EnableLiveTvAccess` out of the exclusion set on both sides.** With the derivation
in place the endpoint tracks the change and the class stays green:

```
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 0,449s
```

**Now replace the derivation with a literal of today's nineteen names**, same moved
exclusion set. The endpoint no longer tracks it, and the class reddens:

```
Jellyfin.Plugin.SSO_Auth.Tests.SSOControllerMappablePermissionsTests.ThePublishedSet_IsJellyfinsEnumMinusTheDedicatedPermissions [FAIL]
  Assert.Equal() Failure: Collections differ at index 6
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0, Time: 0,512s
```

**And with the exclusion set narrowed in production alone**, the published answer gains
the name and two of the five go red, which is the other direction of the same property:

```
Jellyfin.Plugin.SSO_Auth.Tests.SSOControllerMappablePermissionsTests.NoDedicatedPermission_IsOffered [FAIL]
  Assert.DoesNotContain() Failure: Item found in collection
Jellyfin.Plugin.SSO_Auth.Tests.SSOControllerMappablePermissionsTests.ThePublishedSet_IsJellyfinsEnumMinusTheDedicatedPermissions [FAIL]
  Assert.Equal() Failure: Collections differ at index 6
   SSO-Auth.Tests  Total: 5, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,453s
```

Everything was restored between runs; the diff above is the state that ships.

## Notes

The action is named `PermissionVocabulary` rather than `MappablePermissions` because the
builder in the `Config` tier already holds that name and a controller method shadows a
type of the same name inside its own body.

The names are published in ordinal order, so a consumer renders them without sorting and
the answer does not move when upstream reorders the enum.

No second reader looked at this change.
