### PR TITLE
Record the trusted-header verdict where the analysis is [#808]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ each is written for somebody reading the source alongside it:
 - **[Threat model: the trusted-header path](THREAT-MODEL-TRUSTED-HEADER.md)** -
   a STRIDE pass over reverse-proxy forward-auth, and the deployment conditions
   the plugin cannot verify. Evaluation material, not a description of a shipped
-  feature.
+  feature: the evaluation it was written for ended in a DECLINE (#808), recorded
+  at the end of that document.
 
 The [README](../README.md) has the overview and quick start; the Wiki is the
 reference documentation. The contributor architecture reference lives in the

--- a/docs/THREAT-MODEL-TRUSTED-HEADER.md
+++ b/docs/THREAT-MODEL-TRUSTED-HEADER.md
@@ -11,6 +11,11 @@ and which of the remaining conditions belong to the deployment. Some of those
 conditions are ones no code in this repository can check, and saying so is a
 legitimate outcome of the pass rather than a gap in it.
 
+The pass itself is still not a decision, and nothing below its final section has
+been rewritten to read as one. The decision it was written for was taken on
+2026-08-31 and is recorded at the end, so that a reader of this tree finds the
+answer where the analysis is rather than only on the issue that asked for it.
+
 The subject is the hop between the proxy and the plugin, not the proxy's own
 configuration. How Authelia decides that a visitor is `alice` is Authelia's
 problem. What this document is about is everything that happens after it writes
@@ -335,3 +340,30 @@ above and a deployment contract stated in the documentation. What is not
 defensible is adopting it without the constraints, because the version of this
 pattern that reads a group list and honours an administrator flag turns one
 spoofable header into the whole server.
+
+## The decision this pass was written for
+
+**DECLINED on 2026-08-31**, on #808, which is where the reasoning was written and
+where the wording below is taken from rather than re-derived.
+
+The ground is the finding of the section above, not a preference: no code in this
+server process can observe any of the five conditions, and header trust fails
+open, so the failure mode is a valid session for an attacker rather than an error
+a log shows. A plugin that mints a session from a header it cannot prove came
+from the proxy is trusting a claim it has no instrument to check. Adopting with a
+deployment contract moves that risk into a document an operator is asked to
+honour, and a document does not narrow an allowlist. The one adoption shape most
+requesters actually want - reading the proxy-supplied group list and honouring an
+administrator flag - is the one this pass rules out outright.
+
+So the project will not ship an authentication path whose security precondition
+it cannot verify. This document stays in the tree as the evidence behind that,
+because a decline backed by a model is worth more to a future asker than a
+decline backed by a preference.
+
+What would change it is a mechanism by which the plugin can verify the peer it
+received the header from. That is a new issue citing #808, not a reopening of it.
+
+Nothing in this section widens what the pass established. The two readings it
+called defensible were both defensible on the evidence; one of them was taken,
+and the fact that the other remained available is not deleted by the taking.


### PR DESCRIPTION
# What & why

#808 is an evaluation whose stated outcome is "an explicit ADOPT or DECLINE with
rationale". That outcome exists: DECLINE, taken on the issue on 2026-08-31, with the
reasoning written there. It exists nowhere in this tree.

What the tree holds instead is the 337-line STRIDE pass the decision rests on, ending on
the sentence "That difference is the decision, and this document does not take it". So a
reader who opens the analysis learns that the question was framed and not that it was
answered, and the most-asked-for pattern on this board has a dated answer that lives only
in a comment.

This records the verdict at the end of that document - its ground, and the condition that
would change it - and adds one clause to the `docs/README.md` pointer so the file does not
have to be opened to discover that the evaluation ended.

Closes #808

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

No code changes, and the login path, crypto, config persistence and release pipeline are
all untouched:

```
$ git diff --stat origin/main...HEAD
 docs/README.md                      |  3 ++-
 docs/THREAT-MODEL-TRUSTED-HEADER.md | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 34 insertions(+), 1 deletion(-)
```

- [ ] Fail-closed preserved: not applicable, no behaviour changes. What the change records
      is a decision NOT to ship a path that fails open.
- [ ] No secrets logged: not applicable, nothing is logged and no secret is read.
- [ ] A security review was performed: **no.** No second reader looked at this change.
- [ ] Review record: none, per the line above.
- [ ] Log inputs from the IdP are sanitized inline: not applicable, no log call exists here.

### The negative disclosure in that document is not softened

Worth stating explicitly, because this is the change where it would be easy to do by
accident. The pass says that some of the five conditions are ones no code in this
repository can check, and that saying so is a legitimate outcome rather than a gap. That
sentence is untouched, and the new section repeats the same limit as the GROUND for the
decline rather than as something the decline resolves.

The pass also called two readings defensible on the evidence. One was taken. The new
section's last paragraph says the other having been available is not deleted by the
taking, so a later reader cannot mistake the decline for a finding that adoption was
never defensible.

## Quality checklist

- [x] No duplicated logic: no logic. The wording of the ground is taken from the decision
      on #808 rather than re-derived, so the tree and the issue cannot say two different
      things about why.
- [x] The change adds no more code than the problem requires - 32 added lines in the
      document and one clause in the pointer.
- [x] Self-documenting: the section is titled for what it is and carries its date.
- [x] Architecture-conformance tests pass; they are in the full suite runs below.
- [x] Docs impact considered: this IS the doc change. Neither the wiki nor `README.md`
      mentions forward-auth or the trusted-header pattern, so nothing elsewhere states a
      fact this makes wrong:

```
$ grep -rn -i 'forward-auth\|trusted.header\|oauth2-proxy\|Remote-User' <wiki>/*.md | wc -l
0
$ grep -rn -i 'forward-auth\|trusted-header\|oauth2-proxy' README.md providers.md docs/*.md | grep -v THREAT-MODEL-TRUSTED-HEADER
docs/README.md:25:  a STRIDE pass over reverse-proxy forward-auth, and the deployment conditions
```

  That one hit is the pointer this change edits.

## Verification

- [x] Build green on both target frameworks with `--warnaserror`, 0 warnings, and the full
      suite green on both. No source file is touched, so the runs are here to show the
      branch is not carrying anything else:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3548, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,850s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3549, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 36,367s
```

  Those two runs are from the branch this was cut off, at the same tree for every source
  file. The four skips on each are `SsoHttpTests` binding a listener off loopback, which
  this host does not permit - disclosed rather than worked around.

- [x] Prettier: both touched files are markdown, and this is where the local run says
      something the CI run does not. Locally they are reported as needing formatting BEFORE
      this change as well as after it, because the Windows working tree holds CRLF and the
      local Prettier writes LF:

```
$ git stash && npx prettier --check docs/THREAT-MODEL-TRUSTED-HEADER.md docs/README.md
[warn] docs/THREAT-MODEL-TRUSTED-HEADER.md
[warn] docs/README.md
[warn] Code style issues found in 2 files.
$ file docs/README.md
docs/README.md: ASCII text, with CRLF line terminators
```

  So the local warning is the line endings of the checkout and not this change's content;
  the whole file differs either way. The verdict that counts is the `prettier` check on
  this pull request, which reads a Linux checkout.

## Notes

The issue asked for a verdict, and the verdict was given on the issue. What was missing was
the record in the place a future asker actually opens, which is why this is a documentation
change rather than a second decision. Nothing here re-argues it.

No second reader looked at this change.
