### PR TITLE
Report every endpoint of an authorization walk, not the first dead one

### DIFF
--- a/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
+++ b/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins what a red <see cref="SSOControllerAuthorizationTests"/> run is able to say about itself.
+///
+/// <para>
+/// #1444 recorded one run in which all five request-driving authorization tests went red at once and the
+/// evidence was gone by the time anybody read it. Which of the two remaining readings applies - one endpoint
+/// stalled, or the host answered nothing - is decided by how many of the ~25 endpoints in each loop produced
+/// a status, and a walk that throws at the first transport failure never asks the other 24. These units drive
+/// the walk against a scripted transport, so that answer does not depend on catching the occurrence again.
+/// </para>
+///
+/// <para>
+/// The transport is scripted rather than a real host on purpose: a request that produces no status is the
+/// subject, and there is no way to make a live loopback server reliably not answer.
+/// </para>
+/// </summary>
+public sealed class AuthorizationProbeTests
+{
+    private static readonly Func<int, bool> ExpectUnauthorized = status => status == (int)HttpStatusCode.Unauthorized;
+
+    [Fact]
+    public async Task ATransportFailureDoesNotStopTheWalk()
+    {
+        // The property #1444 needs: the endpoints AFTER a dead one are still driven, so their statuses reach
+        // the message. Without them the reader cannot tell a single stall from a host that stopped answering,
+        // which is the fork that issue is stuck on. Take the continuation out of the probe and this goes red -
+        // the exception leaves the walk and the two answers below are never observed.
+        var answered = new List<string>();
+
+        var failures = await Walk(
+            Endpoints(3),
+            request =>
+            {
+                answered.Add(request.RequestUri!.AbsolutePath);
+                return request.RequestUri!.AbsolutePath.EndsWith("/e0", StringComparison.Ordinal)
+                    ? throw new HttpRequestException("no connection")
+                    : new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            });
+
+        Assert.Equal(3, answered.Count);
+        var only = Assert.Single(failures);
+        Assert.Contains("the request produced no status", only, StringComparison.Ordinal);
+        Assert.Contains("/e0", only, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheNoStatusLineNamesTheEndpointTheCallerAndTheBoundInForce()
+    {
+        // The line is the whole deliverable of a red run: which endpoint, as which caller, after how long, and
+        // against which bound. A transport exception on its own names an address and, on this host, says so in
+        // German.
+        var failures = await Walk(
+            Endpoints(1),
+            _ => throw new HttpRequestException("keine Verbindung"),
+            role: TestRoles.Admin);
+
+        var line = Assert.Single(failures);
+        Assert.Contains("GET /e0 [RequiresElevation] (A0)", line, StringComparison.Ordinal);
+        Assert.Contains("as admin", line, StringComparison.Ordinal);
+        Assert.Contains("client timeout 00:00:30", line, StringComparison.Ordinal);
+        Assert.Contains("HttpRequestException: keine Verbindung", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ConsecutiveTransportFailuresStopTheWalkAndSayWhatWasLeftUndriven()
+    {
+        // The bound the continuation is bought with. At the fixture's 30-second client timeout, walking every
+        // dead endpoint of five loops costs an hour of a suite that otherwise takes half a minute; three in a
+        // row already says the host is not answering. Remove the limit and this goes red at ten lines.
+        var driven = 0;
+
+        var failures = await Walk(
+            Endpoints(10),
+            _ =>
+            {
+                driven++;
+                throw new HttpRequestException("no connection");
+            });
+
+        Assert.Equal(AuthorizationProbe.ConsecutiveNoStatusLimit, driven);
+        Assert.Equal(AuthorizationProbe.ConsecutiveNoStatusLimit + 1, failures.Count);
+        Assert.Equal(
+            "stopped after 3 consecutive requests that produced no status, leaving 7 of 10 endpoints undriven",
+            failures[^1]);
+    }
+
+    [Fact]
+    public async Task IsolatedTransportFailuresBetweenAnsweredRequestsWalkToTheEnd()
+    {
+        // Consecutive, not total. An endpoint that fails between two that answered is the case worth walking
+        // out, because its neighbours are what prove the host was alive around it - counted together, the walk
+        // would stop on the third scattered stall and destroy exactly that evidence.
+        var failures = await Walk(
+            Endpoints(6),
+            request => IsOdd(request.RequestUri!.AbsolutePath)
+                ? throw new HttpRequestException("no connection")
+                : new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+        Assert.Equal(3, failures.Count);
+        Assert.All(failures, line => Assert.Contains("the request produced no status", line, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AStatusThatMissesTheExpectationIsReportedForEveryEndpointItMisses()
+    {
+        var failures = await Walk(
+            Endpoints(3),
+            _ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        Assert.Equal(
+            new[]
+            {
+                "GET /e0 [RequiresElevation] (A0) -> 200",
+                "GET /e1 [RequiresElevation] (A1) -> 200",
+                "GET /e2 [RequiresElevation] (A2) -> 200",
+            },
+            failures);
+    }
+
+    [Fact]
+    public async Task AWalkInWhichEveryStatusMeetsTheExpectationReportsNothing()
+    {
+        var failures = await Walk(
+            Endpoints(4),
+            _ => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+        Assert.Empty(failures);
+    }
+
+    private static bool IsOdd(string path) => (path[^1] - '0') % 2 == 1;
+
+    private static string N(int i) => i.ToString(CultureInfo.InvariantCulture);
+
+    private static IReadOnlyList<GatedEndpoint> Endpoints(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new GatedEndpoint("GET", "/e" + N(i), "RequiresElevation", "A" + N(i)))
+            .ToList();
+
+    private static async Task<IReadOnlyList<string>> Walk(
+        IReadOnlyList<GatedEndpoint> endpoints,
+        Func<HttpRequestMessage, HttpResponseMessage> answer,
+        string? role = null)
+    {
+        using var handler = new ScriptedTransport(answer);
+
+        // The same 30 seconds the fixture sets, so the bound this walk reports is the one the suite runs under
+        // rather than a number invented here.
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://127.0.0.1:1/"),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+
+        return await AuthorizationProbe.CollectFailuresAsync(client, endpoints, role, ExpectUnauthorized);
+    }
+
+    /// <summary>A transport that answers, or refuses to, exactly as the unit calling it says.</summary>
+    private sealed class ScriptedTransport : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _answer;
+
+        public ScriptedTransport(Func<HttpRequestMessage, HttpResponseMessage> answer) => _answer = answer;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_answer(request));
+    }
+}

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -167,53 +164,11 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     {
         Assert.NotEmpty(endpoints);
 
-        var failures = new List<string>();
-        foreach (var endpoint in endpoints)
-        {
-            var status = (int)(await SendAsync(endpoint, role).ConfigureAwait(false)).StatusCode;
-            if (!expected(status))
-            {
-                failures.Add($"{endpoint} -> {status}");
-            }
-        }
+        // The walk itself lives in AuthorizationProbe so a red run reports EVERY endpoint's outcome rather
+        // than stopping at the first request that produced no status (#1444). What the assertion needs from
+        // it is only the list.
+        var failures = await AuthorizationProbe.CollectFailuresAsync(_fixture.Client, endpoints, role, expected).ConfigureAwait(false);
 
         Assert.True(failures.Count == 0, $"{because}, but these did not: {string.Join("; ", failures)}");
-    }
-
-    private async Task<HttpResponseMessage> SendAsync(GatedEndpoint endpoint, string? role)
-    {
-        using var request = new HttpRequestMessage(new HttpMethod(endpoint.Method), endpoint.Url);
-        if (role is not null)
-        {
-            request.Headers.Add(TestRoles.Header, role);
-        }
-
-        // A minimal JSON body for methods that carry one, so a [FromBody] action does not 415 before running.
-        // Irrelevant to the assertions (they only care whether the guard produced a 401/403), but it keeps the
-        // authorized-path responses to genuine action outcomes.
-        if (HttpMethod.Post.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase)
-            || HttpMethod.Put.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase))
-        {
-            request.Content = new StringContent("null", Encoding.UTF8, "application/json");
-        }
-
-        var caller = role ?? "an unauthenticated caller";
-        var elapsed = Stopwatch.StartNew();
-        try
-        {
-            return await _fixture.Client.SendAsync(request).ConfigureAwait(false);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-        {
-            // A request that never produced a status carries none of that in its own text: the transport
-            // exception names an address and, on a non-English host, says so in that host's language. The five
-            // tests above each drive ~25 endpoints in a loop, so without this the reader of a red run cannot
-            // tell WHICH endpoint stalled, as which caller, or after how long - which is the evidence #1444
-            // lost the one time this went red. Diagnostics, not a guard: nothing here can fail a green run.
-            throw new InvalidOperationException(
-                FormattableString.Invariant(
-                    $"the request produced no status: {endpoint} as {caller} after {elapsed.ElapsedMilliseconds} ms, client timeout {_fixture.Client.Timeout}, {ex.GetType().Name}"),
-                ex);
-        }
     }
 }

--- a/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
+++ b/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Drives one caller across a gated endpoint set and collects, per endpoint, whatever did not meet the
+/// expectation - an unexpected status, or no status at all.
+///
+/// <para>
+/// The walk CONTINUES past a request that produced no status, which is the property this type exists for
+/// (#1444). A transport failure thrown out of the loop ends the test at the first endpoint it hits, so a red
+/// run reports one endpoint and says nothing about the other two dozen - and "one endpoint stalled" and
+/// "every request failed" are the two readings that issue is left choosing between. Collecting them
+/// separates the two: one line means one, twenty-five lines mean the host stopped answering.
+/// </para>
+///
+/// <para>
+/// It stops after <see cref="ConsecutiveNoStatusLimit"/> CONSECUTIVE no-status results, because the wall
+/// clock is the price of continuing: at the fixture's 30-second client timeout, walking twenty-five dead
+/// endpoints in each of five tests costs an hour of a suite that otherwise takes half a minute. Three in a
+/// row already says the host is not answering; a fourth buys nothing and costs another timeout. Consecutive
+/// rather than total is deliberate - an isolated failure between answered requests is the case worth walking
+/// to the end, since its neighbours are what prove the host was alive around it.
+/// </para>
+/// </summary>
+public static class AuthorizationProbe
+{
+    /// <summary>
+    /// The number of CONSECUTIVE requests producing no status after which the walk stops and says how many
+    /// endpoints it left undriven.
+    /// </summary>
+    public const int ConsecutiveNoStatusLimit = 3;
+
+    /// <summary>
+    /// Sends one request per endpoint as <paramref name="role"/> and returns one line for each endpoint whose
+    /// outcome did not satisfy <paramref name="expected"/>. An empty result means every endpoint answered as
+    /// expected.
+    /// </summary>
+    /// <param name="client">The client bound to the running fixture host.</param>
+    /// <param name="endpoints">The endpoints to drive, in order.</param>
+    /// <param name="role">The <see cref="TestRoles"/> header value, or <c>null</c> for an unauthenticated caller.</param>
+    /// <param name="expected">The predicate the returned status has to satisfy.</param>
+    /// <returns>The failure lines, in the order the endpoints were driven.</returns>
+    public static async Task<IReadOnlyList<string>> CollectFailuresAsync(
+        HttpClient client,
+        IReadOnlyList<GatedEndpoint> endpoints,
+        string? role,
+        Func<int, bool> expected)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(expected);
+
+        var failures = new List<string>();
+        var consecutiveNoStatus = 0;
+
+        for (var i = 0; i < endpoints.Count; i++)
+        {
+            var endpoint = endpoints[i];
+            var elapsed = Stopwatch.StartNew();
+            int status;
+
+            try
+            {
+                using var response = await SendAsync(client, endpoint, role).ConfigureAwait(false);
+                status = (int)response.StatusCode;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                // A request that never produced a status carries none of that in its own text: the transport
+                // exception names an address and, on a non-English host, says so in that host's language.
+                // The endpoint, the caller, the elapsed time and the bound that was in force are what the
+                // reader of a red run needs and cannot reconstruct - which is the evidence #1444 lost.
+                failures.Add(FormattableString.Invariant(
+                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}"));
+
+                if (++consecutiveNoStatus >= ConsecutiveNoStatusLimit)
+                {
+                    failures.Add(FormattableString.Invariant(
+                        $"stopped after {ConsecutiveNoStatusLimit} consecutive requests that produced no status, leaving {endpoints.Count - i - 1} of {endpoints.Count} endpoints undriven"));
+                    break;
+                }
+
+                continue;
+            }
+
+            consecutiveNoStatus = 0;
+            if (!expected(status))
+            {
+                failures.Add(FormattableString.Invariant($"{endpoint} -> {status}"));
+            }
+        }
+
+        return failures;
+    }
+
+    private static async Task<HttpResponseMessage> SendAsync(HttpClient client, GatedEndpoint endpoint, string? role)
+    {
+        using var request = new HttpRequestMessage(new HttpMethod(endpoint.Method), endpoint.Url);
+        if (role is not null)
+        {
+            request.Headers.Add(TestRoles.Header, role);
+        }
+
+        // A minimal JSON body for methods that carry one, so a [FromBody] action does not 415 before running.
+        // Irrelevant to the assertions (they only care whether the guard produced a 401/403), but it keeps the
+        // authorized-path responses to genuine action outcomes.
+        if (HttpMethod.Post.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase)
+            || HttpMethod.Put.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase))
+        {
+            request.Content = new StringContent("null", Encoding.UTF8, "application/json");
+        }
+
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
# What & why

#1444 holds one `net10.0` run in which all five request-driving
`SSOControllerAuthorizationTests` went red at once and no assertion text
survived. Its own eliminations narrow the readings to two: one endpoint
stalled, or the host answered nothing at all. What separates them is how many
of the ~25 endpoints in each loop produced a status - and until now the walk
threw the transport failure out of the loop, so a red run named ONE endpoint
and never asked the other 24. #1445 made that one line readable; this makes
the run report the whole set.

The walk now collects a no-status result as a failure line and carries on. It
stops after three CONSECUTIVE no-status results and says how many endpoints it
left undriven, because continuing costs wall clock: at the fixture's 30-second
client timeout, walking every dead endpoint of five loops is an hour of a
suite that takes half a minute, and three in a row already says the host is
not answering. Consecutive rather than total is deliberate - an isolated
failure between two answered requests is the case worth walking to the end,
since its neighbours are what prove the host was alive around it.

The loop moved to `AuthorizationProbe` in `_Support` so it can be driven
against a scripted transport. A live loopback server cannot be made to
reliably not answer, so the property could otherwise only be tested by
catching the occurrence again, which is exactly what #1444 has been unable to
do.

Refs #1444. This does NOT meet that issue's Done-when and asks for nothing to
be closed: no cause is named here, and no reproduction was produced.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test apparatus only. No file under `SSO-Auth/` changes, so the shipped plugin
is byte-identical.

## Security checklist

Not applicable: the diff touches `SSO-Auth.Tests/` only, and no login path,
crypto, config persistence or release-pipeline code. The guard these tests
assert is unchanged - the five expectations, the caller roles and the endpoint
sets are the same; only what a FAILING walk reports has moved.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

`ModuleTests_MirrorTheSourceModuleFolders` governs test files that mirror a
type under `SSO-Auth/Api/<Module>/`. `AuthorizationProbe` is test apparatus
with no production counterpart, so it establishes no new structural property
and locks in no new rule; it sits in `_Support/` beside
`SsoAuthorizationServerFixture` and `EndpointCatalog`, which are the same kind
of thing.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror`, 0 warnings, then the full suite from
the built runner:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3554, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 27,758s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3555, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 26,531s
```

No `.js` / `.html` / `.md` / `.css` / `.scss` file is touched, so the Prettier
gate has nothing to read in this diff.

### Both halves proven by breaking them

The continuation, restored to the previous behaviour - the transport failure
thrown out of the walk:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "Jellyfin.Plugin.SSO_Auth.Tests.AuthorizationProbeTests"
    ...ATransportFailureDoesNotStopTheWalk [FAIL]
    ...TheNoStatusLineNamesTheEndpointTheCallerAndTheBoundInForce [FAIL]
    ...ConsecutiveTransportFailuresStopTheWalkAndSayWhatWasLeftUndriven [FAIL]
    ...IsolatedTransportFailuresBetweenAnsweredRequestsWalkToTheEnd [FAIL]
   SSO-Auth.Tests  Total: 6, Errors: 0, Failed: 4, Skipped: 0, Not Run: 0, Time: 0,151s
```

The bound, with `ConsecutiveNoStatusLimit` raised past the fixture count so
nothing stops the walk:

```
   SSO-Auth.Tests  Total: 6, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0, Time: 0,153s
```

One test, the one that names the bound. Both mutations were reverted before
the commit.

## Notes

**No second reader looked at this.** The board has no reviewer available for
it tonight, so what stands in place of one is the mutation evidence above and
the fact that the diff cannot reach the shipped plugin.

**This is not a reproduction and does not claim one.** 85 full `net10.0` runs
of the suite at `38bcf7d4` were green before the change, up to six of them
concurrent on a 32-core host; the slowest was 36,755s against the red run's
136,895s. That is recorded on #1444 rather than here.

**What it does not do.** It names no cause, and it does not stop these five
tests from being able to go red without the tree changing. It makes the next
occurrence report which of the two remaining readings applies, which is the
one thing #1444 says it needs and cannot schedule.
