### PR TITLE
Require a named vouch in the pull request body before a non-English catalogue lands

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -28,11 +28,15 @@
 #         character set - printable ASCII plus a short table of code points
 #         derived from the messages already on main (#1006).
 #       * a build.yaml version bump also touches CHANGELOG.md.
+#       * a pull request putting a non-English localization catalogue on the
+#         board carries a vouch line naming the reader and the language (#1494).
 #     The whole FAIL tier is skipped for bots and for authors from outside this
 #     repository; the two skips have different reasons and both are written at
-#     the check, not only here (#1207). The character check takes that skip too,
-#     but drops to the WARN tier rather than going silent, so a skipped run is
-#     never mistaken for a clean one.
+#     the check, not only here (#1207). The character check and the catalogue
+#     vouch take that skip too, but drop to the WARN tier rather than going
+#     silent, so a skipped run is never mistaken for a clean one. The vouch
+#     check's own self-test is outside the narrowing entirely: it judges the
+#     gate rather than the author.
 #   - WARN  (soft convention, annotation only - never fails):
 #       * the diff is large (>=400 changed lines) - advisory; a feature, doc
 #         migration, or bulk rename legitimately exceeds any cap, so size never reds.
@@ -356,6 +360,212 @@ jobs:
                 "SSO-Auth/*.cs changed but no SSO-Auth.Tests/* change is in this PR. " +
                   "Confirm the change is genuinely untestable (docs/refactor) or add a test.",
               );
+            }
+
+            // --- Check 5: a non-English catalogue needs a named vouch (#1494) ---
+            // #1154 decided that a catalogue ships when a person who reads that
+            // language has read it. The tree half of that is built and bites:
+            // `CommittedCultures` in
+            // SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs refuses a
+            // catalogue whose culture is not declared. But what that guard asks is
+            // whether a culture is DECLARED, and adding the name to the list is
+            // exactly as cheap as adding the file beside it - so nothing anywhere
+            // asked whether the reading the declaration stands for happened.
+            //
+            // It has already gone wrong once. `de.json` is on the mainline and
+            // nobody has read it: its pull request was a draft on purpose and the
+            // draft state WAS the vouch, which is one click from not-a-draft with
+            // the click leaving no trace anybody reads. This is that vouch moved
+            // into a sentence a machine reads, which cannot be clicked past.
+            //
+            // WHAT THIS CANNOT DO, and the disclosure stays negative: it reads a
+            // sentence. It proves that somebody put a name to a reading. It never
+            // proves the reading happened, no reader's command of the language is
+            // checked, and it reads a pull request rather than the tree - so a
+            // catalogue already on main is outside it entirely, `de.json`
+            // included.
+            const VOUCH_FORM = "Catalogue-Vouch: <culture> read by <name>";
+            const VOUCH_LINE =
+              /^[ \t]*Catalogue-Vouch:[ \t]*([A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*)[ \t]+read by[ \t]+(\S.*)$/gim;
+            const CATALOGUE_PREFIX = "SSO-Auth/Localization/";
+            const DECLARATION_FILE =
+              "SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs";
+            const DECLARATION_TOKEN = "CommittedCultures =";
+
+            const cultureOfCatalogue = (filename) =>
+              filename.startsWith(CATALOGUE_PREFIX) && filename.endsWith(".json")
+                ? filename.slice(filename.lastIndexOf("/") + 1, -".json".length)
+                : null;
+
+            const declaredOn = (patch, sign) =>
+              (patch || "")
+                .split("\n")
+                .filter(
+                  (line) =>
+                    line.startsWith(sign) && line.includes(DECLARATION_TOKEN),
+                )
+                .flatMap((line) =>
+                  [...line.matchAll(/"([^"]*)"/g)].map((m) => m[1].toLowerCase()),
+                );
+
+            // Two independent readings of the same pull request, because the two
+            // orders of the same mistake look different. The catalogue file is the
+            // load-bearing one: a culture cannot reach a user without one, since
+            // EveryCommittedCulture_HasACatalog reddens the suite for a declared
+            // culture with no file. Reading the declaration patch catches the
+            // reverse order, and its bound is that it matches the declaration on a
+            // single patch line - a declaration rewritten across several lines is
+            // invisible to it, which is why it is the second reading and not the
+            // check.
+            const culturesNeedingAVouch = (prFiles) => {
+              const needed = new Set();
+              for (const file of prFiles) {
+                if (file.status === "removed") continue;
+                const culture = cultureOfCatalogue(file.filename);
+                if (culture) needed.add(culture.toLowerCase());
+                if (file.filename === DECLARATION_FILE) {
+                  const before = new Set(declaredOn(file.patch, "-"));
+                  for (const added of declaredOn(file.patch, "+")) {
+                    if (!before.has(added)) needed.add(added);
+                  }
+                }
+              }
+              // English is the baseline rather than a translation - it is the
+              // invariant fallback every other catalogue is compared against - so a
+              // change to it is not a reading anybody can vouch for. Subtracted once,
+              // at the end, because both readings above can produce it and a second
+              // exemption at the catalogue reading was dead: it survived being
+              // inverted with the whole self-test still green.
+              needed.delete("en");
+              return [...needed].sort();
+            };
+
+            const missingVouches = (prFiles, prBody) => {
+              const vouched = new Set(
+                [...(prBody || "").matchAll(VOUCH_LINE)].map((m) =>
+                  m[1].toLowerCase(),
+                ),
+              );
+              return culturesNeedingAVouch(prFiles).filter((c) => !vouched.has(c));
+            };
+
+            // The near-misses this guard owes, executed on every pull request rather
+            // than pasted once into a body nobody re-reads. A workflow is the class
+            // of change CI cannot otherwise exercise at all, and the whole table
+            // costs milliseconds, no checkout and no new apparatus. The first two
+            // rows are the two the issue names: a change to the English baseline
+            // alone, and a change touching neither path.
+            //
+            // A disagreement here fails the job OUTSIDE the audience narrowing
+            // below. That narrowing is about whose obligation a convention is; a
+            // self-test that disagrees means this gate no longer decides what it
+            // says it decides, and nothing should merge past a broken gate whoever
+            // opened the pull request.
+            const DECLARATION_WAS =
+              '-    private static readonly string[] CommittedCultures = ["de", "en"];';
+            const catalogue = (name, status) => [
+              { filename: CATALOGUE_PREFIX + name, status },
+            ];
+            const declaration = (patch) => [
+              { filename: DECLARATION_FILE, status: "modified", patch },
+            ];
+            const SELF_TEST = [
+              [
+                "the English baseline alone",
+                catalogue("en.json", "modified"),
+                "",
+                [],
+              ],
+              [
+                "a change touching neither path",
+                [
+                  {
+                    filename: "SSO-Auth/Api/Http/SSOController.cs",
+                    status: "modified",
+                  },
+                ],
+                "",
+                [],
+              ],
+              [
+                "a new catalogue, unvouched",
+                catalogue("fr.json", "added"),
+                "",
+                ["fr"],
+              ],
+              [
+                "a new catalogue, vouched",
+                catalogue("fr.json", "added"),
+                "Closes #1\n\nCatalogue-Vouch: fr read by A. Reader\n",
+                [],
+              ],
+              [
+                "a new catalogue, a different language vouched",
+                catalogue("fr.json", "added"),
+                "Catalogue-Vouch: de read by A. Reader",
+                ["fr"],
+              ],
+              [
+                "an existing catalogue edited, unvouched",
+                catalogue("pt-BR.json", "modified"),
+                "",
+                ["pt-br"],
+              ],
+              ["a catalogue deleted", catalogue("fr.json", "removed"), "", []],
+              [
+                "the declaration gains a culture",
+                declaration(
+                  DECLARATION_WAS +
+                    '\n+    private static readonly string[] CommittedCultures = ["de", "en", "fr"];',
+                ),
+                "",
+                ["fr"],
+              ],
+              [
+                "the declaration loses a culture",
+                declaration(
+                  DECLARATION_WAS +
+                    '\n+    private static readonly string[] CommittedCultures = ["en"];',
+                ),
+                "",
+                [],
+              ],
+            ];
+            for (const [name, prFiles, prBody, expected] of SELF_TEST) {
+              const got = missingVouches(prFiles, prBody);
+              if (got.join(",") !== expected.join(",")) {
+                failures.push(
+                  `Check 5 self-test "${name}" disagreed: expected ` +
+                    `[${expected.join(", ")}], got [${got.join(", ")}]. The ` +
+                    "catalogue-vouch gate at check 5 in " +
+                    ".github/workflows/pr-hygiene.yml no longer decides what it says " +
+                    "it decides; repair it before merging anything.",
+                );
+              }
+            }
+
+            // The FAIL tier's audience narrowing (#1207) is taken here deliberately
+            // rather than inherited without a thought, and for this check the reason
+            // is its own. An outside contributor offering a catalogue in their own
+            // language is the growth path #1154 named, and they cannot discharge
+            // this anyway: the vouch names a READER, so a contributor writing their
+            // own name against their own translation is not a second pair of eyes.
+            // The person who can supply one is whoever merges the contribution, and
+            // the annotation below is what that person meets on the pull request.
+            // Reported rather than silent, like check 1c, so a skipped run is never
+            // read as a clean one.
+            const unvouched = missingVouches(files, body);
+            if (unvouched.length > 0) {
+              const report =
+                `Catalogue(s) for ${unvouched.join(", ")} change in this pull request ` +
+                "with no vouch in its body. A catalogue ships when a person who reads " +
+                "that language has read it (#1154). Add one line per language, at the " +
+                "start of its own line:\n" +
+                `  ${VOUCH_FORM}\n` +
+                "This check reads a sentence: it proves somebody put a name to a " +
+                "reading, never that the reading happened, and it reads the pull " +
+                "request rather than the tree.";
+              (failTierApplies ? failures : warnings).push(report);
             }
 
             // --- Report --------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,9 +231,17 @@ We are always open to better docs! The main place documentation could be improve
 
 The plugin serves two pages of its own, the interstitial login page and the browser error page, and their text comes from per-language JSON catalogs rather than from the C# source. Translating one needs no build and no C# at all.
 
-Supported languages today are English alone, shipped as `SSO-Auth/Localization/en.json`. English is also the invariant fallback: every key exists there, and a lookup walks the requested culture, then its base language, then English, then the key itself, so a string that is missing from a catalog falls back rather than rendering blank.
+Which catalogs ship is declared rather than listed here, so print the set instead of trusting a sentence that drifts: `git ls-tree --name-only origin/main SSO-Auth/Localization/`. English is also the invariant fallback: every key exists there, and a lookup walks the requested culture, then its base language, then English, then the key itself, so a string that is missing from a catalog falls back rather than rendering blank.
 
 **To add a language**, copy `en.json` to `SSO-Auth/Localization/<bcp47>.json` (`de.json`, `pt-BR.json`), translate the values, and keep the key set exactly as English has it. Nothing else needs editing: the project file globs `Localization\*.json` into the assembly as embedded resources.
+
+**A catalog ships when a person who reads that language has read it.** So a pull request that adds or edits a non-English catalog carries one line per language in its **body**, at the start of its own line:
+
+```
+Catalogue-Vouch: fr read by Marie Dupont
+```
+
+The PR-hygiene gate reads that line and fails without it. Be clear about how little it proves: it reads a sentence, so it shows that somebody put a name to a reading, never that the reading happened, and it reads the pull request rather than the tree - a catalog already on `main` is outside it. If you are contributing a translation from outside this repository, the gate does not ask this of you (you cannot vouch for your own work anyway); the vouch is supplied by whoever merges it.
 
 **To fix a translation**, change the value and never the key. Keys are internal identifiers that the served pages reference by name, and no user-supplied or provider-supplied value is ever used as one.
 


### PR DESCRIPTION
# What & why

Closes #1494.

#1154 decided that a catalogue ships when a person who reads that language has
read it. Only half of that was built. `CommittedCultures` refuses a catalogue
whose culture is not declared, but what that guard asks is whether a culture is
DECLARED, and adding a name to the list is exactly as cheap as adding the file
beside it. Nothing anywhere asked whether the reading the declaration stands for
happened, and nothing on the pull request route asked either:

```
$ git show origin/main:.github/workflows/pr-hygiene.yml | grep -ci 'localiz\|catalog\|vouch'
0
```

It has already gone wrong once. `de.json` is on the mainline unread: its pull
request was a draft on purpose, the draft state WAS the vouch, and a draft is one
click from not-a-draft with the click leaving no trace anybody reads.

Check 5 in the PR-hygiene gate now reads the pull request body for

```
Catalogue-Vouch: <culture> read by <name>
```

one line per language the change puts on the board, and fails the FAIL tier
without it. The cultures it asks about come from two independent readings of the
same pull request: a catalogue file under `SSO-Auth/Localization/` added or
modified, and a culture added to the `CommittedCultures` declaration. The first
is load-bearing - a culture cannot reach a user without a catalogue file, since
`EveryCommittedCulture_HasACatalog` reddens the suite - and the second catches the
reverse order of the same mistake. Both read pull request metadata only, so the
job still takes no checkout.

**What it cannot do, and this disclosure stays negative.** It reads a sentence.
It proves that somebody put a name to a reading, never that the reading happened,
and no reader's command of the language is checked. It reads a pull request
rather than the tree, so `de.json` is outside it entirely and its reading is
still owed on #1154.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: nothing here touches the login path, crypto, config persistence
or the release pipeline. The change is a pull-request-metadata check in
`.github/workflows/pr-hygiene.yml` and a section of `CONTRIBUTING.md`. No
plugin code, no test project, no published artefact.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

The one thing worth naming that a security lens would ask about: the check
reads the pull request body, the changed-file list and the file patches, all
through the `github`/`context` API objects, and never interpolates any of them
into a shell `run:`. That is the property the workflow header already claims for
itself and this check keeps it - there is no new template-injection surface. The
job's `permissions:` block is unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the second box: the mutation run below found dead code in my own first draft
and it is removed rather than shipped - see "What breaking it found".

On the fourth box: no C# changed, so the conformance suite has no new structural
property to lock in; it is untouched and unaffected.

On docs: `CONTRIBUTING.md` carries the requirement in the "Translating the UI"
section, where a translator meets it, with the same negative disclosure. Its
claim that English is the only catalogue is replaced by the command that prints
the set - that sentence had already gone stale against `de.json`:

```
$ git ls-tree --name-only origin/main SSO-Auth/Localization/
SSO-Auth/Localization/de.json
SSO-Auth/Localization/en.json
```

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The two build boxes are unticked and not because the build is red: no `.cs`,
`.csproj` or lockfile changed in this pull request, so neither run has a subject
here. CI runs both anyway and they are on the required set.

```
$ npx prettier --check "CONTRIBUTING.md" ".github/workflows/pr-hygiene.yml"
Checking formatting...
All matched files use Prettier code style!
```

`.yml` is outside the prettier glob (`**/*.{js,html,md,css,scss}`); it is
included in the command above for completeness rather than because the gate
reads it.

The workflow still parses:

```
$ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/pr-hygiene.yml',encoding='utf-8')); print('parsed ok; steps:', len(d['jobs']['hygiene']['steps']))"
parsed ok; steps: 1
```

## How the guard is proven, and how it is proven on every future run

A workflow is the class of change CI cannot otherwise exercise at all. Two things
answer that here.

**The self-test rides along.** Check 5 carries a nine-row table of pull requests
and their expected verdicts, evaluated on every run of the job. A disagreement
fails the job, and it does so OUTSIDE the FAIL tier's audience narrowing: that
narrowing decides whose obligation a convention is, while a self-test that
disagrees means the gate no longer decides what it says it decides, and nothing
should merge past a broken gate whoever opened the pull request. The whole table
costs milliseconds and no checkout. Its first two rows are the two near-misses
#1494 asks for: a change to the English baseline alone, and a change touching
neither path.

**The behaviour was read off the shipped text, not off a copy.** A throwaway
driver (not in the tree) extracts the `script:` block verbatim from
`.github/workflows/pr-hygiene.yml`, stubs `github`/`context`/`core`, and runs it
over whole pull requests. Six scenarios, and the two `FAILED` results are the two
that should fail:

```
--- a new catalogue, unvouched, from inside ---     FAILURES 1  WARNINGS 0  job result: FAILED
--- a new catalogue, vouched, from inside ---       FAILURES 0  WARNINGS 0  job result: passed
--- the English baseline alone ---                  FAILURES 0  WARNINGS 0  job result: passed
--- a change touching neither path ---              FAILURES 0  WARNINGS 1  job result: passed
--- the declaration gains a culture, unvouched ---  FAILURES 1  WARNINGS 0  job result: FAILED
--- a new catalogue, unvouched, from outside ---    FAILURES 0  WARNINGS 2  job result: passed
```

The single WARNING on row 4 is the pre-existing check 4 (code changed without a
test), untouched by this change. The two on row 6 are the tier-skip notice and
this check's own report, which is the narrowing working as designed.

The failure text a contributor meets:

```
Catalogue(s) for fr change in this pull request with no vouch in its body. A
catalogue ships when a person who reads that language has read it (#1154). Add
one line per language, at the start of its own line:
  Catalogue-Vouch: <culture> read by <name>
This check reads a sentence: it proves somebody put a name to a reading, never
that the reading happened, and it reads the pull request rather than the tree.
```

**Every arm proven by deleting it.** Five one-token mutations of the extracted
script, each run against the self-test:

| mutation | rows that redden |
| --- | --- |
| `filename.endsWith(".json")` -> `false` | 3 |
| `file.filename === DECLARATION_FILE` -> `false` | 1 |
| `!vouched.has(c)` -> `true` | 1 |
| `needed.delete("en");` -> removed | 1 |
| `file.status === "removed"` -> `false` | 1 |

Unmutated, the table is green.

### What breaking it found

A sixth mutation passed, and that is the finding rather than a footnote. My first
draft exempted English twice - once by comparing the filename against
`SSO-Auth/Localization/en.json`, once by `needed.delete("en")` at the end.
Inverting the filename comparison left every row green, because the second
exemption already covers it. So the comparison was dead code, and the
English-baseline row - the near-miss the issue names first - was proving nothing.
It is removed; the row is load-bearing now, which is the fourth line of the table
above.

## The audience narrowing, considered rather than inherited

#1494's fourth Done-when asks for this explicitly. The FAIL tier is skipped for
bots and for authors outside this repository (#1207), and check 5 takes that skip
- but for a reason of its own, written at the check rather than only here.

An outside contributor offering a catalogue in their own language is the growth
path #1154 named, and they cannot discharge this obligation in any case: the
vouch names a READER, so a contributor writing their own name against their own
translation is not a second pair of eyes. The person who can supply one is
whoever merges the contribution, and the annotation is what that person meets on
the pull request. Reported rather than silent, like the character check, so a
skipped run is never read as a clean one.

## Notes

**No second reader looked at any of this.**

Bounds worth carrying forward rather than discovering later:

- The declaration reading matches `CommittedCultures =` on a single patch line. A
  declaration rewritten across several lines is invisible to it. That is stated
  at the check and it is why the catalogue-file reading is the load-bearing one:
  a culture declared with no catalogue file reddens the suite anyway.
- This check reads a pull request. `de.json` is already on `main` and no reading
  of a pull request reaches it. The reading of `de.json` is still owed on #1154
  and this change does not discharge it.
- The vouch is a sentence. It is a record that somebody put their name to a
  reading, and it is worth exactly what that name is worth.
