### PR TITLE
Seed the authorization fixture as a process-wide door

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs
@@ -52,6 +52,23 @@ public partial class ArchitectureConformanceTests
     // here, and the entry is spelled exactly as a call site spells it.
     private const string ScaffoldDoor = "OidcRoundTrip.BuildHarness";
 
+    // The third support type that swaps SSOPlugin.Instance, and the one this rule was blind to. The
+    // authorization fixture assigns the process-wide singleton in its constructor - `_ = new SSOPlugin(...)`
+    // in SsoAuthorizationServerFixture, which its own comment names as process-wide - without going through
+    // the harness, so neither seed above covers it and no `ForTests(` declaration in the production tree
+    // could ever produce it.
+    //
+    // What made it invisible is that a class picks the fixture up as a TYPE ARGUMENT rather than by calling
+    // anything: `IClassFixture<SsoAuthorizationServerFixture>` opens the door for that class, and the string
+    // it spells is the bare type name. So the entry is the type name, which is exactly how a call site
+    // spells this door, and it is why the ScaffoldDoor comment's reasoning applies here one step further out
+    // - the construction is not merely behind a support method, it is behind xUnit's own activation.
+    //
+    // Found while auditing the third cause #1444's Done-when names, state shared with another test. The
+    // suite is clean today: the fixture has exactly one user and that user is serialized. This entry is what
+    // keeps a second user from arriving unserialized without anything refusing it.
+    private const string FixtureDoor = "SsoAuthorizationServerFixture";
+
     // A door no test names because it sits behind another one: a production reset hook opens it, so every
     // test opening THAT door opens this one too. Keyed door -> the door that opens it. The rule proves both
     // halves rather than trusting the table, so an entry whose indirection is removed fails as loudly as a
@@ -206,6 +223,41 @@ public partial class ArchitectureConformanceTests
         Assert.Empty(DoorsOpenedUnserialized(Fixture(string.Empty, call), doors));
     }
 
+    /// <summary>
+    /// The fixture door, proven on the shape it is actually opened in. The pair above drives the decision
+    /// through a door spelled as a CALL; this one is spelled as a TYPE ARGUMENT on a class declaration, and
+    /// the difference is the whole reason the seed was missing - a reader looking for the door hunts for a
+    /// statement inside a method and finds none.
+    /// <para>
+    /// The must-catch here is the change that was possible until this seed landed: a second class picking up
+    /// <see cref="SsoAuthorizationServerFixture"/> and forgetting the collection attribute, which puts two
+    /// classes in parallel over one <c>SSOPlugin.Instance</c> with nothing refusing it. Its twin is the same
+    /// class with the attribute, so what the assertion pair isolates is the serialization and not the naming.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NonParallelRule_ReportsAClassTakingTheAuthorizationFixtureWithoutTheCollection()
+    {
+        var doors = ProcessWideDoors();
+
+        // Sentinel, for the reason the pair above carries one: both assertions below go quiet together if
+        // the seed is gone, and quiet is what a rule that has stopped looking also produces.
+        Assert.Contains(FixtureDoor, doors, StringComparer.Ordinal);
+
+        static string Fixture(string attributes) => string.Join(
+            "\n",
+            attributes,
+            "public sealed class SecondUser : IClassFixture<" + FixtureDoor + ">",
+            "{",
+            "    public SecondUser(" + FixtureDoor + " fixture)",
+            "    {",
+            "    }",
+            "}");
+
+        Assert.Equal(new[] { FixtureDoor }, DoorsOpenedUnserialized(Fixture("[Fact]"), doors));
+        Assert.Empty(DoorsOpenedUnserialized(Fixture("[Collection(\"SSOController\")]\n[Fact]"), doors));
+    }
+
     // Every derived door a source names in CODE, or nothing at all when the source declares no test. A
     // support type is never scheduled by the runner, so it cannot race anything; the harness itself opens
     // six doors and would otherwise be a permanent offender.
@@ -222,14 +274,15 @@ public partial class ArchitectureConformanceTests
             : DoorsNamedByTestBearingSource(source, doors);
 
     // Every process-wide door a test can reach: the test-only hooks the production tree declares, keyed
-    // Type.Method exactly as a call site spells them, plus the harness construction and the support method
-    // that performs it for a caller. The hooks are derived rather than listed, so a new hook cannot create a
-    // door the rule above is blind to; the two seeds are what no reading of the production tree could find.
+    // Type.Method exactly as a call site spells them, plus the harness construction, the support method that
+    // performs it for a caller, and the fixture a class opens by naming it as a type argument. The hooks are
+    // derived rather than listed, so a new hook cannot create a door the rule above is blind to; the three
+    // seeds are what no reading of the production tree could find.
     private static IReadOnlyList<string> ProcessWideDoors()
     {
         var declaration = new Regex(@"\b(?:class|record|struct)\s+(?<type>[A-Za-z0-9_]+)");
         var hook = new Regex(@"\binternal\s+static\s+[^;=]*?\b(?<hook>[A-Za-z0-9_]+ForTests)\s*\(");
-        var doors = new List<string> { HarnessDoor, ScaffoldDoor };
+        var doors = new List<string> { HarnessDoor, ScaffoldDoor, FixtureDoor };
 
         foreach (var src in Directory.EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories))
         {


### PR DESCRIPTION
# What & why

Refs #1444. **This does not meet that issue's Done-when and asks for nothing to
be closed.** #1444 stays open for the assertion text from the next red
`net10.0` run, exactly as its narrowing of 2026-08-28 says.

#1444's Done-when names three candidate causes: contention, a timeout, or state
shared with another test. The first two have been pushed hard on that issue -
six concurrent suites, `DOTNET_PROCESSOR_COUNT=1` sixteen deep, a fresh
worktree, 94 runs - and reddened nothing. The third had not been looked at. This
is what looking found.

## The suite is clean on that axis today

`SSOPlugin.Instance` is the process-wide static the controller reads at
construction, and there is already a rule refusing a test class that reaches
such a door without the serializing collection attribute:

```
$ git grep -n "public void EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection" origin/main
origin/main:SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs:94:    public void EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection()
```

The authorization fixture has exactly one user, and that user carries the
attribute:

```
$ git grep -l "SsoAuthorizationServerFixture" origin/main -- SSO-Auth.Tests/ | grep -v _Support
origin/main:SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
$ git grep -c 'Collection("SSOController")' origin/main -- SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
origin/main:SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs:1
```

So no live instance of the third cause. Reported as a negative finding rather
than left unsaid.

## What was missing is the guard that keeps it that way

`SsoAuthorizationServerFixture` assigns `SSOPlugin.Instance` in its own
constructor, and says so:

```
$ git grep -n "new SSOPlugin(" origin/main -- SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
origin/main:SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs:89:        _ = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
```

It does that without going through the harness, so neither hand-seeded door
covered it, and no `ForTests(` declaration in the production tree could ever
derive it - what makes it a door is a fact about test-support code, which is the
reason the rule's own comment gives for its two existing seeds.

It was invisible for a second reason on top of that one. A class opens this door
by naming the type as a **type argument**, `IClassFixture<SsoAuthorizationServerFixture>`,
rather than by calling anything, so a reader hunting for a statement inside a
method finds none. That is one step further out than the `ScaffoldDoor` case the
rule already documents: the construction is not merely behind a support method,
it is behind xUnit's own activation.

The consequence: a second class taking that fixture and forgetting the
collection attribute would have run in parallel with
`SSOControllerAuthorizationTests` over one `SSOPlugin.Instance`, with nothing
refusing it.

## Proven by breaking it, in both directions

A throwaway probe class (not in the tree) taking the fixture with no collection
attribute:

```
with the seed
    ArchitectureConformanceTests.EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection [FAIL]
      A test class reaching a process-wide door must carry [Collection("SSOController")],
      or it runs in parallel with another class clearing the same static:
      ZzHoleProbe.cs opens SsoAuthorizationServerFixture

without the seed (same probe, `FixtureDoor` dropped from the door list)
    Total: 2, Errors: 0, Failed: 1
    the failure is the new unit's sentinel; EveryTestClassOpeningAProcessWideDoor PASSED
```

The second line is the hole, measured rather than argued: the rule accepted an
unserialized second user of the fixture.

The new unit drives the same per-file decision on synthetic source in the shape
this door is actually opened in - a class declaration rather than a call - and
its twin is the same class with the attribute, so what the pair isolates is the
serialization and not the naming. Both assertions go quiet together if the seed
is removed, which is why the unit carries a sentinel, like the pair beside it.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: no production code changed. The diff is one test file,
`SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs`. Nothing on the login
path, in crypto, in config persistence or in the release pipeline moves.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

Worth naming even so, because the rule this repairs exists for a security
reason: the five tests it protects are the ones asserting that no
unauthenticated or non-administrator caller reaches an authenticated or
elevation endpoint. A guard whose proof is unreliable is a guard whose next real
regression reads as the flake, which is #1444's own sentence.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The fourth box is the change itself: the new structural property is a rule in
`ArchitectureConformanceTests`, which is where it belongs. No README or wiki
surface describes the test suite's door table, so the fifth needs nothing.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, 0 warnings under `--warnaserror`:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3555, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 34,253s

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3556, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 48,053s
```

The four skips on each are the ones this host already skips because they bind a
listener off loopback, which needs an administrator. Disclosed rather than
worked around. No `.js`, `.html`, `.md` or `.css` changed, so the Prettier box is
green vacuously and says so.

Whole output kept per run rather than filtered to the summary lines, which is
what `CONTRIBUTING.md` asks for since #1445 - and the mistake that cost #1444 its
evidence in the first place.

## Notes

**No second reader looked at any of this.**

What this does not do, stated so nobody reads more into it than is there:

- It reproduces nothing. The red run of #1444 is not reproduced here and no
  cause for it is named.
- It does not show that shared state caused that run. It shows that the suite
  has no live instance of shared state on this door, and that the rule keeping
  it that way could not see this door.
- It says nothing about the two remaining candidate causes.
