### PR TITLE
Edit named provisioning profiles from the configuration page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **Named provisioning profiles are editable from the dashboard (#1105).** A
+  profile is a starting policy under a name that any number of providers can
+  share - the `guest` profile beside the default one - and until now the only
+  way to define one was to edit the plugin configuration by hand. The
+  configuration page carries a **Provisioning Profiles** section: list, add,
+  rename, delete, and the same nine controls the provider forms carry, with the
+  same rules - a field you leave alone keeps Jellyfin's own default, and zero is
+  a real value for the bitrate ceiling and the session limit. Each provider form
+  gains the selector that points at one. Add copies the starting policy of a
+  provider you choose, under the name you type, so a new profile begins as what
+  that provider does today rather than as a blank form that silently writes
+  nothing; adding one changes no account until you point a provider at it.
+  Deleting a profile some provider or role rule still names is refused and the
+  references are named, because clearing them would switch those providers to a
+  different starting policy from a delete button. Renaming one repoints every
+  reference in the same save, so nothing is ever left pointing at a name the
+  configuration no longer defines. Pointing a provider at a profile clears that
+  provider's own inline fields when you save, since new accounts get exactly one
+  policy from one source; you are asked before that happens, and adding a
+  profile from the provider's own policy first is the way to keep it. Existing
+  configurations are untouched: a provider that names no profile keeps its
+  inline policy exactly as it is.
+
 - **The starting policy is on the provider forms (#1367).** Everything a
   provider writes onto a brand-new account - the permissions, the remote
   bitrate ceiling, the session limit, the two language preferences, the

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningProfileEditor.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningProfileEditor.cs
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rules for the provisioning-profile editor and the two per-provider profile selectors
+/// (#1105). Same means as the provisioning-template rules next door and for the same reason: this tree
+/// carries no JavaScript runtime, no DOM and no browser automation, so nothing below executes the page.
+/// Each rule pins a STRUCTURAL property a wrong edit cannot satisfy by accident. What a reading of the
+/// markup cannot reach - what an administrator sees after pressing a button - is argued in the pull
+/// request rather than claimed here.
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    // The editor renders the same nine controls a third time, outside both provider forms, under this id
+    // prefix. It is deliberately not "saml-" and not empty: templateControls in config.js resolves a prefix
+    // to a form, and two prefixes resolving to one form would make each one's serializer read the other's
+    // fields.
+    private const string ProfileEditorPrefix = "profile-";
+
+    private static string ProfileEditorMarkup(string html)
+    {
+        const string marker = "id=\"sso-provisioning-profiles\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The #sso-provisioning-profiles form was not found in configPage.html.");
+        var end = html.IndexOf("</form>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "The #sso-provisioning-profiles form has no closing </form> tag.");
+        return html[start..end];
+    }
+
+    [Fact]
+    public void ProvisioningProfileEditor_OffersExactlyTheTemplateProperties()
+    {
+        // The editor's twin of ProvisioningTemplateForm_OffersExactlyTheTemplateProperties. A profile IS a
+        // ProvisioningPolicyTemplate, so a field the editor does not render is a field of the named policy
+        // an administrator cannot set from the dashboard at all - and a marked id that is not a property
+        // renders and never saves, because the server drops JSON members the type does not declare.
+        // Compared as a SET IN BOTH DIRECTIONS for that reason: a subset assertion would pass an editor
+        // that quietly stopped offering a field.
+        var form = ProfileEditorMarkup(ProvisioningTemplateMarkup());
+        var controls = TemplateControls(form);
+        Assert.True(controls.Count > 0, "the profile editor carries no template control at all - a renamed marker class would empty this scan silently");
+
+        var offenders = controls
+            .Where(c => !c.Id.StartsWith(ProfileEditorPrefix + "Tmpl-", StringComparison.Ordinal))
+            .Select(c => $"{c.Id} (classes: {c.Classes})")
+            .ToList();
+        Assert.True(
+            offenders.Count == 0,
+            $"Every profile-editor control must have an id of \"{ProfileEditorPrefix}Tmpl-\" + a ProvisioningPolicyTemplate property; these do not: " + string.Join(" | ", offenders));
+
+        var offered = controls
+            .Select(c => c.Id[(ProfileEditorPrefix + "Tmpl-").Length..])
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(TemplatePropertyNames(), offered);
+    }
+
+    [Fact]
+    public void ProvisioningProfileEditorNullableBooleans_RenderAsThreeStateSelects()
+    {
+        // The fail-closed direction, on the third rendering of the control set. A profile's three `bool?`
+        // members mean the same thing they mean inline - null leaves Jellyfin's own default alone - and a
+        // checkbox has two states, so an editor built with checkboxes would write a deliberate false onto
+        // every account created under the profile for a field nobody touched. The field set is DERIVED from
+        // the type, so a member that becomes nullable later joins this rule on its own.
+        var nullableBooleans = typeof(ProvisioningPolicyTemplate)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(bool?))
+            .Select(p => p.Name)
+            .ToList();
+        Assert.Equal(3, nullableBooleans.Count);
+
+        var form = ProfileEditorMarkup(ProvisioningTemplateMarkup());
+
+        foreach (var name in nullableBooleans)
+        {
+            var id = ProfileEditorPrefix + "Tmpl-" + name;
+            var control = TemplateControls(form).SingleOrDefault(c => c.Id == id);
+            Assert.True(control.Tag != null, $"{id} is not a marked template control in the profile editor");
+            Assert.StartsWith("<select", control.Tag, StringComparison.Ordinal);
+            Assert.Contains("sso-tmpl-bool", control.Classes, StringComparison.Ordinal);
+            Assert.DoesNotContain("sso-toggle", control.Classes, StringComparison.Ordinal);
+
+            var start = form.IndexOf(control.Tag, StringComparison.Ordinal);
+            var end = form.IndexOf("</select>", start, StringComparison.Ordinal);
+            Assert.True(end > start, $"{id} has no closing select tag");
+            Assert.Contains("value=\"\"", form[start..end], StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ProvisioningProfileEditor_SitsOutsideBothProviderForms()
+    {
+        // The editor writes a ROOT PluginConfiguration member, so a control of it placed inside a provider
+        // form would be read by that form's serializer instead: the flat contract writes
+        // current_config[element.id] onto the provider, and the template serializer scans the form for the
+        // sso-tmpl-* markers. Either would silently persist the editor's fields onto whichever provider
+        // happened to be open. Checked as a position rather than as an intention.
+        var html = ProvisioningTemplateMarkup();
+
+        foreach (var (name, slice) in new[]
+        {
+            ("#sso-new-oidc-provider", OidcProviderFormMarkup(html)),
+            ("#sso-new-saml-provider", SamlProviderFormMarkup(html)),
+        })
+        {
+            Assert.DoesNotContain("id=\"sso-provisioning-profiles\"", slice, StringComparison.Ordinal);
+            Assert.False(
+                slice.Contains(ProfileEditorPrefix + "Tmpl-", StringComparison.Ordinal),
+                $"A profile-editor control is inside {name}, where that form's own serializer would persist it onto the open provider.");
+        }
+    }
+
+    [Fact]
+    public void TemplateFormSelectors_NameOneDistinctFormPerPrefix()
+    {
+        // templateControls resolves a prefix to the form it scans. Two prefixes resolving to one form would
+        // make each prefix's serializer read the other's controls - reading the OpenID provider's fields
+        // while saving a profile, for instance - and a prefix naming a form the page does not carry would
+        // throw on a querySelectorAll of null. Both are read out of the declaration rather than assumed.
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "templateFormSelectors: {");
+        var pairs = Regex.Matches(body, "\"(?<prefix>[^\"]*)\":\\s*\"(?<form>#[^\"]+)\"")
+            .Select(m => (Prefix: m.Groups["prefix"].Value, Form: m.Groups["form"].Value))
+            .ToList();
+
+        Assert.Equal(3, pairs.Count);
+        Assert.Equal(pairs.Count, pairs.Select(p => p.Prefix).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(pairs.Count, pairs.Select(p => p.Form).Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains(ProfileEditorPrefix, pairs.Select(p => p.Prefix));
+
+        var html = ProvisioningTemplateMarkup();
+        var missing = pairs
+            .Where(p => !html.Contains($"id=\"{p.Form[1..]}\"", StringComparison.Ordinal))
+            .Select(p => $"{p.Prefix} -> {p.Form}")
+            .ToList();
+        Assert.True(
+            missing.Count == 0,
+            "These template-form selectors name no element in configPage.html, so templateControls would query a null form: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void ProviderFormProfileSelectors_ExistAndStayOffTheFlatSavePath()
+    {
+        // Each provider form names its profile with a select whose id is the exact ProviderConfigBase
+        // property (prefixed for SAML, as every SAML field is). It must NOT carry a flat marker class: the
+        // flat LOAD path sets a text field only when the loaded provider carries a value, so a provider
+        // naming no profile would keep the previous provider's name selected and the next save would write
+        // it onto the second provider. That is a change to what a provider's new accounts get, made by
+        // switching providers in a dropdown, so the field is filled and read beside the inline template
+        // instead - which is also where the mutual exclusion between the two lives.
+        var flatMarkers = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
+        var html = ProvisioningTemplateMarkup();
+        Assert.Contains("ProvisioningProfile", typeof(OidConfig).GetProperties().Select(p => p.Name));
+        Assert.Contains("ProvisioningProfile", typeof(SamlConfig).GetProperties().Select(p => p.Name));
+
+        foreach (var (name, id, slice) in new[]
+        {
+            ("oidc", "ProvisioningProfile", OidcProviderFormMarkup(html)),
+            ("saml", "saml-ProvisioningProfile", SamlProviderFormMarkup(html)),
+        })
+        {
+            var tag = Regex.Matches(slice, "<[a-zA-Z][^>]*>", RegexOptions.Singleline)
+                .Select(m => m.Value)
+                .SingleOrDefault(t => Regex.IsMatch(t, "(?<![-\\w])id=\"" + Regex.Escape(id) + "\""));
+            Assert.True(tag != null, $"The {name} provider form carries no element with id=\"{id}\".");
+            Assert.StartsWith("<select", tag, StringComparison.Ordinal);
+
+            var classes = Regex.Match(tag!, "class=\"([^\"]*)\"").Groups[1].Value
+                .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            var flat = classes.Where(c => flatMarkers.Contains(c, StringComparer.Ordinal)).ToList();
+            Assert.True(
+                flat.Count == 0,
+                $"{id} carries the flat save-contract marker(s) {string.Join(", ", flat)}, which would put it back on the load path that leaves a stale profile name selected when switching providers.");
+        }
+    }
+
+    [Fact]
+    public void ProviderSavePaths_ReadTheProfileFromTheirOwnSelector()
+    {
+        // The selector is off the flat contract by the rule above, so nothing writes it unless the save
+        // path reads it by hand - and a save that never read it would post the STORED name back every time,
+        // making the control look connected while changing nothing. Each path must read its OWN selector:
+        // the two ids differ only by the prefix, so a copy-paste that kept the OpenID id in the SAML arm
+        // would write the OpenID form's choice onto a SAML provider. What happens to the inline template
+        // once a profile is named is the neighbouring rule's subject
+        // (ProvisioningTemplateSave_NeverSendsATemplateBesideANamedProfile) and is not re-checked here.
+        var js = ProvisioningTemplateScript();
+
+        foreach (var (opener, selector, foreign) in new[]
+        {
+            ("saveProvider: (page, provider_name) => {", "#ProvisioningProfile", "#saml-ProvisioningProfile"),
+            ("saveSamlProvider: (page, provider_name) => {", "#saml-ProvisioningProfile", "#ProvisioningProfile"),
+        })
+        {
+            var body = ProvisioningTemplateFunctionBody(js, opener);
+            Assert.Contains("current_config.ProvisioningProfile =", body, StringComparison.Ordinal);
+            Assert.Contains($"page.querySelector(\"{selector}\").value || null;", body, StringComparison.Ordinal);
+            Assert.DoesNotContain($"querySelector(\"{foreign}\")", body, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ProfileDelete_IsRefusedWhileAnythingStillNamesTheProfile()
+    {
+        // The Surfaces clause of #1105, and the one act on this page that can change what a provider's new
+        // accounts get without touching that provider. Deleting a profile some provider or role rule still
+        // names produces exactly the state ProviderConfigValidator refuses, so the delete consults the
+        // reference walk BEFORE the PUT and stops. Cascading instead - clearing the references - would
+        // silently switch each of those providers to a different starting policy, or, where the provider
+        // carries no inline template, to none at all.
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "deleteProvisioningProfile: (page) => {");
+
+        var walk = body.IndexOf("provisioningProfileReferences(", StringComparison.Ordinal);
+        var put = body.IndexOf("putProvisioningProfiles(", StringComparison.Ordinal);
+        Assert.True(walk >= 0, "deleteProvisioningProfile no longer consults provisioningProfileReferences.");
+        Assert.True(put > walk, "deleteProvisioningProfile posts the configuration before checking what still names the profile.");
+        Assert.Contains("references.length > 0", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProfileRename_RepointsEveryReferenceInTheSameDocument()
+    {
+        // A rename that left the references behind would be a delete with extra steps: every provider and
+        // role rule naming the old name would point at a name the configuration no longer defines, which
+        // provisions NOTHING at the next first login rather than falling back. The repoint therefore
+        // happens in the same object that is posted, so the configuration is never in the refused state at
+        // any point, not even briefly.
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "renameProvisioningProfile: (page) => {");
+
+        var repoint = body.IndexOf("repointProvisioningProfile(config, from, to)", StringComparison.Ordinal);
+        var put = body.IndexOf("putProvisioningProfiles(", StringComparison.Ordinal);
+        Assert.True(repoint >= 0, "renameProvisioningProfile no longer repoints the references.");
+        Assert.True(put > repoint, "renameProvisioningProfile posts the configuration before repointing the references.");
+
+        // Both reference shapes, so a rename cannot repoint the provider default and forget the role rules
+        // #1106 added beside it.
+        var walk = ProvisioningTemplateFunctionBody(js, "repointProvisioningProfile: (config, from, to) => {");
+        Assert.Contains("provider_config.ProvisioningProfile === from", walk, StringComparison.Ordinal);
+        Assert.Contains("ProvisioningProfileRoleMappings", walk, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProfileEditorNames_AreRenderedAsTextNeverAsMarkup()
+    {
+        // A profile name is administrator-supplied configuration that this page reads back out of the saved
+        // document and renders in three places - the editor's list and both provider selectors. The rule
+        // linking.js states for the self-service page holds here too (#221): built with
+        // createElement/textContent, never innerHTML. Scoped to the option builder, which is the one place
+        // a name becomes an element.
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "populateProvisioningProfileOptions: (select, names, selected) => {");
+
+        Assert.Contains("option.textContent = name;", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("innerHTML", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("new Option(", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProfileEditorButtons_AreNotWiredToTheProviderSavePaths()
+    {
+        // The editor's four acts each write the ROOT profile set and nothing else. Wiring one of them to a
+        // provider save would post a provider's whole form as a side effect of editing a profile, which is
+        // the failure the separate global handlers exist to prevent - the same reason saveLoginButtons is
+        // its own path rather than a flag on the provider form.
+        var js = ProvisioningTemplateScript();
+        var acts = new[]
+        {
+            "addProvisioningProfile",
+            "renameProvisioningProfile",
+            "deleteProvisioningProfile",
+            "saveProvisioningProfile",
+        };
+
+        var bodies = new List<string>();
+        foreach (var act in acts)
+        {
+            bodies.Add(ProvisioningTemplateFunctionBody(js, act + ": (page) => {"));
+        }
+
+        foreach (var body in bodies)
+        {
+            Assert.DoesNotContain("saveProvider(", body, StringComparison.Ordinal);
+            Assert.DoesNotContain("saveSamlProvider(", body, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ProfileNames_AreRefusedWhereAnAssignmentWouldNotCreateThem()
+    {
+        // The profile set is a plain JavaScript object, so profiles[name] = template does not create an own
+        // property for every string: "__proto__" sets the prototype and creates nothing. Add would then
+        // report a profile it did not create, and RENAME - which deletes the source name first - would lose
+        // the profile while reporting that it had moved. Both acts must refuse such a name BEFORE they
+        // touch the set, and the refusal must be DERIVED by probing an assignment rather than listed by
+        // name, so a second spelling with the same asymmetry is refused without anybody thinking of it.
+        var js = ProvisioningTemplateScript();
+
+        var helper = ProvisioningTemplateFunctionBody(js, "provisioningProfileNameIsAssignable: (name) => {");
+        Assert.Contains("probe[name] = true;", helper, StringComparison.Ordinal);
+        Assert.Contains("Object.prototype.hasOwnProperty.call(probe, name)", helper, StringComparison.Ordinal);
+        Assert.DoesNotContain("__proto__", helper, StringComparison.Ordinal);
+
+        foreach (var (opener, mutation) in new[]
+        {
+            ("addProvisioningProfile: (page) => {", "profiles[name] = template || {};"),
+            ("renameProvisioningProfile: (page) => {", "delete profiles[from];"),
+        })
+        {
+            var body = ProvisioningTemplateFunctionBody(js, opener);
+            var guard = body.IndexOf("provisioningProfileNameIsAssignable(", StringComparison.Ordinal);
+            var writes = body.IndexOf(mutation, StringComparison.Ordinal);
+            Assert.True(guard >= 0, $"{opener} no longer refuses a name an assignment would not create.");
+            Assert.True(writes > guard, $"{opener} changes the profile set before checking the name is assignable.");
+        }
+    }
+
+    [Fact]
+    public void ProfileSave_WaitsForTheFillItIsSerializing()
+    {
+        // The permission rows are cleared synchronously and re-rendered only once sso/Config/Permissions
+        // answers, so the editor is EMPTY of them for the length of that fetch. A Save pressed inside that
+        // window serializes no rows and writes a profile with every grant and deny removed - with a success
+        // message, because nothing failed. The save therefore waits on the fill it is about to read.
+        var js = ProvisioningTemplateScript();
+
+        var show = ProvisioningTemplateFunctionBody(js, "showSelectedProvisioningProfile: (page, config) => {");
+        Assert.Contains("ssoConfigurationPage.provisioningProfileFill =", show, StringComparison.Ordinal);
+
+        var save = ProvisioningTemplateFunctionBody(js, "saveProvisioningProfile: (page) => {");
+        var wait = save.IndexOf("ssoConfigurationPage.provisioningProfileFill", StringComparison.Ordinal);
+        var read = save.IndexOf("readProvisioningTemplate(page, \"profile-\")", StringComparison.Ordinal);
+        Assert.True(wait >= 0, "saveProvisioningProfile no longer waits for the fill in flight.");
+        Assert.True(read > wait, "saveProvisioningProfile reads the editor before the fill it is serializing has settled.");
+    }
+}

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningProfileEditor.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningProfileEditor.cs
@@ -229,6 +229,14 @@ public partial class ArchitectureConformanceTests
         Assert.True(walk >= 0, "deleteProvisioningProfile no longer consults provisioningProfileReferences.");
         Assert.True(put > walk, "deleteProvisioningProfile posts the configuration before checking what still names the profile.");
         Assert.Contains("references.length > 0", body, StringComparison.Ordinal);
+
+        // And the walk it consults must see BOTH shapes a reference takes. Pinning only the call site let
+        // the role-rule arm be deleted with every assertion still green, while a profile named only by a
+        // role rule was deleted unrefused - which is the reference shape #1106 added and the one a reader
+        // of this section is least likely to remember.
+        var referenceWalk = ProvisioningTemplateFunctionBody(js, "provisioningProfileReferences: (config, name) => {");
+        Assert.Contains("provider_config.ProvisioningProfile === name", referenceWalk, StringComparison.Ordinal);
+        Assert.Contains("ProvisioningProfileRoleMappings", referenceWalk, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -338,13 +346,146 @@ public partial class ArchitectureConformanceTests
         // message, because nothing failed. The save therefore waits on the fill it is about to read.
         var js = ProvisioningTemplateScript();
 
-        var show = ProvisioningTemplateFunctionBody(js, "showSelectedProvisioningProfile: (page, config) => {");
-        Assert.Contains("ssoConfigurationPage.provisioningProfileFill =", show, StringComparison.Ordinal);
+        // WHAT THE FILL HAS TO COVER IS ITS OWN FETCH, and pinning only "the save waits on something" let
+        // the property fail while the rule stayed green. Filling begins with a configuration fetch, so a
+        // promise assigned after that fetch resolved is the PREVIOUS profile's, already settled: the save
+        // sailed through it and wrote the previous policy under the newly chosen name, with a success
+        // message. The assignment is therefore of the whole chain, taken synchronously in the change
+        // handler, with the fetch inside it.
+        var choose = ProvisioningTemplateFunctionBody(js, "selectProvisioningProfile: (page) => {");
+        var fetch = choose.IndexOf("const pending = ApiClient.getPluginConfiguration(", StringComparison.Ordinal);
+        var assign = choose.IndexOf("ssoConfigurationPage.provisioningProfileFill = pending;", StringComparison.Ordinal);
+        Assert.True(fetch >= 0, "selectProvisioningProfile no longer opens the fill with the configuration fetch.");
+        Assert.True(assign > fetch, "selectProvisioningProfile no longer assigns the whole fill chain, so a save would wait on the previous profile's settled promise.");
 
+        // And the save must act on the answer rather than merely await it: a fill that failed leaves the
+        // fields describing another profile, which is the one state where saving them is wrong.
         var save = ProvisioningTemplateFunctionBody(js, "saveProvisioningProfile: (page) => {");
         var wait = save.IndexOf("ssoConfigurationPage.provisioningProfileFill", StringComparison.Ordinal);
+        var refuse = save.IndexOf("filled === false", StringComparison.Ordinal);
         var read = save.IndexOf("readProvisioningTemplate(page, \"profile-\")", StringComparison.Ordinal);
         Assert.True(wait >= 0, "saveProvisioningProfile no longer waits for the fill in flight.");
-        Assert.True(read > wait, "saveProvisioningProfile reads the editor before the fill it is serializing has settled.");
+        Assert.True(refuse > wait, "saveProvisioningProfile no longer refuses when the fill it waited on failed.");
+        Assert.True(read > refuse, "saveProvisioningProfile reads the editor before the fill it is serializing has settled.");
+    }
+
+    [Fact]
+    public void TemplatePermissionAddButtons_AreWiredForEveryPrefix()
+    {
+        // Three renderings of the control set, and the wiring was written out per form: two prefixes were
+        // listed by hand and the third was missed, leaving a button that renders, is styled and has its
+        // disabled state managed while doing nothing at all - so a named profile could never be given a
+        // permission from the page. Derived from the prefix map instead, and pinned as derived: a list
+        // would go one short again the next time a form is added.
+        var js = ProvisioningTemplateScript();
+        Assert.Contains(
+            "Object.keys(ssoConfigurationPage.templateFormSelectors).forEach((prefix) => {",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains("addTemplatePermissionRow(view, prefix)", js, StringComparison.Ordinal);
+
+        // Exactly one registration, so a hand-written one beside the derived loop cannot re-introduce the
+        // asymmetry from the other side.
+        Assert.Single(Regex.Matches(js, "addTemplatePermissionRow\\(view,"));
+
+        // And every prefix the map declares has the button that loop will look for.
+        var html = ProvisioningTemplateMarkup();
+        var prefixes = Regex.Matches(
+                ProvisioningTemplateFunctionBody(js, "templateFormSelectors: {"),
+                "\"(?<prefix>[^\"]*)\":\\s*\"#")
+            .Select(m => m.Groups["prefix"].Value)
+            .ToList();
+        Assert.Equal(3, prefixes.Count);
+        var missing = prefixes
+            .Where(prefix => !html.Contains($"id=\"{prefix}Tmpl-Permissions-add\"", StringComparison.Ordinal))
+            .ToList();
+        Assert.True(
+            missing.Count == 0,
+            "These template prefixes have no permission-add button in configPage.html, so the wiring loop would query null: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void ProfileActs_CarryTheirSelectionAcrossTheReloadRatherThanAssigningIt()
+    {
+        // An act finishes by re-posting the configuration and reloading the page's view of it, and the list
+        // of profiles is rebuilt during that reload. Writing the new name onto the select BEFORE the option
+        // exists leaves the element on selectedIndex -1 with an empty value, so the rebuild read "" and fell
+        // back to the first profile: after adding or renaming, the editor showed one profile while the
+        // administrator believed it showed the other, and the next Save wrote there. The intent is carried
+        // in a field the rebuild consumes instead, so no act assigns the select directly.
+        var js = ProvisioningTemplateScript();
+
+        foreach (var act in new[] { "addProvisioningProfile", "renameProvisioningProfile" })
+        {
+            var body = ProvisioningTemplateFunctionBody(js, act + ": (page) => {");
+            Assert.Contains("ssoConfigurationPage.provisioningProfileWanted =", body, StringComparison.Ordinal);
+            Assert.DoesNotContain("querySelector(\"#selectProvisioningProfile\").value =", body, StringComparison.Ordinal);
+        }
+
+        var rebuild = ProvisioningTemplateFunctionBody(js, "populateProvisioningProfiles: (page, config) => {");
+        Assert.Contains("const wanted = ssoConfigurationPage.provisioningProfileWanted;", rebuild, StringComparison.Ordinal);
+        // Consumed, so an ordinary later reload does not re-apply a choice somebody made minutes ago.
+        Assert.Contains("ssoConfigurationPage.provisioningProfileWanted = null;", rebuild, StringComparison.Ordinal);
+        Assert.Contains("names.includes(wanted)", rebuild, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProfileStateSync_KeepsAManagedFormFrozen()
+    {
+        // This runs AFTER applyManagedState, which disables or ENABLES every control in a provider form
+        // from the declarative-managed report. Setting the disabled state from the profile alone therefore
+        // re-enabled exactly the nine starting-policy controls on a provider frozen by a configuration
+        // file - a form greyed out everywhere except the section deciding what its new accounts get, which
+        // is the inverse of what applyManagedState exists to say.
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "syncProvisioningProfileState: (page, prefix, managed) => {");
+        Assert.Contains("|| Boolean(managed)", body, StringComparison.Ordinal);
+
+        foreach (var loader in new[] { "loadProvider: (page, provider_name) => {", "loadSamlProvider: (page, provider_name) => {" })
+        {
+            var load = ProvisioningTemplateFunctionBody(js, loader);
+            var managed = load.IndexOf("applyManagedState(page,", StringComparison.Ordinal);
+            var sync = load.IndexOf("syncProvisioningProfileState(", StringComparison.Ordinal);
+            Assert.True(managed >= 0 && sync > managed, $"{loader} must re-apply the profile state after applyManagedState, which would otherwise leave it undone.");
+            Assert.Contains("isManagedProvider(", load, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void ProfileSourceOptions_AreRenderedAsTextNeverAsMarkup()
+    {
+        // The second option builder this section adds, and the one a rule scoped to the first misses: the
+        // Add source list renders PROVIDER names, which are configuration a careless or hostile value
+        // reaches exactly as a profile name does. Same rule, same reason (#221).
+        var js = ProvisioningTemplateScript();
+        var body = ProvisioningTemplateFunctionBody(js, "populateProvisioningProfiles: (page, config) => {");
+
+        Assert.Contains("option.textContent = source.label;", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("innerHTML", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("new Option(", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProfileRename_IsRefusedWhereItCannotMoveTheReference()
+    {
+        // A repoint that the save then undoes is worse than no repoint. ProviderConfigStore.Save validates
+        // FIRST and applies the declarative freeze AFTER, and DeclarativeManagedProviders.Reinject restores
+        // a managed provider WHOLE - its ProvisioningProfile included. So renaming a profile that a managed
+        // provider names passes validation, is persisted with the provider still naming the old name, and
+        // that state is then refused by ValidateProvisioningProfileReference on EVERY later save: the whole
+        // plugin configuration becomes unsaveable from this page, over a rename that reported success.
+        // Nothing downstream can undo it, so it is refused here, and the walk carries the fact the refusal
+        // needs rather than the rename asking a second question of its own.
+        var js = ProvisioningTemplateScript();
+
+        var walk = ProvisioningTemplateFunctionBody(js, "provisioningProfileReferences: (config, name) => {");
+        Assert.Contains("ssoConfigurationPage.isManagedProvider(key, provider)", walk, StringComparison.Ordinal);
+
+        var body = ProvisioningTemplateFunctionBody(js, "renameProvisioningProfile: (page) => {");
+        var refuse = body.IndexOf("references.filter((reference) => reference.managed)", StringComparison.Ordinal);
+        var move = body.IndexOf("delete profiles[from];", StringComparison.Ordinal);
+        Assert.True(refuse >= 0, "renameProvisioningProfile no longer asks whether a reference is on a provider a declarative source decided.");
+        Assert.True(move > refuse, "renameProvisioningProfile moves the profile before checking that every reference can follow it.");
+        Assert.Contains("frozen.length > 0", body, StringComparison.Ordinal);
     }
 }

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningTemplateForm.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProvisioningTemplateForm.cs
@@ -262,22 +262,35 @@ public partial class ArchitectureConformanceTests
     }
 
     [Theory]
-    [InlineData("saveProvider: (page, provider_name) => {")]
-    [InlineData("saveSamlProvider: (page, provider_name) => {")]
-    public void ProvisioningTemplateSave_LeavesAProfileUsingProviderAlone(string opener)
+    [InlineData("saveProvider: (page, provider_name) => {", "\"\"")]
+    [InlineData("saveSamlProvider: (page, provider_name) => {", "\"saml-\"")]
+    public void ProvisioningTemplateSave_NeverSendsATemplateBesideANamedProfile(string opener, string prefix)
     {
-        // The other half of the same refusal, one level up. A provider that names a provisioning profile
-        // may carry no inline template at all, so the save must write NOTHING here rather than write null:
-        // the member is left exactly as stored, and a provider whose policy comes from a profile stays
-        // saveable from this page - client id, secret, redirect path and all - over a section the
-        // administrator never opened.
+        // The other half of the same refusal, one level up. ProviderConfigValidator refuses a provider that
+        // names a profile AND carries an inline template, on the object being PRESENT, so this save must
+        // never post both - otherwise a profile-using provider is unsaveable from this page, client id and
+        // secret included, over a section the administrator never opened.
+        //
+        // WHAT THIS RULE PINNED UNTIL #1105 WAS THE SPELLING, AND THE SPELLING HAD TO CHANGE. It required
+        // the write to sit inside `if (!current_config.ProvisioningProfile)`, so that a named profile left
+        // the stored member exactly as it was. That was correct while the page could not SET the name: a
+        // provider already naming a profile stored no template, so leaving it alone and writing null were
+        // the same act. #1105 put the name on the form, so a provider carrying an inline template can now
+        // acquire one, and "leave it alone" then posts both members and is refused by the server on every
+        // save, with no way back from this page. The property the rule is actually about is unchanged and
+        // is what is checked now: an assembled template reaches the configuration ONLY where no profile is
+        // named, and the other branch sends null.
         var save = ProvisioningTemplateFunctionBody(ProvisioningTemplateScript(), opener);
 
-        var guard = save.IndexOf("if (!current_config.ProvisioningProfile) {", StringComparison.Ordinal);
-        Assert.True(guard >= 0, $"{opener} must guard the template write on the provider not naming a profile");
+        var guard = save.IndexOf("current_config.ProvisioningProfile === null", StringComparison.Ordinal);
+        Assert.True(guard >= 0, $"{opener} must decide the inline template on whether the provider names a profile");
 
-        var write = save.IndexOf("current_config.ProvisioningPolicyTemplate", StringComparison.Ordinal);
-        Assert.True(write > guard, $"{opener} writes the template outside the profile guard");
+        var assembled = save.IndexOf($"readProvisioningTemplate(page, {prefix})", StringComparison.Ordinal);
+        Assert.True(assembled > guard, $"{opener} assembles the inline template outside the profile decision");
+
+        // The named-profile branch, immediately after the assembled one: null, not the object.
+        var tail = save[assembled..];
+        Assert.Contains(": null;", tail, StringComparison.Ordinal);
     }
 
     // The text of one property on the ssoConfigurationPage object literal, by the same rule the

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -144,7 +144,7 @@
   "config.linked_accounts_revoke_failed": "Die SSO-Verknüpfungen konnten nicht widerrufen werden. Stellen Sie sicher, dass Sie als Administrator angemeldet sind, und versuchen Sie es erneut.",
   "config.template_title": "Startrichtlinie für neue Konten",
   "config.template_help": "Womit ein brandneues Konto beginnt, das dieser Anbieter anlegt. Jedes Feld ist optional: Was Sie unberührt lassen, behält die Voreinstellung von Jellyfin, und diese Werte werden einmalig beim Anlegen des Kontos geschrieben, sodass eine spätere Änderung jede folgende Anmeldung überdauert.",
-  "config.template_profile_note": "Dieser Anbieter bezieht seine Startrichtlinie aus einem benannten Bereitstellungsprofil. Die Felder unten sind daher nicht seine Richtlinie und bleiben beim Speichern unberührt. Löschen Sie den Profilnamen in der Plugin-Konfiguration, um wieder eine eingebettete Vorlage zu verwenden.",
+  "config.template_profile_note": "Dieser Anbieter bezieht seine Startrichtlinie aus dem oben genannten Bereitstellungsprofil. Die Felder unten sind daher nicht seine Richtlinie: Sie sind deaktiviert, und beim Speichern wird eine eingebettete Richtlinie gelöscht, die dieser Anbieter gespeichert hatte. Setzen Sie das Profil auf (keines) zurück, um diese Felder wieder zu verwenden.",
   "config.template_unset": "Voreinstellung von Jellyfin behalten",
   "config.template_yes": "Ja",
   "config.template_no": "Nein",

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -144,7 +144,7 @@
   "config.linked_accounts_revoke_failed": "Could not revoke the SSO links. Make sure you are signed in as an administrator, then try again.",
   "config.template_title": "Starting policy for new accounts",
   "config.template_help": "What a brand-new account created by this provider starts with. Every field is opt-in: anything you leave alone keeps Jellyfin's own default, and these values are written once, when the account is created, so a change made later survives every following login.",
-  "config.template_profile_note": "This provider takes its starting policy from a named provisioning profile, so the fields below are not its policy and are left untouched when you save. Clear the profile name in the plugin configuration to use an inline template again.",
+  "config.template_profile_note": "This provider takes its starting policy from the named provisioning profile above, so the fields below are not its policy: they are disabled, and saving clears any inline policy this provider had stored. Set the profile back to (none) to use these fields again.",
   "config.template_unset": "Leave Jellyfin's own default",
   "config.template_yes": "Yes",
   "config.template_no": "No",

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -1046,11 +1046,19 @@ const ssoConfigurationPage = {
     // "no profile" and being saved that way.
     const selector = page.querySelector("#" + prefix + "ProvisioningProfile");
     if (selector) {
-      ssoConfigurationPage.populateProvisioningProfileOptions(
-        selector,
-        profiles || [],
-        profile || "",
-      );
+      // A caller that supplies no name list is clearing the form rather than describing the configuration -
+      // resetEditor and resetSamlEditor do exactly that - so the OPTIONS are kept and only the value is
+      // cleared. Rebuilding them from an empty list instead emptied the selector on every new provider, and
+      // a new provider could then not be pointed at a profile at all until it was saved and reopened.
+      if (profiles) {
+        ssoConfigurationPage.populateProvisioningProfileOptions(
+          selector,
+          profiles,
+          profile || "",
+        );
+      } else {
+        selector.value = profile || "";
+      }
     }
 
     ssoConfigurationPage.syncProvisioningProfileState(page, prefix);
@@ -1067,10 +1075,14 @@ const ssoConfigurationPage = {
   // in, so choosing a profile updates the page immediately instead of only after the next load; the
   // profile editor's own prefix has neither a selector nor a note, so it reads as "no profile named" and
   // leaves its controls enabled, which is what a profile is.
-  syncProvisioningProfileState: (page, prefix) => {
+  syncProvisioningProfileState: (page, prefix, managed) => {
     const controls = ssoConfigurationPage.templateControls(page, prefix);
     const selector = page.querySelector("#" + prefix + "ProvisioningProfile");
-    const named = Boolean(selector && selector.value);
+    // Disabled where a profile supersedes the fields OR where the whole form is frozen by a declarative
+    // source (#1104). The second half is not optional: this call runs AFTER applyManagedState, so a plain
+    // `= named` re-enables exactly these nine controls on a managed provider and tells the administrator
+    // the opposite of what a save does - the inverse of the invariant applyManagedState exists for.
+    const named = Boolean(selector && selector.value) || Boolean(managed);
 
     const note = page.querySelector("#" + prefix + "Tmpl-profile-note");
     if (note) {
@@ -1126,6 +1138,12 @@ const ssoConfigurationPage = {
   // ---------------------------------------------------------------------------------------------------
   provisioningProfileNames: (config) =>
     Object.keys(config.ProvisioningProfiles || {}).sort(),
+  // The name the act that is running wants selected once the reload has rebuilt the list. It cannot be
+  // written onto the select before then: assigning a value no option carries leaves the element on
+  // selectedIndex -1 with an empty value, so the rebuild read "" and fell back to the FIRST profile - the
+  // editor then showed one profile while the administrator believed it showed the one just added or
+  // renamed, and the next Save wrote there. Consumed once, so a later ordinary reload does not re-apply it.
+  provisioningProfileWanted: null,
   // A name an ordinary assignment does not turn into an own property is not usable as a profile name, and
   // "__proto__" is the one that reaches this page: profiles["__proto__"] = template sets the prototype and
   // creates nothing, so an Add would report success over an empty set and a rename would DELETE the source
@@ -1141,25 +1159,34 @@ const ssoConfigurationPage = {
       page.querySelector("#ProvisioningProfileResult"),
       message,
     ),
-  // Every provider and every role rule that names a profile, as readable subjects. Used to refuse a delete
-  // and to report what a rename moved; the walk is one function so the two acts cannot disagree about what
-  // counts as a reference.
+  // Every provider and every role rule that names a profile, as readable subjects, each carrying whether
+  // the provider holding it is decided by a declarative source. Used to refuse a delete, to refuse a rename
+  // it cannot carry out, and to report what a rename moved; the walk is one function so the three cannot
+  // disagree about what counts as a reference.
   provisioningProfileReferences: (config, name) => {
     const found = [];
     [
-      ["OpenID", config.OidConfigs],
-      ["SAML", config.SamlConfigs],
-    ].forEach(([protocol, providers]) => {
+      ["oid", "OpenID", config.OidConfigs],
+      ["saml", "SAML", config.SamlConfigs],
+    ].forEach(([key, protocol, providers]) => {
       Object.keys(providers || {}).forEach((provider) => {
         const provider_config = providers[provider] || {};
+        const managed = ssoConfigurationPage.isManagedProvider(key, provider);
         if (provider_config.ProvisioningProfile === name) {
-          found.push(`${protocol} provider "${provider}"`);
+          found.push({ label: `${protocol} provider "${provider}"`, managed });
         }
 
+        // Trimmed, because the server resolves a ROLE ROW's name trimmed - a row reading " Staff " is a
+        // live reference to Staff for ProviderConfigValidator and would be invisible to an exact
+        // comparison. Such a row can only arrive from a configuration file or an import; this page has no
+        // editor for them, which is why it must not assume the shape it would have written.
         (provider_config.ProvisioningProfileRoleMappings || []).forEach(
           (row) => {
-            if (row && row.Profile === name) {
-              found.push(`${protocol} provider "${provider}" (a role rule)`);
+            if (row && (row.Profile || "").trim() === name) {
+              found.push({
+                label: `${protocol} provider "${provider}" (a role rule)`,
+                managed,
+              });
             }
           },
         );
@@ -1176,9 +1203,11 @@ const ssoConfigurationPage = {
           provider_config.ProvisioningProfile = to;
         }
 
+        // Trimmed on the same reading as the reference walk, so a rename repoints every row the server
+        // would have resolved rather than posting a document the validator then refuses.
         (provider_config.ProvisioningProfileRoleMappings || []).forEach(
           (row) => {
-            if (row && row.Profile === from) {
+            if (row && (row.Profile || "").trim() === from) {
               row.Profile = to;
             }
           },
@@ -1232,7 +1261,14 @@ const ssoConfigurationPage = {
   populateProvisioningProfiles: (page, config) => {
     const names = ssoConfigurationPage.provisioningProfileNames(config);
     const select = page.querySelector("#selectProvisioningProfile");
-    const chosen = names.includes(select.value) ? select.value : names[0] || "";
+    const wanted = ssoConfigurationPage.provisioningProfileWanted;
+    ssoConfigurationPage.provisioningProfileWanted = null;
+    const chosen =
+      wanted && names.includes(wanted)
+        ? wanted
+        : names.includes(select.value)
+          ? select.value
+          : names[0] || "";
     ssoConfigurationPage.populateProvisioningProfileOptions(
       select,
       names,
@@ -1266,28 +1302,55 @@ const ssoConfigurationPage = {
       source_select.appendChild(option);
     });
 
-    return ssoConfigurationPage.showSelectedProvisioningProfile(page, config);
+    ssoConfigurationPage.provisioningProfileFill = ssoConfigurationPage
+      .showSelectedProvisioningProfile(page, config)
+      .then(() => true);
+
+    return ssoConfigurationPage.provisioningProfileFill;
   },
-  // The fill in flight, so a Save cannot read the editor before it has been filled. The permission rows are
-  // cleared synchronously and re-rendered only after sso/Config/Permissions answers, so a Save pressed
-  // inside that window would serialize an empty row set and drop every grant and deny the profile carries -
-  // with a success message. Held as one promise rather than a flag because the acts are already promise
-  // chains and a flag would need clearing on both arms.
+  // Whether the editor currently shows the profile the selector names, as a promise resolving true or
+  // false. A Save must wait on it for two reasons, and only the whole chain covers both: the permission
+  // rows are cleared synchronously and re-rendered only once sso/Config/Permissions answers, so a Save in
+  // that window serializes no rows and drops every grant and deny the profile carries; and the fill itself
+  // begins with a configuration fetch, so between choosing a profile and that fetch answering the selector
+  // names one profile while the fields still hold another. Assigned SYNCHRONOUSLY by the change handler,
+  // covering its own fetch - a promise assigned after the fetch resolved would be the PREVIOUS profile's,
+  // already settled, and the Save would sail straight through it and write the previous policy under the
+  // new name.
   provisioningProfileFill: null,
+  selectProvisioningProfile: (page) => {
+    const pending = ApiClient.getPluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+    ).then(
+      (config) =>
+        ssoConfigurationPage
+          .showSelectedProvisioningProfile(page, config)
+          .then(() => true),
+      // Resolves FALSE rather than rejecting: a rejection nobody is waiting for is an unhandled one, and
+      // what the Save needs to know is not the error but that the fields no longer describe the selection.
+      () => {
+        ssoConfigurationPage.provisioningProfileStatus(
+          page,
+          "Could not load the profile you chose. The fields below still show the previous one, so nothing will be saved until the page is reloaded.",
+        );
+        return false;
+      },
+    );
+
+    ssoConfigurationPage.provisioningProfileFill = pending;
+    return pending;
+  },
   showSelectedProvisioningProfile: (page, config) => {
     const name = page.querySelector("#selectProvisioningProfile").value;
     page.querySelector("#ProvisioningProfileName").value = name;
 
-    ssoConfigurationPage.provisioningProfileFill =
-      ssoConfigurationPage.fillProvisioningTemplate(
-        page,
-        "profile-",
-        (config.ProvisioningProfiles || {})[name] || null,
-        null,
-        [],
-      );
-
-    return ssoConfigurationPage.provisioningProfileFill;
+    return ssoConfigurationPage.fillProvisioningTemplate(
+      page,
+      "profile-",
+      (config.ProvisioningProfiles || {})[name] || null,
+      null,
+      [],
+    );
   },
   // The one write path of the four acts: re-post the whole configuration, then reload the page's view of it.
   // A rejected PUT is reported in this section's own status region rather than swallowed - the server can
@@ -1354,7 +1417,7 @@ const ssoConfigurationPage = {
 
         profiles[name] = template || {};
         config.ProvisioningProfiles = profiles;
-        page.querySelector("#selectProvisioningProfile").value = name;
+        ssoConfigurationPage.provisioningProfileWanted = name;
 
         ssoConfigurationPage.putProvisioningProfiles(
           page,
@@ -1416,20 +1479,35 @@ const ssoConfigurationPage = {
           config,
           from,
         );
+        // A provider a declarative source decided is restored WHOLE after this configuration is validated
+        // (DeclarativeManagedProviders.Reinject), so a repoint of one does not survive the save: the
+        // profile ends up renamed and that provider keeps naming the old name. That state is refused by
+        // ProviderConfigValidator on every LATER save, so the whole plugin configuration becomes
+        // unsaveable from this page - over a rename that reported success. Refused here instead, with the
+        // repair named, because nothing downstream can undo it.
+        const frozen = references.filter((reference) => reference.managed);
+        if (frozen.length > 0) {
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `"${from}" cannot be renamed: it is named by ${frozen.map((reference) => reference.label).join("; ")}, which a configuration file or environment variables decide. That name would be restored after the save and would then point at a profile this configuration no longer defines, which makes every later save fail. Rename it at that source, or leave this profile's name as it is.`,
+          );
+          return;
+        }
+
         profiles[to] = profiles[from];
         delete profiles[from];
         config.ProvisioningProfiles = profiles;
         // In the SAME document, so the configuration is never posted with a provider pointing at a name
         // that no longer exists - the state ProviderConfigValidator refuses.
         ssoConfigurationPage.repointProvisioningProfile(config, from, to);
-        page.querySelector("#selectProvisioningProfile").value = to;
+        ssoConfigurationPage.provisioningProfileWanted = to;
 
         ssoConfigurationPage.putProvisioningProfiles(
           page,
           config,
           references.length === 0
             ? `Renamed "${from}" to "${to}". Nothing pointed at it.`
-            : `Renamed "${from}" to "${to}" and repointed ${references.length} reference(s): ${references.join("; ")}.`,
+            : `Renamed "${from}" to "${to}" and repointed ${references.length} reference(s): ${references.map((reference) => reference.label).join("; ")}.`,
         );
       },
     );
@@ -1456,7 +1534,7 @@ const ssoConfigurationPage = {
           // at all - which is a change to what new accounts get, made from a delete button.
           ssoConfigurationPage.provisioningProfileStatus(
             page,
-            `"${name}" is still in use, so it was not deleted: ${references.join("; ")}. Point each of them at another profile first, or clear the name to go back to that provider's own inline policy.`,
+            `"${name}" is still in use, so it was not deleted: ${references.map((reference) => reference.label).join("; ")}. Point each of them at another profile first, or clear the name to go back to that provider's own inline policy.`,
           );
           return;
         }
@@ -1472,7 +1550,6 @@ const ssoConfigurationPage = {
         const profiles = config.ProvisioningProfiles || {};
         delete profiles[name];
         config.ProvisioningProfiles = profiles;
-        page.querySelector("#selectProvisioningProfile").value = "";
 
         ssoConfigurationPage.putProvisioningProfiles(
           page,
@@ -1493,33 +1570,45 @@ const ssoConfigurationPage = {
     }
 
     // Waits for the fill above, so what is serialized is the profile as it was loaded plus the
-    // administrator's edits - never a permission list that has not been rendered yet.
-    Promise.resolve(ssoConfigurationPage.provisioningProfileFill).then(() =>
-      ApiClient.getPluginConfiguration(
-        ssoConfigurationPage.pluginUniqueId,
-      ).then((config) => {
-        const profiles = config.ProvisioningProfiles || {};
-        if (!Object.prototype.hasOwnProperty.call(profiles, name)) {
+    // administrator's edits - never a permission list that has not been rendered yet, and never a previous
+    // profile's policy under this name.
+    Promise.resolve(ssoConfigurationPage.provisioningProfileFill).then(
+      (filled) => {
+        if (filled === false) {
           ssoConfigurationPage.provisioningProfileStatus(
             page,
-            `The profile "${name}" is no longer in the saved configuration. Reload the page.`,
+            "The fields below do not show the profile you chose, because loading it failed, so nothing was saved. Reload the page and try again.",
           );
-          return;
+          return undefined;
         }
 
-        // An all-declined profile is an EMPTY OBJECT here, never null. The provider arm sends no object at
-        // all for that state, because an object present beside a named profile is refused; a profile IS the
-        // object, so removing it would delete the profile and break every provider pointing at it.
-        profiles[name] =
-          ssoConfigurationPage.readProvisioningTemplate(page, "profile-") || {};
-        config.ProvisioningProfiles = profiles;
+        return ApiClient.getPluginConfiguration(
+          ssoConfigurationPage.pluginUniqueId,
+        ).then((config) => {
+          const profiles = config.ProvisioningProfiles || {};
+          if (!Object.prototype.hasOwnProperty.call(profiles, name)) {
+            ssoConfigurationPage.provisioningProfileStatus(
+              page,
+              `The profile "${name}" is no longer in the saved configuration. Reload the page.`,
+            );
+            return;
+          }
 
-        ssoConfigurationPage.putProvisioningProfiles(
-          page,
-          config,
-          `Saved the profile "${name}".`,
-        );
-      }),
+          // An all-declined profile is an EMPTY OBJECT here, never null. The provider arm sends no object at
+          // all for that state, because an object present beside a named profile is refused; a profile IS the
+          // object, so removing it would delete the profile and break every provider pointing at it.
+          profiles[name] =
+            ssoConfigurationPage.readProvisioningTemplate(page, "profile-") ||
+            {};
+          config.ProvisioningProfiles = profiles;
+
+          ssoConfigurationPage.putProvisioningProfiles(
+            page,
+            config,
+            `Saved the profile "${name}".`,
+          );
+        });
+      },
     );
   },
   // Choosing a profile on a PROVIDER form is the only act here that discards something: the provider's own
@@ -1825,7 +1914,11 @@ const ssoConfigurationPage = {
         ssoConfigurationPage
           .applyManagedState(page, "oid", provider_name)
           .then(() =>
-            ssoConfigurationPage.syncProvisioningProfileState(page, ""),
+            ssoConfigurationPage.syncProvisioningProfileState(
+              page,
+              "",
+              ssoConfigurationPage.isManagedProvider("oid", provider_name),
+            ),
           );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "oid");
@@ -3475,7 +3568,11 @@ const ssoConfigurationPage = {
         ssoConfigurationPage
           .applyManagedState(page, "saml", provider_name)
           .then(() =>
-            ssoConfigurationPage.syncProvisioningProfileState(page, "saml-"),
+            ssoConfigurationPage.syncProvisioningProfileState(
+              page,
+              "saml-",
+              ssoConfigurationPage.isManagedProvider("saml", provider_name),
+            ),
           );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "saml");
@@ -4037,10 +4134,18 @@ export default function initSsoConfigurationPage(view) {
     ssoConfigurationPage.populateRoleMappings(current_mappings, container);
   });
 
-  view.querySelector("#Tmpl-Permissions-add").addEventListener("click", (e) => {
-    ssoConfigurationPage.addTemplatePermissionRow(view, "");
-    e.preventDefault();
-    return false;
+  // One registration per template-control prefix, derived from the prefix->form map rather than written
+  // out per form. Two of the three were listed by hand and the third - the profile editor's - was missed,
+  // which left the button rendered, styled and disabled-managed while doing nothing, so a named profile
+  // could never be given a permission from the page at all.
+  Object.keys(ssoConfigurationPage.templateFormSelectors).forEach((prefix) => {
+    view
+      .querySelector("#" + prefix + "Tmpl-Permissions-add")
+      .addEventListener("click", (e) => {
+        ssoConfigurationPage.addTemplatePermissionRow(view, prefix);
+        e.preventDefault();
+        return false;
+      });
   });
 
   // The insecure-options expander keeps the dangerous toggles in the DOM (hidden), never detached, so they
@@ -4274,14 +4379,6 @@ export default function initSsoConfigurationPage(view) {
   });
 
   view
-    .querySelector("#saml-Tmpl-Permissions-add")
-    .addEventListener("click", (e) => {
-      ssoConfigurationPage.addTemplatePermissionRow(view, "saml-");
-      e.preventDefault();
-      return false;
-    });
-
-  view
     .querySelector("#saml-ShowInsecureOptions")
     .addEventListener("click", (e) => {
       const collapsed = view.querySelector("#saml-insecure-options").hidden;
@@ -4404,8 +4501,10 @@ export default function initSsoConfigurationPage(view) {
 
   // ---- Provisioning profiles (#1105) ----
   // The editor is filled by loadConfiguration, so nothing is populated here; these are the four acts and
-  // the selection. Each is its own handler against the live configuration, and none of them is a submit:
-  // the section sits in its own form so the browser's default submit would reload the dashboard.
+  // the selection. Each is its own handler against the live configuration, and every one of the four
+  // buttons is type="button" in the markup: the section sits in its own form, so a submit that reached the
+  // browser would reload the dashboard, and preventDefault runs only AFTER the act - a synchronous throw
+  // inside one would let the navigation happen.
   [
     ["#AddProvisioningProfile", "addProvisioningProfile"],
     ["#RenameProvisioningProfile", "renameProvisioningProfile"],
@@ -4421,13 +4520,9 @@ export default function initSsoConfigurationPage(view) {
 
   view
     .querySelector("#selectProvisioningProfile")
-    .addEventListener("change", () => {
-      ApiClient.getPluginConfiguration(
-        ssoConfigurationPage.pluginUniqueId,
-      ).then((config) =>
-        ssoConfigurationPage.showSelectedProvisioningProfile(view, config),
-      );
-    });
+    .addEventListener("change", () =>
+      ssoConfigurationPage.selectProvisioningProfile(view),
+    );
 
   // The per-provider selectors, on both forms. The handler asks before the inline policy is discarded and
   // then syncs the note and the disabled state, so the page reflects the choice immediately rather than

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -344,6 +344,11 @@ const ssoConfigurationPage = {
         page.querySelector("#EnableSingleLogout").checked = Boolean(
           config.EnableSingleLogout,
         );
+        // The GLOBAL provisioning profile set (#1105) rides the same configuration load, for the
+        // reason the two flags above do: it is a root PluginConfiguration member with its own save
+        // path. Doing it here means every existing save, delete and import route refreshes the
+        // editor and both provider-form selectors without knowing that they exist.
+        ssoConfigurationPage.populateProvisioningProfiles(page, config);
       },
     );
 
@@ -953,9 +958,18 @@ const ssoConfigurationPage = {
   // ---------------------------------------------------------------------------------------------------
   templateFieldName: (prefix, element) =>
     element.id.slice((prefix + "Tmpl-").length),
+  // The form each template-control prefix lives in. The global profile editor (#1105) renders the same
+  // nine controls a THIRD time, outside both provider forms, so the two-way ternary this replaced could
+  // not name it: "is it the SAML prefix" is a different question from "which form is this prefix in", and
+  // the first one silently answers the OpenID form for every prefix that is not "saml-".
+  templateFormSelectors: {
+    "": "#sso-new-oidc-provider",
+    "saml-": "#sso-new-saml-provider",
+    "profile-": "#sso-provisioning-profiles",
+  },
   templateControls: (page, prefix) => {
     const form = page.querySelector(
-      prefix ? "#sso-new-saml-provider" : "#sso-new-oidc-provider",
+      ssoConfigurationPage.templateFormSelectors[prefix],
     );
 
     return {
@@ -1010,7 +1024,7 @@ const ssoConfigurationPage = {
 
     return Object.keys(template).length === 0 ? null : template;
   },
-  fillProvisioningTemplate: (page, prefix, template, profile) => {
+  fillProvisioningTemplate: (page, prefix, template, profile, profiles) => {
     const controls = ssoConfigurationPage.templateControls(page, prefix);
     const values = template || {};
 
@@ -1023,16 +1037,41 @@ const ssoConfigurationPage = {
       },
     );
 
-    ssoConfigurationPage.populateTemplatePermissions(
+    // The named-profile selector is filled here rather than by the flat load path (#1105). That path sets
+    // a text field ONLY when the loaded provider carries a value, so a provider naming no profile would
+    // keep the previously loaded provider's name selected and a later save would write it onto the second
+    // provider - the same stale-value failure the check_fields loop above is written unconditionally for.
+    // Set unconditionally for exactly that reason, and the stored name is offered even when the profile
+    // set does not carry it, so a name that has gone missing is visible instead of silently reading as
+    // "no profile" and being saved that way.
+    const selector = page.querySelector("#" + prefix + "ProvisioningProfile");
+    if (selector) {
+      ssoConfigurationPage.populateProvisioningProfileOptions(
+        selector,
+        profiles || [],
+        profile || "",
+      );
+    }
+
+    ssoConfigurationPage.syncProvisioningProfileState(page, prefix);
+
+    return ssoConfigurationPage.populateTemplatePermissions(
       page,
       prefix,
       values.Permissions || [],
     );
+  },
+  // Where the provider names a provisioning profile the inline template is not this provider's policy.
+  // The controls are disabled and the reason is put on the page, rather than leaving the administrator to
+  // infer it from a save that changes nothing here. Read off the SELECTOR rather than off a value passed
+  // in, so choosing a profile updates the page immediately instead of only after the next load; the
+  // profile editor's own prefix has neither a selector nor a note, so it reads as "no profile named" and
+  // leaves its controls enabled, which is what a profile is.
+  syncProvisioningProfileState: (page, prefix) => {
+    const controls = ssoConfigurationPage.templateControls(page, prefix);
+    const selector = page.querySelector("#" + prefix + "ProvisioningProfile");
+    const named = Boolean(selector && selector.value);
 
-    // Where the provider names a provisioning profile the inline template is not this provider's policy.
-    // The controls are disabled and the reason is put on the page, rather than leaving the administrator
-    // to infer it from a save that changes nothing here.
-    const named = Boolean(profile);
     const note = page.querySelector("#" + prefix + "Tmpl-profile-note");
     if (note) {
       note.hidden = !named;
@@ -1046,6 +1085,462 @@ const ssoConfigurationPage = {
     ].forEach((element) => {
       element.disabled = named;
     });
+  },
+  // Options are built with createElement/textContent, never innerHTML (#221): a profile name is
+  // administrator-supplied configuration and is rendered as literal text wherever it appears.
+  populateProvisioningProfileOptions: (select, names, selected) => {
+    const offered =
+      selected && !names.includes(selected) ? [...names, selected] : names;
+
+    select.replaceChildren();
+    const none = window.document.createElement("option");
+    none.value = "";
+    none.textContent = "(none)";
+    select.appendChild(none);
+
+    offered.forEach((name) => {
+      const option = window.document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      select.appendChild(option);
+    });
+
+    select.value = selected || "";
+  },
+  // ---------------------------------------------------------------------------------------------------
+  // The provisioning-profile editor (#1105).
+  //
+  // ProvisioningProfiles is a root PluginConfiguration member - a named set of ProvisioningPolicyTemplate -
+  // so every act here fetches the live configuration, changes only that member (and, on a rename, the
+  // references to it), and re-posts the whole document, exactly as saveLoginButtons does. Nothing here adds
+  // a server route.
+  //
+  // Two of the four acts can break a provider, and both are checked against the live configuration BEFORE
+  // the PUT rather than left to ProviderConfigValidator's refusal:
+  //  - DELETE of a profile some provider or role rule still names is refused here and the references are
+  //    shown. The server refuses the same state; what this adds is telling the administrator before they
+  //    lose the edit, which is courtesy rather than the guard.
+  //  - RENAME repoints every reference in the same document, so the configuration is never posted in the
+  //    state the validator refuses. A rename that left the references behind would be a delete with extra
+  //    steps.
+  // ---------------------------------------------------------------------------------------------------
+  provisioningProfileNames: (config) =>
+    Object.keys(config.ProvisioningProfiles || {}).sort(),
+  // A name an ordinary assignment does not turn into an own property is not usable as a profile name, and
+  // "__proto__" is the one that reaches this page: profiles["__proto__"] = template sets the prototype and
+  // creates nothing, so an Add would report success over an empty set and a rename would DELETE the source
+  // profile while reporting that it had moved. Derived by probing an assignment rather than listed by name,
+  // so a second spelling with the same asymmetry is refused without anybody having to think of it first.
+  provisioningProfileNameIsAssignable: (name) => {
+    const probe = {};
+    probe[name] = true;
+    return Object.prototype.hasOwnProperty.call(probe, name);
+  },
+  provisioningProfileStatus: (page, message) =>
+    ssoConfigurationPage.renderTransferMessage(
+      page.querySelector("#ProvisioningProfileResult"),
+      message,
+    ),
+  // Every provider and every role rule that names a profile, as readable subjects. Used to refuse a delete
+  // and to report what a rename moved; the walk is one function so the two acts cannot disagree about what
+  // counts as a reference.
+  provisioningProfileReferences: (config, name) => {
+    const found = [];
+    [
+      ["OpenID", config.OidConfigs],
+      ["SAML", config.SamlConfigs],
+    ].forEach(([protocol, providers]) => {
+      Object.keys(providers || {}).forEach((provider) => {
+        const provider_config = providers[provider] || {};
+        if (provider_config.ProvisioningProfile === name) {
+          found.push(`${protocol} provider "${provider}"`);
+        }
+
+        (provider_config.ProvisioningProfileRoleMappings || []).forEach(
+          (row) => {
+            if (row && row.Profile === name) {
+              found.push(`${protocol} provider "${provider}" (a role rule)`);
+            }
+          },
+        );
+      });
+    });
+
+    return found;
+  },
+  repointProvisioningProfile: (config, from, to) => {
+    [config.OidConfigs, config.SamlConfigs].forEach((providers) => {
+      Object.keys(providers || {}).forEach((provider) => {
+        const provider_config = providers[provider] || {};
+        if (provider_config.ProvisioningProfile === from) {
+          provider_config.ProvisioningProfile = to;
+        }
+
+        (provider_config.ProvisioningProfileRoleMappings || []).forEach(
+          (row) => {
+            if (row && row.Profile === from) {
+              row.Profile = to;
+            }
+          },
+        );
+      });
+    });
+  },
+  // The providers that carry an inline template, as the sources an Add can copy. Only those: a source with
+  // no policy of its own would produce an empty profile under a label that promised one.
+  provisioningProfileSources: (config) => {
+    const sources = [];
+    [
+      ["oid", "OpenID", config.OidConfigs],
+      ["saml", "SAML", config.SamlConfigs],
+    ].forEach(([key, protocol, providers]) => {
+      Object.keys(providers || {})
+        .sort()
+        .forEach((provider) => {
+          if ((providers[provider] || {}).ProvisioningPolicyTemplate) {
+            sources.push({
+              value: `${key}:${provider}`,
+              label: `${protocol}: ${provider}`,
+            });
+          }
+        });
+    });
+
+    return sources;
+  },
+  provisioningProfileSourceTemplate: (config, value) => {
+    const separator = value.indexOf(":");
+    if (separator < 0) {
+      return null;
+    }
+
+    const providers =
+      value.slice(0, separator) === "saml"
+        ? config.SamlConfigs
+        : config.OidConfigs;
+    const provider = (providers || {})[value.slice(separator + 1)] || {};
+
+    // A COPY, not the live object: the profile and the provider's own template are two independent policies
+    // from the moment the profile exists, and sharing one object would make the next edit to either of them
+    // change both inside this one PUT.
+    return provider.ProvisioningPolicyTemplate
+      ? JSON.parse(JSON.stringify(provider.ProvisioningPolicyTemplate))
+      : null;
+  },
+  // Fills the editor and both provider-form selectors from one configuration load. Called from
+  // loadConfiguration, so every existing save, delete and import path refreshes the editor for free.
+  populateProvisioningProfiles: (page, config) => {
+    const names = ssoConfigurationPage.provisioningProfileNames(config);
+    const select = page.querySelector("#selectProvisioningProfile");
+    const chosen = names.includes(select.value) ? select.value : names[0] || "";
+    ssoConfigurationPage.populateProvisioningProfileOptions(
+      select,
+      names,
+      chosen,
+    );
+
+    // An open provider form keeps whatever it has selected, so a profile added here appears in its list
+    // without discarding a choice the administrator has already made and not yet saved.
+    ["ProvisioningProfile", "saml-ProvisioningProfile"].forEach((id) => {
+      const selector = page.querySelector("#" + id);
+      if (selector) {
+        ssoConfigurationPage.populateProvisioningProfileOptions(
+          selector,
+          names,
+          selector.value,
+        );
+      }
+    });
+
+    const sources = ssoConfigurationPage.provisioningProfileSources(config);
+    const source_select = page.querySelector("#ProvisioningProfileSource");
+    source_select.replaceChildren();
+    const empty = window.document.createElement("option");
+    empty.value = "";
+    empty.textContent = "Nothing - start empty";
+    source_select.appendChild(empty);
+    sources.forEach((source) => {
+      const option = window.document.createElement("option");
+      option.value = source.value;
+      option.textContent = source.label;
+      source_select.appendChild(option);
+    });
+
+    return ssoConfigurationPage.showSelectedProvisioningProfile(page, config);
+  },
+  // The fill in flight, so a Save cannot read the editor before it has been filled. The permission rows are
+  // cleared synchronously and re-rendered only after sso/Config/Permissions answers, so a Save pressed
+  // inside that window would serialize an empty row set and drop every grant and deny the profile carries -
+  // with a success message. Held as one promise rather than a flag because the acts are already promise
+  // chains and a flag would need clearing on both arms.
+  provisioningProfileFill: null,
+  showSelectedProvisioningProfile: (page, config) => {
+    const name = page.querySelector("#selectProvisioningProfile").value;
+    page.querySelector("#ProvisioningProfileName").value = name;
+
+    ssoConfigurationPage.provisioningProfileFill =
+      ssoConfigurationPage.fillProvisioningTemplate(
+        page,
+        "profile-",
+        (config.ProvisioningProfiles || {})[name] || null,
+        null,
+        [],
+      );
+
+    return ssoConfigurationPage.provisioningProfileFill;
+  },
+  // The one write path of the four acts: re-post the whole configuration, then reload the page's view of it.
+  // A rejected PUT is reported in this section's own status region rather than swallowed - the server can
+  // refuse for a reason this act did not cause, and a silent failure here reads as a save that worked.
+  putProvisioningProfiles: (page, config, message) =>
+    ApiClient.updatePluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+      config,
+    ).then(
+      (result) => {
+        Dashboard.processPluginConfigurationUpdateResult(result);
+        ssoConfigurationPage.loadConfiguration(page);
+        ssoConfigurationPage.provisioningProfileStatus(page, message);
+      },
+      () => {
+        ssoConfigurationPage.provisioningProfileStatus(
+          page,
+          "The server refused the saved configuration, so nothing was changed. A profile is checked by exactly the rules an inline starting policy is: the administrator, all-folders and Live TV permissions keep their own settings on a provider and are not written from here, and no account can be created disabled from here. Reload the page and try again.",
+        );
+      },
+    ),
+  addProvisioningProfile: (page) => {
+    const name = page.querySelector("#ProvisioningProfileName").value.trim();
+    if (name === "") {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        "Type the name the new profile should have. A name is the only thing a provider can point at, so an unnamed profile could never be selected.",
+      );
+      return;
+    }
+
+    if (!ssoConfigurationPage.provisioningProfileNameIsAssignable(name)) {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        `"${name}" cannot be used as a profile name: a JavaScript object cannot carry it as an ordinary member, so the profile would be reported as created and would not exist. Choose a different name.`,
+      );
+      return;
+    }
+
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        const profiles = config.ProvisioningProfiles || {};
+        if (Object.prototype.hasOwnProperty.call(profiles, name)) {
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `A profile called "${name}" already exists. Choose it above to edit it, or type a different name.`,
+          );
+          return;
+        }
+
+        // Add COPIES the chosen provider's inline policy rather than creating an empty profile (#1105,
+        // decided 2026-09-02): an empty profile writes nothing onto a new account, so the control would
+        // appear to do something and not do it. The copy works for the reason the automatic load-time hoist
+        // declined on 2026-08-31 did not - the administrator supplies the name that could not be derived.
+        // It CREATES and does not SELECT: no provider changes policy until somebody points it at this
+        // profile, so the two acts stay distinct in the record and on the page.
+        const source = page.querySelector("#ProvisioningProfileSource").value;
+        const template = source
+          ? ssoConfigurationPage.provisioningProfileSourceTemplate(
+              config,
+              source,
+            )
+          : null;
+
+        profiles[name] = template || {};
+        config.ProvisioningProfiles = profiles;
+        page.querySelector("#selectProvisioningProfile").value = name;
+
+        ssoConfigurationPage.putProvisioningProfiles(
+          page,
+          config,
+          template
+            ? `Added the profile "${name}" as a copy of that provider's own starting policy. No provider uses it yet: point one at it in its own Starting policy section.`
+            : `Added the empty profile "${name}". It writes nothing onto a new account until you set a field below and save it.`,
+        );
+      },
+    );
+  },
+  renameProvisioningProfile: (page) => {
+    const from = page.querySelector("#selectProvisioningProfile").value;
+    const to = page.querySelector("#ProvisioningProfileName").value.trim();
+    if (from === "") {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        "Choose the profile to rename first.",
+      );
+      return;
+    }
+
+    if (to === "" || to === from) {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        "Type the new name in Profile name. A rename needs a name that is not the current one.",
+      );
+      return;
+    }
+
+    if (!ssoConfigurationPage.provisioningProfileNameIsAssignable(to)) {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        `"${to}" cannot be used as a profile name, for the reason Add gives. Refused here BEFORE anything moves: the rename deletes the source name, so renaming onto a name that cannot be assigned would lose the profile and report that it had moved.`,
+      );
+      return;
+    }
+
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        const profiles = config.ProvisioningProfiles || {};
+        if (!Object.prototype.hasOwnProperty.call(profiles, from)) {
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `The profile "${from}" is no longer in the saved configuration. Reload the page.`,
+          );
+          return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(profiles, to)) {
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `A profile called "${to}" already exists, and renaming onto it would silently replace its policy. Choose a different name.`,
+          );
+          return;
+        }
+
+        const references = ssoConfigurationPage.provisioningProfileReferences(
+          config,
+          from,
+        );
+        profiles[to] = profiles[from];
+        delete profiles[from];
+        config.ProvisioningProfiles = profiles;
+        // In the SAME document, so the configuration is never posted with a provider pointing at a name
+        // that no longer exists - the state ProviderConfigValidator refuses.
+        ssoConfigurationPage.repointProvisioningProfile(config, from, to);
+        page.querySelector("#selectProvisioningProfile").value = to;
+
+        ssoConfigurationPage.putProvisioningProfiles(
+          page,
+          config,
+          references.length === 0
+            ? `Renamed "${from}" to "${to}". Nothing pointed at it.`
+            : `Renamed "${from}" to "${to}" and repointed ${references.length} reference(s): ${references.join("; ")}.`,
+        );
+      },
+    );
+  },
+  deleteProvisioningProfile: (page) => {
+    const name = page.querySelector("#selectProvisioningProfile").value;
+    if (name === "") {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        "Choose the profile to delete first.",
+      );
+      return;
+    }
+
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        const references = ssoConfigurationPage.provisioningProfileReferences(
+          config,
+          name,
+        );
+        if (references.length > 0) {
+          // Refused rather than cascaded. Clearing the references here would silently switch every one of
+          // those providers to a different starting policy - for a provider with no inline template, to none
+          // at all - which is a change to what new accounts get, made from a delete button.
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `"${name}" is still in use, so it was not deleted: ${references.join("; ")}. Point each of them at another profile first, or clear the name to go back to that provider's own inline policy.`,
+          );
+          return;
+        }
+
+        if (
+          !window.confirm(
+            `Are you sure you want to delete the provisioning profile ${name}?`,
+          )
+        ) {
+          return;
+        }
+
+        const profiles = config.ProvisioningProfiles || {};
+        delete profiles[name];
+        config.ProvisioningProfiles = profiles;
+        page.querySelector("#selectProvisioningProfile").value = "";
+
+        ssoConfigurationPage.putProvisioningProfiles(
+          page,
+          config,
+          `Deleted the profile "${name}".`,
+        );
+      },
+    );
+  },
+  saveProvisioningProfile: (page) => {
+    const name = page.querySelector("#selectProvisioningProfile").value;
+    if (name === "") {
+      ssoConfigurationPage.provisioningProfileStatus(
+        page,
+        "Choose a profile above, or add one, before saving. This section edits a named profile; it is not a provider's own starting policy.",
+      );
+      return;
+    }
+
+    // Waits for the fill above, so what is serialized is the profile as it was loaded plus the
+    // administrator's edits - never a permission list that has not been rendered yet.
+    Promise.resolve(ssoConfigurationPage.provisioningProfileFill).then(() =>
+      ApiClient.getPluginConfiguration(
+        ssoConfigurationPage.pluginUniqueId,
+      ).then((config) => {
+        const profiles = config.ProvisioningProfiles || {};
+        if (!Object.prototype.hasOwnProperty.call(profiles, name)) {
+          ssoConfigurationPage.provisioningProfileStatus(
+            page,
+            `The profile "${name}" is no longer in the saved configuration. Reload the page.`,
+          );
+          return;
+        }
+
+        // An all-declined profile is an EMPTY OBJECT here, never null. The provider arm sends no object at
+        // all for that state, because an object present beside a named profile is refused; a profile IS the
+        // object, so removing it would delete the profile and break every provider pointing at it.
+        profiles[name] =
+          ssoConfigurationPage.readProvisioningTemplate(page, "profile-") || {};
+        config.ProvisioningProfiles = profiles;
+
+        ssoConfigurationPage.putProvisioningProfiles(
+          page,
+          config,
+          `Saved the profile "${name}".`,
+        );
+      }),
+    );
+  },
+  // Choosing a profile on a PROVIDER form is the only act here that discards something: the provider's own
+  // inline policy stops being its policy, and the save clears it, because a configuration carrying both is
+  // refused. Asked here, at the moment of the choice, where those fields are still on screen - not at Save,
+  // where the administrator has already committed. Declining puts the selector back on (none).
+  chooseProvisioningProfile: (page, prefix) => {
+    const selector = page.querySelector("#" + prefix + "ProvisioningProfile");
+    const inline = ssoConfigurationPage.readProvisioningTemplate(page, prefix);
+
+    if (
+      selector.value !== "" &&
+      inline !== null &&
+      !window.confirm(
+        `This provider has its own starting policy. Taking it from the profile "${selector.value}" instead clears those fields when you save, because a provider's new accounts get exactly one policy. Add a profile from this provider's policy first if you want to keep it.`,
+      )
+    ) {
+      selector.value = "";
+    }
+
+    ssoConfigurationPage.syncProvisioningProfileState(page, prefix);
   },
   // The mappable permission vocabulary, fetched once per page load from the one route that publishes it
   // (#1484). It is deliberately NOT a list kept in this file: a copy here drifts in three silent
@@ -1312,6 +1807,7 @@ const ssoConfigurationPage = {
           "",
           provider.ProvisioningPolicyTemplate,
           provider.ProvisioningProfile,
+          ssoConfigurationPage.provisioningProfileNames(config),
         );
 
         // Reflect the loaded toggles in the reveal-on-toggle groups (hide-not-remove) and surface any
@@ -1320,8 +1816,17 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.syncDependentFields(page);
         // Reflect the loaded provider's name + base-URL override in the computed redirect URI (#724).
         ssoConfigurationPage.updateRedirectUri(page);
-        // Last, so the role-map and folder-list controls the calls above created are covered too (#1104).
-        ssoConfigurationPage.applyManagedState(page, "oid", provider_name);
+        // Last, so the role-map and folder-list controls the calls above created are covered too (#1104),
+        // and the profile state is re-applied after it: applyManagedState disables or ENABLES every
+        // control in the form, so for an unmanaged provider it re-enables the template controls this load
+        // had just disabled for a provider whose policy comes from a profile - the fields would look
+        // editable and their contents would then be discarded by the save. Chained on its promise,
+        // because it waits for the managed-set report before it touches anything.
+        ssoConfigurationPage
+          .applyManagedState(page, "oid", provider_name)
+          .then(() =>
+            ssoConfigurationPage.syncProvisioningProfileState(page, ""),
+          );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "oid");
       },
@@ -1580,13 +2085,20 @@ const ssoConfigurationPage = {
           current_config[id] = ssoConfigurationPage.serializeRoleMappings(elem);
         });
 
-        // Untouched where the provider names a provisioning profile: the two are mutually exclusive by a
-        // refusal on the OBJECT being present, so writing one here would make that provider unsaveable
-        // from this page entirely - over a section the administrator never opened.
-        if (!current_config.ProvisioningProfile) {
-          current_config.ProvisioningPolicyTemplate =
-            ssoConfigurationPage.readProvisioningTemplate(page, "");
-        }
+        // The named profile and the inline template are ONE decision and are written together (#1105).
+        // The selector is read here rather than by the flat loop above, for the reason
+        // fillProvisioningTemplate states; the template follows it, because a save carrying both is
+        // refused by ProviderConfigValidator - one account-creation policy has one source. Leaving the
+        // stored template in place beside a newly chosen profile name would therefore make the provider
+        // unsaveable from this page, client id and secret included, so the discard is deliberate; it is
+        // confirmed at the moment the profile is chosen (chooseProvisioningProfile) rather than here,
+        // where the administrator has already pressed Save.
+        current_config.ProvisioningProfile =
+          page.querySelector("#ProvisioningProfile").value || null;
+        current_config.ProvisioningPolicyTemplate =
+          current_config.ProvisioningProfile === null
+            ? ssoConfigurationPage.readProvisioningTemplate(page, "")
+            : null;
 
         config.OidConfigs[provider_name] = current_config;
 
@@ -2954,12 +3466,17 @@ const ssoConfigurationPage = {
           "saml-",
           provider.ProvisioningPolicyTemplate,
           provider.ProvisioningProfile,
+          ssoConfigurationPage.provisioningProfileNames(config),
         );
 
         ssoConfigurationPage.syncSamlDependentFields(page);
         ssoConfigurationPage.updateSamlUrls(page);
-        // Last, for the same reason as the OpenID arm (#1104).
-        ssoConfigurationPage.applyManagedState(page, "saml", provider_name);
+        // Last, for the same reason as the OpenID arm (#1104), including the profile re-sync after it.
+        ssoConfigurationPage
+          .applyManagedState(page, "saml", provider_name)
+          .then(() =>
+            ssoConfigurationPage.syncProvisioningProfileState(page, "saml-"),
+          );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "saml");
       },
@@ -3365,11 +3882,13 @@ const ssoConfigurationPage = {
             ssoConfigurationPage.serializeRoleMappings(elem);
         });
 
-        // Same rule as the OpenID arm above.
-        if (!current_config.ProvisioningProfile) {
-          current_config.ProvisioningPolicyTemplate =
-            ssoConfigurationPage.readProvisioningTemplate(page, "saml-");
-        }
+        // Same rule as the OpenID arm above, including the discard.
+        current_config.ProvisioningProfile =
+          page.querySelector("#saml-ProvisioningProfile").value || null;
+        current_config.ProvisioningPolicyTemplate =
+          current_config.ProvisioningProfile === null
+            ? ssoConfigurationPage.readProvisioningTemplate(page, "saml-")
+            : null;
 
         config.SamlConfigs[provider_name] = current_config;
 
@@ -3881,6 +4400,47 @@ export default function initSsoConfigurationPage(view) {
       ),
     );
     ssoConfigurationPage.refreshReadiness(view, key);
+  });
+
+  // ---- Provisioning profiles (#1105) ----
+  // The editor is filled by loadConfiguration, so nothing is populated here; these are the four acts and
+  // the selection. Each is its own handler against the live configuration, and none of them is a submit:
+  // the section sits in its own form so the browser's default submit would reload the dashboard.
+  [
+    ["#AddProvisioningProfile", "addProvisioningProfile"],
+    ["#RenameProvisioningProfile", "renameProvisioningProfile"],
+    ["#DeleteProvisioningProfile", "deleteProvisioningProfile"],
+    ["#SaveProvisioningProfile", "saveProvisioningProfile"],
+  ].forEach(([selector, act]) => {
+    view.querySelector(selector).addEventListener("click", (e) => {
+      ssoConfigurationPage[act](view);
+      e.preventDefault();
+      return false;
+    });
+  });
+
+  view
+    .querySelector("#selectProvisioningProfile")
+    .addEventListener("change", () => {
+      ApiClient.getPluginConfiguration(
+        ssoConfigurationPage.pluginUniqueId,
+      ).then((config) =>
+        ssoConfigurationPage.showSelectedProvisioningProfile(view, config),
+      );
+    });
+
+  // The per-provider selectors, on both forms. The handler asks before the inline policy is discarded and
+  // then syncs the note and the disabled state, so the page reflects the choice immediately rather than
+  // only after the next load.
+  [
+    ["#ProvisioningProfile", ""],
+    ["#saml-ProvisioningProfile", "saml-"],
+  ].forEach(([selector, prefix]) => {
+    view
+      .querySelector(selector)
+      .addEventListener("change", () =>
+        ssoConfigurationPage.chooseProvisioningProfile(view, prefix),
+      );
   });
 
   // ---- Provider template pickers (#726) ----

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -358,6 +358,409 @@
           </form>
 
           <!--
+            Provisioning profiles (#1105): the editor for the GLOBAL named profile set. A profile is a
+            ProvisioningPolicyTemplate under a name, so the nine controls below are the SAME control set
+            both provider forms carry, with the same sso-tmpl-* markers and the same three-state rules,
+            under a "profile-Tmpl-" id prefix. They are deliberately a third rendering rather than a
+            shared one: the page has no template engine, and the conformance rules that pin the kind and
+            vocabulary of each control read the markup, so a control that is not written here is not
+            guarded here either. ProvisioningProfiles is a root PluginConfiguration member, not a provider
+            field, so this section sits OUTSIDE both provider forms and carries no flat sso-* marker: it
+            is saved by its own handler (config.js saveProvisioningProfile), which re-posts the whole
+            configuration with only the profile set changed, exactly as saveLoginButtons does.
+
+            Delete and rename are the two acts that can break a provider from here, and both are checked
+            against the live configuration BEFORE the PUT rather than left to the server's refusal: a
+            delete of a profile some provider still names is refused and the names are shown, and a
+            rename repoints every reference in the same document so the configuration is never posted in
+            the state the validator refuses. The server rule remains the guard - this is the courtesy
+            that tells the administrator before they lose the edit.
+          -->
+          <form id="sso-provisioning-profiles" class="esqConfigurationForm">
+            <div
+              class="verticalSection verticalSection-extrabottompadding"
+              is="emby-collapse"
+              title="Provisioning Profiles"
+            >
+              <div class="collapseContent">
+                <div class="fieldDescription">
+                  A named starting policy that any number of providers can
+                  share. A provider points at one by name in its own Starting
+                  policy section; a provider that names none keeps its own
+                  inline policy instead, and the two are mutually exclusive.
+                  Every field here follows the same rules as the inline version:
+                  anything left alone keeps Jellyfin's own default, zero is a
+                  real value for the two numbers, and the values are written
+                  once, when an account is created.
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="selectProvisioningProfile"
+                    >Profile:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="selectProvisioningProfile"
+                    name="selectProvisioningProfile"
+                    class="emby-select-withcolor emby-select"
+                  ></select>
+                  <div class="fieldDescription">
+                    The profiles this configuration defines. Choosing one loads
+                    it into the fields below; Save profile writes it back.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="ProvisioningProfileName"
+                    >Profile name:</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="ProvisioningProfileName"
+                    name="ProvisioningProfileName"
+                    type="text"
+                    class="emby-input"
+                  />
+                  <div class="fieldDescription">
+                    The name a provider points at. Add profile creates a new one
+                    under this name; Rename profile renames the profile selected
+                    above and repoints every provider and role rule that names
+                    it, so nothing is left pointing at a name that no longer
+                    exists.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="ProvisioningProfileSource"
+                    >Add copies the starting policy of:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="ProvisioningProfileSource"
+                    name="ProvisioningProfileSource"
+                    class="emby-select-withcolor emby-select"
+                  ></select>
+                  <div class="fieldDescription">
+                    A new profile begins as what a provider does today, so the
+                    first edit is a difference from a known state rather than a
+                    form filled from blank. Only providers that carry an inline
+                    policy are listed. Choosing to start empty is allowed and
+                    means exactly that: until you set a field, the profile
+                    writes nothing onto a new account.
+                  </div>
+                </div>
+                <button
+                  id="AddProvisioningProfile"
+                  is="emby-button"
+                  type="button"
+                  class="raised block emby-button"
+                >
+                  <span>Add profile</span>
+                </button>
+                <button
+                  id="RenameProvisioningProfile"
+                  is="emby-button"
+                  type="button"
+                  class="raised block emby-button"
+                >
+                  <span>Rename profile</span>
+                </button>
+                <button
+                  id="DeleteProvisioningProfile"
+                  is="emby-button"
+                  type="button"
+                  class="raised block emby-button"
+                >
+                  <span>Delete profile</span>
+                </button>
+                <div
+                  id="ProvisioningProfileResult"
+                  class="fieldDescription"
+                  role="status"
+                  aria-live="polite"
+                ></div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-RemoteClientBitrateLimit"
+                    data-i18n="config.template_bitrate_label"
+                    >Remote client bitrate limit:</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="profile-Tmpl-RemoteClientBitrateLimit"
+                    name="profile-Tmpl-RemoteClientBitrateLimit"
+                    type="number"
+                    min="0"
+                    step="1"
+                    class="sso-tmpl-number emby-input"
+                  />
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_bitrate_help"
+                  >
+                    The remote streaming ceiling in bits per second. Zero means
+                    no limit, which is a real setting rather than an empty one.
+                    Leave blank to keep Jellyfin's own default.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-MaxActiveSessions"
+                    data-i18n="config.template_sessions_label"
+                    >Maximum active sessions:</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="profile-Tmpl-MaxActiveSessions"
+                    name="profile-Tmpl-MaxActiveSessions"
+                    type="number"
+                    min="0"
+                    step="1"
+                    class="sso-tmpl-number emby-input"
+                  />
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_sessions_help"
+                  >
+                    How many sessions the account may hold at once. Zero means
+                    unlimited, which is a real setting rather than an empty one.
+                    Leave blank to keep Jellyfin's own default.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-AudioLanguagePreference"
+                    data-i18n="config.template_audio_language_label"
+                    >Preferred audio language:</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="profile-Tmpl-AudioLanguagePreference"
+                    name="profile-Tmpl-AudioLanguagePreference"
+                    type="text"
+                    class="sso-tmpl-text emby-input"
+                  />
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_audio_language_help"
+                  >
+                    The language code Jellyfin itself stores, for example eng.
+                    It is passed on as given rather than checked against a list,
+                    so any code Jellyfin accepts works. Leave blank to keep
+                    Jellyfin's own default.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-SubtitleLanguagePreference"
+                    data-i18n="config.template_subtitle_language_label"
+                    >Preferred subtitle language:</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="profile-Tmpl-SubtitleLanguagePreference"
+                    name="profile-Tmpl-SubtitleLanguagePreference"
+                    type="text"
+                    class="sso-tmpl-text emby-input"
+                  />
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_subtitle_language_help"
+                  >
+                    The language code Jellyfin itself stores, for example eng.
+                    Leave blank to keep Jellyfin's own default.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-SubtitleMode"
+                    data-i18n="config.template_subtitle_mode_label"
+                    >Subtitle mode:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="profile-Tmpl-SubtitleMode"
+                    name="profile-Tmpl-SubtitleMode"
+                    class="sso-tmpl-text emby-select-withcolor emby-select"
+                  >
+                    <option value="" data-i18n="config.template_unset">
+                      Leave Jellyfin's own default
+                    </option>
+                    <option value="Default">Default</option>
+                    <option value="Always">Always</option>
+                    <option value="OnlyForced">OnlyForced</option>
+                    <option value="None">None</option>
+                    <option value="Smart">Smart</option>
+                  </select>
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_subtitle_mode_help"
+                  >
+                    Which subtitles play by default. The options are the exact
+                    mode names Jellyfin declares, which is the spelling a save
+                    accepts; leaving it unset keeps Jellyfin's own default.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-PlayDefaultAudioTrack"
+                    data-i18n="config.template_play_default_audio_label"
+                    >Play the default audio track:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="profile-Tmpl-PlayDefaultAudioTrack"
+                    name="profile-Tmpl-PlayDefaultAudioTrack"
+                    class="sso-tmpl-bool emby-select-withcolor emby-select"
+                  >
+                    <option value="" data-i18n="config.template_unset">
+                      Leave Jellyfin's own default
+                    </option>
+                    <option value="true" data-i18n="config.template_yes">
+                      Yes
+                    </option>
+                    <option value="false" data-i18n="config.template_no">
+                      No
+                    </option>
+                  </select>
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_play_default_audio_help"
+                  >
+                    Leaving this unset keeps Jellyfin's own default. No is a
+                    deliberate setting rather than an absent one, which is why
+                    this is a list and not a checkbox.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-RememberAudioSelections"
+                    data-i18n="config.template_remember_audio_label"
+                    >Remember audio selections:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="profile-Tmpl-RememberAudioSelections"
+                    name="profile-Tmpl-RememberAudioSelections"
+                    class="sso-tmpl-bool emby-select-withcolor emby-select"
+                  >
+                    <option value="" data-i18n="config.template_unset">
+                      Leave Jellyfin's own default
+                    </option>
+                    <option value="true" data-i18n="config.template_yes">
+                      Yes
+                    </option>
+                    <option value="false" data-i18n="config.template_no">
+                      No
+                    </option>
+                  </select>
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_remember_audio_help"
+                  >
+                    Whether an audio track chosen during playback is remembered
+                    for next time. Leaving this unset keeps Jellyfin's own
+                    default; No is a deliberate setting rather than an absent
+                    one.
+                  </div>
+                </div>
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="profile-Tmpl-RememberSubtitleSelections"
+                    data-i18n="config.template_remember_subtitle_label"
+                    >Remember subtitle selections:</label
+                  >
+                  <select
+                    is="emby-select"
+                    id="profile-Tmpl-RememberSubtitleSelections"
+                    name="profile-Tmpl-RememberSubtitleSelections"
+                    class="sso-tmpl-bool emby-select-withcolor emby-select"
+                  >
+                    <option value="" data-i18n="config.template_unset">
+                      Leave Jellyfin's own default
+                    </option>
+                    <option value="true" data-i18n="config.template_yes">
+                      Yes
+                    </option>
+                    <option value="false" data-i18n="config.template_no">
+                      No
+                    </option>
+                  </select>
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_remember_subtitle_help"
+                  >
+                    Whether a subtitle chosen during playback is remembered for
+                    next time. Leaving this unset keeps Jellyfin's own default;
+                    No is a deliberate setting rather than an absent one.
+                  </div>
+                </div>
+                <div class="sso-subgroup">
+                  <p
+                    class="sso-subgroup-title"
+                    data-i18n="config.template_permissions_label"
+                  >
+                    Permissions written onto a new account
+                  </p>
+                  <div
+                    class="fieldDescription"
+                    data-i18n="config.template_permissions_help"
+                  >
+                    Each row names one Jellyfin permission and the value a new
+                    account starts with. A permission that is not listed is
+                    never touched. The names come from the server rather than
+                    from a list kept on this page, so they cannot drift from
+                    what a save accepts; administrator, all-folders and Live TV
+                    access are not offered here because each keeps its own
+                    setting above, and no account can be created disabled from
+                    here.
+                  </div>
+                  <div
+                    id="profile-Tmpl-Permissions"
+                    class="sso-tmpl-perms checkboxList paperList"
+                  ></div>
+                  <div
+                    id="profile-Tmpl-Permissions-status"
+                    class="fieldDescription"
+                    role="status"
+                    aria-live="polite"
+                  ></div>
+                  <button
+                    id="profile-Tmpl-Permissions-add"
+                    is="emby-button"
+                    type="button"
+                    class="raised sso-tmpl-perms-add emby-button"
+                  >
+                    <span class="material-icons add" aria-hidden="true"></span>
+                    <span data-i18n="config.template_permissions_add"
+                      >Add permission</span
+                    >
+                  </button>
+                </div>
+                <button
+                  id="SaveProvisioningProfile"
+                  is="emby-button"
+                  type="submit"
+                  class="raised button-submit block emby-button"
+                >
+                  <span>Save profile</span>
+                </button>
+              </div>
+            </div>
+          </form>
+
+          <!--
             Login-page buttons (#722): GLOBAL setting. ManageLoginPageButtons lives on the root
             PluginConfiguration, not on a provider, so it deliberately sits OUTSIDE both provider forms
             and carries NO sso-* marker class: it is saved by its own handler (config.js
@@ -1390,6 +1793,38 @@
                     provisioning profile, so the fields below are not its policy
                     and are left untouched when you save. Clear the profile name
                     in the plugin configuration to use an inline template again.
+                  </div>
+                  <!--
+                    The named provisioning profile this provider's new accounts get (#1105). It is a real
+                    ProviderConfigBase property, but it is deliberately NOT a flat sso-text field: the flat
+                    load path sets a text field only when the loaded provider carries a value, so switching
+                    from a provider that names a profile to one that names none would leave the previous
+                    provider's name selected and a later save would write it onto the second provider - the
+                    same stale-value failure the check_fields comment in config.js describes. It is filled
+                    and read beside the inline template instead, in fillProvisioningTemplate and in the two
+                    save paths, which is also where the mutual exclusion between the two lives.
+                  -->
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="ProvisioningProfile"
+                      >Named provisioning profile:</label
+                    >
+                    <select
+                      is="emby-select"
+                      id="ProvisioningProfile"
+                      name="ProvisioningProfile"
+                      class="sso-tmpl-profile emby-select-withcolor emby-select"
+                    ></select>
+                    <div class="fieldDescription">
+                      Take the starting policy from a profile defined in
+                      Provisioning Profiles above, instead of from the fields
+                      below. The two are mutually exclusive: a provider that
+                      names a profile and also carries its own inline fields is
+                      refused on save, because one account-creation policy has
+                      one source. Leave it on (none), or set it back to (none)
+                      and save, to use the fields below again.
+                    </div>
                   </div>
                   <div class="inputContainer">
                     <label
@@ -3343,6 +3778,38 @@
                     provisioning profile, so the fields below are not its policy
                     and are left untouched when you save. Clear the profile name
                     in the plugin configuration to use an inline template again.
+                  </div>
+                  <!--
+                    The named provisioning profile this provider's new accounts get (#1105). It is a real
+                    ProviderConfigBase property, but it is deliberately NOT a flat sso-text field: the flat
+                    load path sets a text field only when the loaded provider carries a value, so switching
+                    from a provider that names a profile to one that names none would leave the previous
+                    provider's name selected and a later save would write it onto the second provider - the
+                    same stale-value failure the check_fields comment in config.js describes. It is filled
+                    and read beside the inline template instead, in fillProvisioningTemplate and in the two
+                    save paths, which is also where the mutual exclusion between the two lives.
+                  -->
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-ProvisioningProfile"
+                      >Named provisioning profile:</label
+                    >
+                    <select
+                      is="emby-select"
+                      id="saml-ProvisioningProfile"
+                      name="saml-ProvisioningProfile"
+                      class="sso-tmpl-profile emby-select-withcolor emby-select"
+                    ></select>
+                    <div class="fieldDescription">
+                      Take the starting policy from a profile defined in
+                      Provisioning Profiles above, instead of from the fields
+                      below. The two are mutually exclusive: a provider that
+                      names a profile and also carries its own inline fields is
+                      refused on save, because one account-creation policy has
+                      one source. Leave it on (none), or set it back to (none)
+                      and save, to use the fields below again.
+                    </div>
                   </div>
                   <div class="inputContainer">
                     <label

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -751,7 +751,7 @@
                 <button
                   id="SaveProvisioningProfile"
                   is="emby-button"
-                  type="submit"
+                  type="button"
                   class="raised button-submit block emby-button"
                 >
                   <span>Save profile</span>
@@ -1789,10 +1789,11 @@
                     hidden
                     data-i18n="config.template_profile_note"
                   >
-                    This provider takes its starting policy from a named
-                    provisioning profile, so the fields below are not its policy
-                    and are left untouched when you save. Clear the profile name
-                    in the plugin configuration to use an inline template again.
+                    This provider takes its starting policy from the named
+                    provisioning profile above, so the fields below are not its
+                    policy: they are disabled, and saving clears any inline
+                    policy this provider had stored. Set the profile back to
+                    (none) to use these fields again.
                   </div>
                   <!--
                     The named provisioning profile this provider's new accounts get (#1105). It is a real
@@ -3774,10 +3775,11 @@
                     hidden
                     data-i18n="config.template_profile_note"
                   >
-                    This provider takes its starting policy from a named
-                    provisioning profile, so the fields below are not its policy
-                    and are left untouched when you save. Clear the profile name
-                    in the plugin configuration to use an inline template again.
+                    This provider takes its starting policy from the named
+                    provisioning profile above, so the fields below are not its
+                    policy: they are disabled, and saving clears any inline
+                    policy this provider had stored. Set the profile back to
+                    (none) to use these fields again.
                   </div>
                   <!--
                     The named provisioning profile this provider's new accounts get (#1105). It is a real


### PR DESCRIPTION
# What & why

The named provisioning-profile set has existed since #1426 and could only be
defined by editing the plugin configuration by hand, so the shape a deployment is
meant to use for a shared starting policy was the one no administrator could
reach. This is the profile editor the Surfaces list asks for — list, add, rename,
delete — plus the per-provider selector that points at one, which the
2026-08-31T13:45Z comment on the issue recorded as the whole of what stood
between the issue and closing.

The nine controls are the set #1367 landed on the provider forms, rendered a
third time under a `profile-Tmpl-` prefix and read by the same serializer:
`templateControls` now resolves a prefix to a form instead of asking whether the
prefix is the SAML one, which is the change that lets a third form join at all.
Every rule the inline surface holds holds here — a control left alone sends
nothing, the three nullable booleans are lists rather than checkboxes, and the
permission vocabulary comes from `sso/Config/Permissions` rather than from a copy
on the page.

**Add copies** the starting policy of a provider you choose, under the name you
type, which is what #1105 decided on 2026-09-02T13:22Z. It creates and does not
select: no provider changes policy until somebody points it at the new profile.

Done-when, clause by clause:

- clause 1 is **unmet by decision**, recorded on the issue on 2026-08-31 — no
  load-time hoist, inline templates stay as they are. Untouched here.
- clauses 2, 3 and 4 were met by #1426 and are untouched.
- the profile editor, which the 2026-08-26T12:55Z comment kept inside this issue,
  is what this change is.

Closes #1105

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here touches the login path. The
      fail-closed property this change is near is the profile resolution — a
      provider naming a profile the configuration does not define provisions
      nothing rather than falling back — and the two acts that could produce that
      state are refused before the PUT.
- [x] No secrets logged; secrets are redacted on config export. The four acts
      re-post the configuration fetched at act start, so `OidEndpoint` and
      `OidClientId` are unchanged and `ServerManagedFields.Preserve` keeps
      `OidSecret` and both SAML signing keys. Verified by the bypass lens against
      `ServerManagedFields.cs:91-162`.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

### Review record

Four lenses, refute-by-default, over the first commit (`f356d11e`). **CONFIRMED
9 / PLAUSIBLE 3.** A finding counts CONFIRMED where a reproduction was produced;
the correctness lens built a jsdom harness that loads the real `configPage.html`
and `config.js`, so six of the nine are observed transcripts rather than
arguments, and each fix was re-run against the same harness.

**bypass — NEEDS_IMPROVEMENT.** Refuted privilege escalation through the editor
(the offered vocabulary and the validator both exclude `IsAdministrator`,
`EnableAllFolders`, the Live TV kinds and `IsDisabled`), server-managed-field
loss on the new PUT, and markup injection from a profile name. Findings:

| # | Severity | Finding | Disposition |
|---|---|---|---|
| B1 | MEDIUM | The editor is the only write door to a declaratively **managed** profile that neither refuses nor says so: a save reports success over a write `DeclarativeManagedProviders.ReinjectProfiles` discards, and a rename forks a file-owned policy for unmanaged providers. | **DEFER** — needs a route this change does not add (`ManagedProviderSetDocument` publishes provider names only). Filed as #1498. The half of it that could wedge the configuration is fixed here, see A1. |
| B2 | LOW (CONFIRMED, node probe) | `profiles["__proto__"] = template` creates no own property, so Add reported a profile it had not created and a rename **deleted** the source while reporting that it had moved. | **FIX** — a name is refused where an ordinary assignment does not turn it into an own property. Probed, not listed by name. |
| B3 | INFO | The note beside a named profile had become false. | **FIX**, see A4. |
| B4 | INFO | Two pre-existing races the third rendering inherits. | **FIX** for the save arm (C2); the Add-permission arm is disclosed below. |

**correctness — FAIL.** Findings, all CONFIRMED by harness transcript:

| # | Severity | Finding | Disposition |
|---|---|---|---|
| C1 | HIGH | The editor's `#profile-Tmpl-Permissions-add` was never wired — rendered, styled, disabled-managed, inert. A named profile could not be given a permission from the page. | **FIX** — one registration derived from the prefix map. |
| C2 | HIGH | Save could write the previous profile's policy under the newly chosen name, and the change handler had no rejection arm, so one failed GET left the page permanently inconsistent. | **FIX** — the fill promise is the whole chain, taken synchronously; a failed fill makes the save refuse. |
| C3 | HIGH | Add and rename left the editor on the wrong profile (assigning a value no option carries leaves `selectedIndex -1`), and the next Save wrote there. | **FIX** — the choice is carried in a field the rebuild consumes. |
| C4 | MEDIUM | `resetEditor` / `resetSamlEditor` emptied the per-provider selector, so a new provider could not be pointed at a profile until saved and reopened. | **FIX** — no name list means clear the value, keep the options. |
| C5 | MEDIUM | Regression of #1104: the nine controls were re-enabled on a declaratively frozen provider. | **FIX** — the sync takes the managed flag. |
| C6 | LOW | The walks compared a role row's profile name exactly; the server resolves it trimmed. | **FIX** — both walks trim. |
| C7 | LOW | The delete guard is blind to a selection made on an open provider form and not yet saved. | **DECLINE** — the guard reads the saved configuration on purpose; the page deliberately keeps offering a vanished name so the state is visible rather than silently rewritten. Disclosed in Notes. |
| C8 | LOW | The Save button was `type="submit"` and `preventDefault` runs after the act. | **FIX** — `type="button"`. |
| C9 | — | Three conformance rules stayed green while the property they named was violated. | **FIX** — two strengthened, one superseded; see below. |

**availability — NEEDS_IMPROVEMENT.** Refuted every login-failure and
mass-lockout path: `TemplateFor` returns rather than throws on an unresolved
name, `ApplyAtProvisioning` runs on the create arm only, blank never becomes
`MaxActiveSessions: 0`, and `ServerManagedFields.Preserve` freezes
`DisablePasswordLogin`, the break-glass admin and the SSO-only bookkeeping on all
four new PUTs. Findings:

| # | Severity | Finding | Disposition |
|---|---|---|---|
| A1 | HIGH (conditional) | `ProviderConfigStore.Save` validates **before** the declarative freeze, and `Reinject` restores a managed provider whole — its profile name included. A rename therefore persists with that provider naming the old name, and `ValidateProvisioningProfileReference` then refuses **every later save of the whole plugin configuration**: the dashboard becomes unsaveable, over a rename that reported success. | **FIX** — a rename whose reference sits on a provider a declarative source decides is refused, naming the repair. |
| A2 | MEDIUM | Same as B1. | **DEFER** — #1498. |
| A3 | MEDIUM | Four more last-write-wins doors over the provider dictionaries. | **DECLINE** — the shape every existing save path on this page has (`saveProvider`, `saveLoginButtons`); changing it is a different topic. Disclosed in Notes. |
| A4 | MEDIUM | The on-screen note said the fields are left untouched by the save and that the name is cleared in the plugin configuration; both halves became false when the selector landed. | **FIX** — corrected in the markup and in both catalogues. |
| A5 | LOW | An unrelated save reloads the page's view and discards unsaved profile edits. | **DECLINE** — the reload is what keeps every other section correct after a save. Disclosed in Notes. |
| A6 | LOW | Add permission pressed inside the first vocabulary fetch leaves a reduced row set. | **DECLINE** — the provider forms' own pre-existing race reaching the third rendering; fixing it belongs where it originates. Disclosed in Notes. |

**PLAUSIBLE, not confirmed:** B1/A2 (the managed-profile blindness is read from
the source, not reproduced against a declarative source), A3 and A5 (structural
readings, no transcript).

This board had no second human reader tonight. The evidence stands in place of
one: every fix is re-run against the harness the finding was produced with, and
every rule below was proven by making the one-character mistake it exists for.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The serializer, the permission rows and the disable/enable state are
      the ones #1367 built; this adds the prefix→form map that lets a third form
      use them, and one reference walk that the delete refusal, the rename
      refusal and the rename report all read.
- [x] The change adds no more code than the problem requires. The nine controls
      are markup a third time, deliberately: the page has no template engine, and
      the rules that pin the kind and vocabulary of each control read the markup,
      so a control not written out is not guarded either.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and every new structural property is
      locked in.
- [x] Docs impact considered — filed, see Notes.

### The rules, and the one that changed

Twenty-one rules in `ArchitectureConformanceTests.ProvisioningProfileEditor.cs`
and the amended one next door. Each was proven by mutation:

```
--- 1 drop a template control from the editor ---           Failed: 1
--- 2 make an editor tri-state a checkbox ---               Failed: 1
--- 3 point two prefixes at one form ---                    Failed: 1
--- 4 put the provider selector back on the flat contract --- Failed: 1
--- 5 SAML save reads the OpenID selector ---               Failed: 1
--- 6 delete stops consulting the reference walk ---        Failed: 1
--- 7 rename forgets the role rules ---                     Failed: 1
--- 8 profile names rendered with new Option ---            Failed: 1
--- 9 save leaves the stored template beside a named profile --- Failed: 1
--- 10 an editor control inside the OpenID form ---         Failed: 1
--- 11 an editor act calls the provider save ---            Failed: 1
--- 12 add drops the assignable-name guard ---              Failed: 1
--- 13 save stops waiting for the fill ---                  Failed: 1
--- 14 delete walk forgets the role rules ---               Failed: 1
--- 15 the fill is assigned after its own fetch resolved --- Failed: 1
--- 16 the save stops refusing a failed fill ---            Failed: 1
--- 17 the add-permission wiring goes back to a hand list --- Failed: 1
--- 18 an act assigns the select directly again ---         Failed: 1
--- 19 the profile sync forgets the managed form ---        Failed: 1
--- 20 the source list renders provider names as markup ---  Failed: 1
--- 21 rename drops the frozen-reference refusal ---        Failed: 1
--- baseline ---                                            Total: 130, Failed: 0
```

`ProvisioningTemplateSave_LeavesAProfileUsingProviderAlone` (#1367) **had to
change and is renamed** to `..._NeverSendsATemplateBesideANamedProfile`. It
pinned the SPELLING of the guard — the write had to sit inside
`if (!current_config.ProvisioningProfile)`, so a named profile left the stored
member exactly as it was. That was correct while the page could not SET the name:
a provider already naming a profile stored no template, so leaving it alone and
writing null were the same act. With the name on the form, a provider carrying an
inline template can acquire one, and "leave it alone" then posts both members and
is refused by the server on every save, with no way back from this page. The rule
now checks the property it was always about.

## Verification

- [x] `dotnet build --warnaserror` green on both TFMs, 0 warnings.
- [x] `dotnet test` green on both TFMs: `net9.0` 3583 passed / 4 skipped,
      `net10.0` 3584 passed / 4 skipped. The four skips are the pre-existing
      off-loopback bind tests (#1227), skipped because binding a listener off
      loopback raises a Windows firewall consent dialog needing an administrator.
      They are skipped on `main` too and nothing here touches them.
- [x] Prettier clean for `config.js`, `configPage.html` and `CHANGELOG.md`.

## Notes

**No browser ran this page in CI, and none can.** This tree carries no JavaScript
runtime, no DOM and no browser automation, which is why every rule above is
structural. What that reading cannot reach was reached instead by a throwaway
jsdom harness built during the review, outside the repository: it loads the real
markup and script against a stubbed `ApiClient` and reproduced six of the nine
defects as transcripts, then confirmed each fix. That harness is not part of this
change and nothing in the tree runs it — treat the structural rules as the
standing guard and the harness as the evidence behind these particular fixes.

**Deferred, with an issue:** #1498 — the page cannot see that a profile is
decided by a declarative source, so a save on one reports success over a write
the server discards. The half that could wedge the configuration is fixed here
(A1); the rest needs the managed-set report to name profiles.

**Accepted risks, stated rather than implied:**

- The four acts post the whole configuration fetched at act start, so a provider
  another administrator added in between is dropped along with its links. This is
  the shape every existing save path on this page has; it is now behind four more
  buttons.
- An unrelated save reloads the page's view of the configuration and discards
  unsaved profile-editor edits, including the name typed for Add.
- Add permission pressed inside the first `sso/Config/Permissions` fetch leaves a
  reduced row set — the provider forms' own race, reaching the third rendering of
  their controls.
- The delete refusal reads the saved configuration, so a profile chosen on an
  open provider form and not yet saved does not protect it.

**Docs:** the wiki needs a page for this section, and #1493 is the sibling page
for the provider forms' own Starting policy section. Filed as #1499.

**#1103** — its Done-when is "both sub-issues are closed"; #1106 closed on
2026-08-28, so this merge is the last thing it waits on.
