### PR TITLE
Refuse a provisioning policy the save refuses at the OID/SAML Add doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,20 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **The provider API stored a starting policy the configuration page would have
+  refused (#1502).** `OID/Add` and `SAML/Add` write the provider they are given
+  without running the configuration save's checks, and nothing ran the
+  provisioning-template ones at that door. A template naming a permission that
+  is not one Jellyfin declares, a subtitle mode or home-screen section it does
+  not know, a negative ceiling, or a provisioning profile the configuration
+  does not define was stored as posted and answered with success. Nothing was
+  widened by it - every writer skips a value it cannot read - but the template
+  did nothing, and the first sign was an account that arrived without the
+  policy. Both doors now refuse such a body and store nothing. The reason is the
+  same message the configuration page shows, naming the field; for an API caller
+  it is written to the server log, because Jellyfin answers every refused request
+  with a bare 400 outside a development host.
+
 - **The sign-in buttons did not look like the login page's own buttons (#1372).**
   Jellyfin restyles every link in the login disclaimer at runtime: it adds its
   own `button-link` class, which is declared after `emby-button` at the same

--- a/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
@@ -277,4 +277,144 @@ public class SSOControllerAddTests
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].Enabled));
         await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
     }
+
+    [Theory]
+    [InlineData(true, "permission")]
+    [InlineData(true, "subtitle mode")]
+    [InlineData(true, "sessions")]
+    [InlineData(true, "home section")]
+    [InlineData(false, "permission")]
+    [InlineData(false, "subtitle mode")]
+    [InlineData(false, "sessions")]
+    [InlineData(false, "home section")]
+    public void Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(bool openId, string field)
+    {
+        // #1502: the Add doors persist through MutateConfiguration and so bypass the config-page save-time
+        // Validate. Before the door guard, a template the save refuses was stored as posted with a 200, and
+        // every writer's fail-closed skip then made it do nothing - the reason surfaced only at the first
+        // login that provisioned an account. The refusal must name the field, because the caller has to fix
+        // it; the message is the save's own, so the two admin write paths cannot drift apart.
+        var harness = new SsoControllerHarness();
+        var (template, names) = TemplateTheSaveRefuses(field);
+        var body = Body(openId);
+        body.ProvisioningPolicyTemplate = template;
+
+        var ex = Assert.Throws<ArgumentException>(() => Add(harness, openId, body));
+
+        Assert.Contains(names, ex.Message, StringComparison.Ordinal);
+        Assert.Null(Stored(openId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Add_UndefinedProfile_Throws_NamingTheProfile_AndDoesNotPersist(bool openId)
+    {
+        // The profile-reference half of #1502: a provider pointing at a profile the configuration does not
+        // define provisions nothing rather than falling back, so the door refuses it the way the save does.
+        var harness = new SsoControllerHarness();
+        var body = Body(openId);
+        body.ProvisioningProfile = "guest";
+
+        var ex = Assert.Throws<ArgumentException>(() => Add(harness, openId, body));
+
+        Assert.Contains("'guest', which this configuration does not define", ex.Message, StringComparison.Ordinal);
+        Assert.Null(Stored(openId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Add_ProfileTheConfigurationDefines_Persists(bool openId)
+    {
+        // The positive control for the reference check: it resolves against the LIVE profile set under the
+        // lock, so a defined profile is accepted - a check resolving against the posted body alone would
+        // refuse every profile, since the Add body never carries the profile set.
+        var harness = new SsoControllerHarness(c => c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate());
+        var body = Body(openId);
+        body.ProvisioningProfile = "guest";
+
+        Add(harness, openId, body);
+
+        Assert.Equal("guest", Stored(openId)?.ProvisioningProfile);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Add_TemplateTheSaveAccepts_Persists(bool openId)
+    {
+        // Zero is a real value on both ceilings (no limit / unlimited), so the guard must let it through:
+        // a door refusing what the save accepts would be the same drift in the other direction.
+        var harness = new SsoControllerHarness();
+        var body = Body(openId);
+        body.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { RemoteClientBitrateLimit = 0, MaxActiveSessions = 0 };
+
+        Add(harness, openId, body);
+
+        Assert.Equal(0, Stored(openId)?.ProvisioningPolicyTemplate?.MaxActiveSessions);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Add_RoleRowNamingAnUndefinedProfile_Throws_AndDoesNotPersist(bool openId)
+    {
+        // The third check the guard runs. A row pointing at a missing profile provisions nothing for the
+        // logins it matches rather than falling back, so the door refuses it the way the save does.
+        var harness = new SsoControllerHarness();
+        var body = Body(openId);
+        body.ProvisioningProfileRoleMappings = new List<ProvisioningProfileRoleMap> { new() { Profile = "staff", Roles = new[] { "admins" } } };
+
+        var ex = Assert.Throws<ArgumentException>(() => Add(harness, openId, body));
+
+        Assert.Contains("row naming 'staff', which this configuration does not define", ex.Message, StringComparison.Ordinal);
+        Assert.Null(Stored(openId));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Add_ProfileBesideAnInlineTemplate_Throws_AndDoesNotPersist(bool openId)
+    {
+        // A provider's new accounts get exactly one policy; the save refuses a body carrying both sources,
+        // and a door that let both through would persist a provider whose policy the page cannot show.
+        var harness = new SsoControllerHarness(c => c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate());
+        var body = Body(openId);
+        body.ProvisioningProfile = "guest";
+        body.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { MaxActiveSessions = 0 };
+
+        var ex = Assert.Throws<ArgumentException>(() => Add(harness, openId, body));
+
+        Assert.Contains("also carries its own inline provisioning template", ex.Message, StringComparison.Ordinal);
+        Assert.Null(Stored(openId));
+    }
+
+    // One template per field the save refuses, with the fragment of the save's message that names it.
+    private static (ProvisioningPolicyTemplate Template, string Names) TemplateTheSaveRefuses(string field) => field switch
+    {
+        "permission" => (new ProvisioningPolicyTemplate { Permissions = new List<ProvisionedPermissionEntry> { new() { Permission = "EnableTimeTravel", Granted = true } } }, "'EnableTimeTravel', which is not a known Jellyfin permission"),
+        "subtitle mode" => (new ProvisioningPolicyTemplate { SubtitleMode = "smart" }, "subtitle mode 'smart'"),
+        "sessions" => (new ProvisioningPolicyTemplate { MaxActiveSessions = -1 }, "maximum active sessions"),
+        "home section" => (new ProvisioningPolicyTemplate { HomeSections = new List<string> { "Nope" } }, "home-screen section 'Nope'"),
+        _ => throw new ArgumentOutOfRangeException(nameof(field)),
+    };
+
+    private static ProviderConfigBase Body(bool openId) => openId ? new OidConfig() : new SamlConfig();
+
+    private static void Add(SsoControllerHarness harness, bool openId, ProviderConfigBase body)
+    {
+        if (openId)
+        {
+            harness.Controller.OidAdd("keycloak", (OidConfig)body);
+        }
+        else
+        {
+            harness.Controller.SamlAdd("adfs", (SamlConfig)body);
+        }
+    }
+
+    private static ProviderConfigBase? Stored(bool openId) => SSOPlugin.Instance.ReadConfiguration(c => openId
+        ? c.OidConfigs.TryGetValue("keycloak", out var oid) ? oid : null
+        : c.SamlConfigs.TryGetValue("adfs", out var saml) ? (ProviderConfigBase?)saml : null);
 }

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -678,6 +678,33 @@ public class SSOController : ControllerBase
         }
     }
 
+    // Rejects a provisioning policy the configuration save would refuse (#1502) at the OID/SAML Add doors,
+    // which persist through MutateConfiguration and so bypass the save-time Validate. Without this, a
+    // template naming a permission that is not a PermissionKind, a subtitle mode that is not a
+    // SubtitlePlaybackMode, a negative ceiling, or a home-screen section that is not a HomeSectionType was
+    // stored as posted with a 200; every writer then skipped it fail-closed at provisioning, so the
+    // template widened nothing and did nothing, with the reason visible only at the first login that
+    // created an account. The three checks are the save's own, so both admin write paths refuse the same
+    // policy with the same message. Runs under the config lock, because the profile checks resolve the
+    // posted name against the LIVE profile set; it runs before any mutation, so a throw persists nothing.
+
+    /// <summary>
+    /// Rejects a provisioning template, profile reference, or role-to-profile row the configuration save
+    /// would refuse (#1502), at the Add doors that bypass that save. Called inside the configuration
+    /// mutation, before it changes anything, because the profile checks read the live profile set.
+    /// </summary>
+    /// <param name="protocol">The protocol label (<c>OpenID</c> or <c>SAML</c>) echoed in the rejection message.</param>
+    /// <param name="provider">The provider name posted to the Add endpoint.</param>
+    /// <param name="config">The provider body posted to the Add endpoint.</param>
+    /// <param name="live">The live configuration, whose profile set a posted profile name must resolve in.</param>
+    /// <exception cref="ArgumentException">The template, the profile reference, or a role-to-profile row is invalid.</exception>
+    private static void RejectInvalidProvisioningPolicy(string protocol, string provider, ProviderConfigBase config, PluginConfiguration live)
+    {
+        ProviderConfigValidator.ValidateProvisioningTemplate(protocol, provider, config.ProvisioningPolicyTemplate);
+        ProviderConfigValidator.ValidateProvisioningProfileReference(protocol, provider, config, live.ProvisioningProfiles);
+        ProviderConfigValidator.ValidateProvisioningProfileRoleMappings(protocol, provider, config, live.ProvisioningProfiles);
+    }
+
     // The refusal every elevated write door gives for a declaratively managed provider (#1415), defined once
     // so five doors and their tests cannot drift into five wordings. It names the source, because a refusal
     // that does not say where the change belongs leaves an administrator with nowhere to make it.
@@ -762,6 +789,7 @@ public class SSOController : ControllerBase
             // so a throw leaves the live configuration untouched and nothing is persisted.
             var providerExists = configuration.OidConfigs.TryGetValue(provider, out var existing);
             RejectInvalidNewProviderName(provider, providerExists);
+            RejectInvalidProvisioningPolicy(OpenIdProtocol, provider, config, configuration);
 
             // Re-inject the server-managed fields this API cannot carry - CanonicalLinks ([JsonIgnore],
             // #157) and the write-only secret's blank-means-keep rule (#189) - through the one shared
@@ -1275,6 +1303,7 @@ public class SSOController : ControllerBase
             // so a throw leaves the live configuration untouched and nothing is persisted.
             var providerExists = configuration.SamlConfigs.TryGetValue(provider, out var existing);
             RejectInvalidNewProviderName(provider, providerExists);
+            RejectInvalidProvisioningPolicy(SamlProtocol, provider, newConfig, configuration);
 
             // Preserve the server-managed canonical links (#157), as OidAdd does, through the shared
             // ServerManagedFields.Preserve: the posted config never carries them ([JsonIgnore]), so


### PR DESCRIPTION
# What & why

`OID/Add` and `SAML/Add` persist through `MutateConfiguration`, which never runs
`ProviderConfigValidator.Validate`, and neither door ran the provisioning checks the
configuration save applies. A body carrying a template the save would refuse - a
permission that is not a `PermissionKind`, a subtitle mode that is not a
`SubtitlePlaybackMode`, a negative ceiling, a home-screen section that is not a
`HomeSectionType` or a list longer than the ten slots - or naming a provisioning
profile the configuration does not define, was stored as posted and answered with
success. Every writer skips such a value fail-closed at provisioning, so nothing was
widened; what the administrator got was a template that did nothing, with the reason
visible only at the first login that created an account.

Both doors now run the save's own three checks - `ValidateProvisioningTemplate`,
`ValidateProvisioningProfileReference` and `ValidateProvisioningProfileRoleMappings`
- through one private helper, called inside the configuration mutation before it
changes anything. Under the lock on purpose: the Add body cannot carry the profile
set, so a posted profile name is resolved against the LIVE set, which is the one the
provider would provision from. A throw there persists nothing, exactly like the
existing name guard beside it. The messages are the validator's own, so the two admin
write paths refuse the same policy with the same words.

The writers' fail-closed skips are untouched: a configuration file edited by hand
still reaches them.

Means: C# in the existing controller and test project, the only language this tree
carries for this surface; the guard reuses the validator the save already runs, so no
second implementation of any rule exists.

Closes #1502

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (This change adds a refusal and removes
      none; the runtime writers' own skips stay as they were.)
- [x] No secrets logged; secrets are redacted on config export. (The refusal
      message echoes the provider name and the offending field value, both
      control-stripped by the validator; no secret is part of a template.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.

  Five refute-by-default lenses over the diff, each a fresh instance with no
  implementation context, the change presented as an external submission:

  - Availability / mass-lockout: PASS, no finding. Checked that a refused Add
    persists nothing (the mutation throws before the persist step), that a
    stored provider carrying a template the guard refuses keeps working, that
    the checks under the lock are pure, and that the web UI never posts to
    these doors.
  - Security bypass: PASS. CONFIRMED 0 / PLAUSIBLE 2. (1) The role-to-profile
    row check was wired but untested at the doors - FIX: two theories added,
    one per branch, and the guard's removal now reddens fourteen rows instead
    of ten. (2) `OID/Add` also skips the save's `ValidatePostLogoutRedirectUri`,
    a drift that predates this change and is fail-safe at logout - DEFER as
    #1504.
  - Correctness: PASS. CONFIRMED 0 / PLAUSIBLE 1. A missing blank line
    between two test methods - FIX. It traced every asserted message
    fragment to the validator's text, the lock and persist order, and the
    fields `ServerManagedFields.Preserve` writes after the guard.
  - Integration: PASS. CONFIRMED 0 / PLAUSIBLE 1. The acceptance criterion
    "reads a 400 naming the field" holds in-process; over HTTP, Jellyfin's
    exception middleware writes the exception message into the body only on a
    Development host and answers `Error processing request.` otherwise, with
    the message in the server log. I verified that against
    `Jellyfin.Api/Middleware/ExceptionMiddleware.cs` on `release-10.11.z`.
    FIX: the changelog entry now says where the reason is read. The
    behaviour is the same for every sibling door guard and for the
    configuration save itself, so nothing regresses.
  - Execution: PASS, no finding. Built both target frameworks with
    `--warnaserror`, ran the Add class on both, and ran its own probe posting
    a defined profile beside an inline template, a role row naming an
    undefined profile, and an invalid re-save of an existing provider, then
    removed the probe and confirmed the tree carried only the three files of
    this change.

  No lens returned FAIL, so no lens was re-run on the post-fix state; the
  added tests and the reworded entry are covered by the gate below.

- [x] Log inputs from the IdP are sanitized inline at the log call. (No log
      call is added; the exception text is built by the validator, which strips
      control characters from every echoed value.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (One helper of three delegating lines; every rule stays in
      `ProviderConfigValidator`.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property: the guard is one more door check in the
      pattern the doors already follow.)
- [x] Docs impact considered: this change needs no README/wiki update. The Add
      API's documented contract - the body is the provider configuration - is
      unchanged; what changes is that a body the configuration page refuses is
      now refused here too. The CHANGELOG carries the entry under Unreleased /
      Fixed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Run at the head of this branch, in the worktree that carries it, whole output
kept per run:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3632, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 33,207s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3633, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,439s
$ npx prettier --check CHANGELOG.md
All matched files use Prettier code style!
```

The guard is proven by deleting it. With both `RejectInvalidProvisioningPolicy`
calls commented out and the tree rebuilt (build exit 0, 0 warnings), the Add test
class reports exactly the fourteen refusal rows red and the four acceptance rows
green:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "Jellyfin.Plugin.SSO_Auth.Tests.SSOControllerAddTests"
    Add_RoleRowNamingAnUndefinedProfile_Throws_AndDoesNotPersist(openId: True) [FAIL]
    Add_RoleRowNamingAnUndefinedProfile_Throws_AndDoesNotPersist(openId: False) [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: True, field: "permission") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: True, field: "subtitle mode") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: True, field: "sessions") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: True, field: "home section") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: False, field: "permission") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: False, field: "subtitle mode") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: False, field: "sessions") [FAIL]
    Add_TemplateTheSaveRefuses_Throws_NamingTheField_AndDoesNotPersist(openId: False, field: "home section") [FAIL]
    Add_ProfileBesideAnInlineTemplate_Throws_AndDoesNotPersist(openId: True) [FAIL]
    Add_ProfileBesideAnInlineTemplate_Throws_AndDoesNotPersist(openId: False) [FAIL]
    Add_UndefinedProfile_Throws_NamingTheProfile_AndDoesNotPersist(openId: True) [FAIL]
    Add_UndefinedProfile_Throws_NamingTheProfile_AndDoesNotPersist(openId: False) [FAIL]
   SSO-Auth.Tests  Total: 37, Errors: 0, Failed: 14, Skipped: 0, Not Run: 0, Time: 0,718s
```

## Notes

The acceptance criterion says the test "reads a 400 naming the field". The tests
here are in-process, like every other test of these two doors: they read the
`ArgumentException` whose message names the field, which is what every existing
door guard throws and what the host's exception middleware turns into the 400 on the
wire. On a production host that 400 carries a fixed body and the message is in the
server log; on a Development host the body carries the message. No test in this
tree drives the Add doors over HTTP, and this change adds none.

The review's deferred finding is #1504: `OID/Add` skips the save's post-logout
redirect URI check, which predates this change.

No second reader looked at this pull request. The review record above is the
adversarial lens run and the evidence is in place of one.
