### PR TITLE
Say what the host saw while a no-status request ran

### DIFF
--- a/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
+++ b/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
@@ -77,6 +77,42 @@ public sealed class AuthorizationProbeTests
     }
 
     [Fact]
+    public async Task TheNoStatusLineSaysWhatTheHostSawWhileTheRequestRan()
+    {
+        // The last thing the elapsed time cannot say. An accepted connection Kestrel never dispatched and a
+        // pipeline that took the request and never answered both cost the whole client timeout and are
+        // different faults; only the host's own counters separate them. Take the counters out of the line and
+        // this goes red, and the next occurrence of #1444 is back to being unable to say which happened.
+        var entered = 7L;
+        var completed = 7L;
+
+        var failures = await Walk(
+            Endpoints(1),
+            _ =>
+            {
+                entered++;
+                throw new HttpRequestException("no connection");
+            },
+            traffic: () => (entered, completed));
+
+        var line = Assert.Single(failures);
+        Assert.Contains("the host pipeline took 1 request(s) and finished 0 while it ran", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AWalkWithNoHostBehindItReportsNoCountersRatherThanZeroes()
+    {
+        // A scripted transport has no host, so a pair of zeroes here would read as "Kestrel never saw it" and
+        // mean nothing of the sort. Absent is the honest answer and the units above depend on it.
+        var failures = await Walk(
+            Endpoints(1),
+            _ => throw new HttpRequestException("no connection"));
+
+        var line = Assert.Single(failures);
+        Assert.DoesNotContain("the host pipeline", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ConsecutiveTransportFailuresStopTheWalkAndSayWhatWasLeftUndriven()
     {
         // The bound the continuation is bought with. At the fixture's 30-second client timeout, walking every
@@ -154,7 +190,8 @@ public sealed class AuthorizationProbeTests
     private static async Task<IReadOnlyList<string>> Walk(
         IReadOnlyList<GatedEndpoint> endpoints,
         Func<HttpRequestMessage, HttpResponseMessage> answer,
-        string? role = null)
+        string? role = null,
+        Func<(long Entered, long Completed)>? traffic = null)
     {
         using var handler = new ScriptedTransport(answer);
 
@@ -166,7 +203,7 @@ public sealed class AuthorizationProbeTests
             Timeout = TimeSpan.FromSeconds(30),
         };
 
-        return await AuthorizationProbe.CollectFailuresAsync(client, endpoints, role, ExpectUnauthorized);
+        return await AuthorizationProbe.CollectFailuresAsync(client, endpoints, role, ExpectUnauthorized, traffic);
     }
 
     /// <summary>A transport that answers, or refuses to, exactly as the unit calling it says.</summary>

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -156,6 +157,23 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
             because: "a bare [Authorize] endpoint must admit any authenticated caller (no 401/403)");
     }
 
+    [Fact]
+    public async Task TheHostCountersMoveByOneAcrossOneRealRequest()
+    {
+        // What makes the numbers in a no-status line readable. The walk reports the DIFFERENCE across one
+        // request, so the pair is only worth printing if a request that the host both took and finished moves
+        // each side by exactly one. The facts of this class run one after the other - measured, not assumed -
+        // so nothing else is in flight to inflate it. Remove the middleware and this goes red at 0.
+        var before = _fixture.Traffic;
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, _fixture.Endpoints.ElevationGated[0].Url);
+        using var response = await _fixture.Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        var after = _fixture.Traffic;
+        Assert.Equal(1, after.Entered - before.Entered);
+        Assert.Equal(1, after.Completed - before.Completed);
+    }
+
     private async Task AssertAllAsync(
         IReadOnlyList<GatedEndpoint> endpoints,
         string? role,
@@ -166,8 +184,10 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
 
         // The walk itself lives in AuthorizationProbe so a red run reports EVERY endpoint's outcome rather
         // than stopping at the first request that produced no status (#1444). What the assertion needs from
-        // it is only the list.
-        var failures = await AuthorizationProbe.CollectFailuresAsync(_fixture.Client, endpoints, role, expected).ConfigureAwait(false);
+        // it is only the list; the host counters go with it so a no-status line says whether the host ever
+        // saw that request.
+        var failures = await AuthorizationProbe.CollectFailuresAsync(
+            _fixture.Client, endpoints, role, expected, () => _fixture.Traffic).ConfigureAwait(false);
 
         Assert.True(failures.Count == 0, $"{because}, but these did not: {string.Join("; ", failures)}");
     }

--- a/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
+++ b/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
@@ -48,12 +48,17 @@ public static class AuthorizationProbe
     /// <param name="endpoints">The endpoints to drive, in order.</param>
     /// <param name="role">The <see cref="TestRoles"/> header value, or <c>null</c> for an unauthenticated caller.</param>
     /// <param name="expected">The predicate the returned status has to satisfy.</param>
+    /// <param name="traffic">
+    /// Reads the host's entered/completed request counters, or <c>null</c> where no host is being driven. It is
+    /// read either side of each request that produces no status, and the difference goes into that line.
+    /// </param>
     /// <returns>The failure lines, in the order the endpoints were driven.</returns>
     public static async Task<IReadOnlyList<string>> CollectFailuresAsync(
         HttpClient client,
         IReadOnlyList<GatedEndpoint> endpoints,
         string? role,
-        Func<int, bool> expected)
+        Func<int, bool> expected,
+        Func<(long Entered, long Completed)>? traffic = null)
     {
         ArgumentNullException.ThrowIfNull(client);
         ArgumentNullException.ThrowIfNull(endpoints);
@@ -65,6 +70,7 @@ public static class AuthorizationProbe
         for (var i = 0; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
+            var before = traffic?.Invoke();
             var elapsed = Stopwatch.StartNew();
             int status;
 
@@ -79,8 +85,11 @@ public static class AuthorizationProbe
                 // exception names an address and, on a non-English host, says so in that host's language.
                 // The endpoint, the caller, the elapsed time and the bound that was in force are what the
                 // reader of a red run needs and cannot reconstruct - which is the evidence #1444 lost.
+                // The host counters are the last thing the elapsed time cannot say: an accepted connection
+                // Kestrel never dispatched and a pipeline that took the request and never answered cost the
+                // same wall clock and are different faults.
                 failures.Add(FormattableString.Invariant(
-                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}"));
+                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}{Seen(before, traffic)}"));
 
                 if (++consecutiveNoStatus >= ConsecutiveNoStatusLimit)
                 {
@@ -100,6 +109,23 @@ public static class AuthorizationProbe
         }
 
         return failures;
+    }
+
+    /// <summary>
+    /// Renders what the host saw during ONE request, as the difference between the counters either side of it.
+    /// Empty where no host is being driven, so a scripted transport reports nothing rather than zeroes it cannot
+    /// know the meaning of.
+    /// </summary>
+    private static string Seen((long Entered, long Completed)? before, Func<(long Entered, long Completed)>? traffic)
+    {
+        if (before is null || traffic is null)
+        {
+            return string.Empty;
+        }
+
+        var after = traffic();
+        return FormattableString.Invariant(
+            $", the host pipeline took {after.Entered - before.Value.Entered} request(s) and finished {after.Completed - before.Value.Completed} while it ran");
     }
 
     private static async Task<HttpResponseMessage> SendAsync(HttpClient client, GatedEndpoint endpoint, string? role)

--- a/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -77,6 +78,10 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
 {
     private readonly WebApplication _app;
 
+    private long _entered;
+
+    private long _completed;
+
     public SsoAuthorizationServerFixture()
     {
         // Set the process-wide SSOPlugin.Instance the controller reads at construction
@@ -117,6 +122,27 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
         builder.Services.AddControllers().AddApplicationPart(typeof(SSOController).Assembly);
 
         _app = builder.Build();
+
+        // First in the pipeline, so the pair answers the question a request producing no status otherwise
+        // leaves open (#1444): a connection the operating system accepted and Kestrel never dispatched
+        // increments neither counter, while a request that entered the pipeline and never came back out
+        // increments only the first. Measured on this host, those two cost different amounts of wall clock -
+        // a refused port answers in about two seconds, an accepted-but-unanswered connection costs the whole
+        // client timeout - so the elapsed time already separates them from a refusal; what it cannot say is
+        // which side of Kestrel the request died on.
+        _app.Use(async (context, next) =>
+        {
+            Interlocked.Increment(ref _entered);
+            try
+            {
+                await next(context).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Increment(ref _completed);
+            }
+        });
+
         _app.UseRouting();
         _app.UseAuthentication();
         _app.UseAuthorization();
@@ -142,6 +168,14 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
 
     /// <summary>Gets the authorization metadata discovered from the live endpoint table.</summary>
     public EndpointCatalog Endpoints { get; }
+
+    /// <summary>
+    /// Gets the count of requests that have entered the host pipeline and the count that have left it again,
+    /// read as one snapshot. The walk reads it either side of a request that produced no status, and the
+    /// difference says whether the host ever saw that request (#1444).
+    /// </summary>
+    public (long Entered, long Completed) Traffic =>
+        (Interlocked.Read(ref _entered), Interlocked.Read(ref _completed));
 
     /// <summary>The role name Jellyfin grants administrators; the elevation policy requires it.</summary>
     internal const string AdministratorRole = "Administrator";


### PR DESCRIPTION
# What & why

A red run of the five request-driving authorization tests already reports, per
endpoint, how long a request that produced no status took and which transport
exception ended it (#1445, #1491). Two different faults cost the same wall clock
and read the same way in that line: a connection the operating system accepted
and Kestrel never dispatched, and a request that entered the pipeline and never
came back out. They are repaired in different places, and nothing in the fixture
could tell them apart.

I measured both costs on this host before changing anything, with a throwaway
probe that is not in the tree, at `origin/main` `27a9a868`:

```
refused-port run 0: 2076 ms   threw HttpRequestException / SocketException
refused-port run 1: 2042 ms   threw HttpRequestException / SocketException
refused-port run 2: 2055 ms   threw HttpRequestException / SocketException
accepted-but-silent, client timeout 5s:  5023 ms   threw TaskCanceledException / TimeoutException
accepted-but-silent, client timeout 10s: 10003 ms  threw TaskCanceledException / TimeoutException
```

So a refusal and a stall are already separated by the elapsed time and the
exception type. What neither says is which side of Kestrel the stall happened
on.

The fixture now counts requests entering and leaving its pipeline, first in the
pipeline so nothing is missed, and the walk reads the pair either side of each
request that produced no status. The line carries the difference:

```
..., the host pipeline took 1 request(s) and finished 0 while it ran
```

The class can attribute that difference to one request because its facts run one
after the other. Measured rather than assumed, with a second throwaway probe -
three two-second facts of one class, `Total: 3, Time: 6,841s`, and their marks:

```
B start 11:21:34.825
B end   11:21:36.836
A start 11:21:37.532
A end   11:21:39.536
C start 11:21:39.537
C end   11:21:41.546
```

Closes nothing. `#1444` waits on an occurrence, and this changes only what that
occurrence is able to say about itself.

Part of #1444.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: the change is confined to the test suite. It touches no login
path, no crypto, no config persistence and no release pipeline, and it adds no
production code. The three unticked boxes below are unticked because they were
not exercised, not because they passed.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No second reader looked at any of this.**

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

Each of the three properties is proven by breaking it. The build was verified to
have SUCCEEDED before each run, because a mutation that does not compile runs
the previous executable and reports green:

| mutation | result |
| --- | --- |
| drop `{Seen(before, traffic)}` from the no-status line | `TheNoStatusLineSaysWhatTheHostSawWhileTheRequestRan` **FAIL**, alone |
| return a zero pair where there is no host behind the walk | `AWalkWithNoHostBehindItReportsNoCountersRatherThanZeroes` **FAIL**, alone |
| `Interlocked.Add(ref _entered, 0)` instead of `Increment` | `TheHostCountersMoveByOneAcrossOneRealRequest` **FAIL**, alone |

The zero pair is a mutation rather than an omission on purpose: absent is the
honest answer where no host exists, and a pair of zeroes there would read as
"Kestrel never saw it" and mean nothing of the sort.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, 0 warnings under `--warnaserror`, whole output kept per
run rather than filtered to the summary:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3640, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,769s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3641, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,947s
```

No `.js`, `.html`, `.md` or `.css` file is touched, so Prettier has nothing to
say about this change.

## Notes

The means is C# inside the existing xUnit v3 suite: the subject is that suite's
own fixture, every new property is refusable by a unit that already runs on both
target frameworks, and each claim above carries the command that produced it. No
dependency is added.

What this does not do: it names no cause for the run that opened `#1444`, it
reproduces nothing, and it asks for nothing to be closed. The counters are
cumulative over the fixture's lifetime and only their difference across one
request is reported, which is sound here because the facts of the class are
serialized and is the reason the probe above measures that rather than assuming
it.
