### PR TITLE
Name the thread pool in the line a no-status request writes

### DIFF
--- a/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
+++ b/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
@@ -100,6 +100,24 @@ public sealed class AuthorizationProbeTests
     }
 
     [Fact]
+    public async Task TheNoStatusLineNamesTheThreadPoolItFailedUnder()
+    {
+        // A saturated pool produces exactly the fault the host counters report as "took 0": the connection is
+        // accepted and the request never dispatched, and it dies at the client timeout. Measured on this host,
+        // a request under a saturated pool read 63 threads with 229 work items pending against 5 and 0 for one
+        // that answered - while GetAvailableThreads still reported 32735 of 32766 free, which is why the
+        // pending count is the number in the line and the available count is not. Take the reading out and this
+        // goes red, and a red run says the request never reached the pipeline without saying why.
+        var failures = await Walk(
+            Endpoints(1),
+            _ => throw new HttpRequestException("no connection"));
+
+        var line = Assert.Single(failures);
+        Assert.Contains("thread pool ", line, StringComparison.Ordinal);
+        Assert.Contains(" work item(s) pending", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task AWalkWithNoHostBehindItReportsNoCountersRatherThanZeroes()
     {
         // A scripted transport has no host, so a pair of zeroes here would read as "Kestrel never saw it" and

--- a/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
+++ b/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -87,9 +88,12 @@ public static class AuthorizationProbe
                 // reader of a red run needs and cannot reconstruct - which is the evidence #1444 lost.
                 // The host counters are the last thing the elapsed time cannot say: an accepted connection
                 // Kestrel never dispatched and a pipeline that took the request and never answered cost the
-                // same wall clock and are different faults.
+                // same wall clock and are different faults. The thread pool goes with them because a saturated
+                // pool produces the first of those exactly - measured on this host, a request under one was
+                // accepted, never dispatched and died at the client timeout - and ThreadPool.GetAvailableThreads
+                // does not show it, while the pending count does.
                 failures.Add(FormattableString.Invariant(
-                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}{Seen(before, traffic)}"));
+                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}{Seen(before, traffic)}{Pool()}"));
 
                 if (++consecutiveNoStatus >= ConsecutiveNoStatusLimit)
                 {
@@ -110,6 +114,14 @@ public static class AuthorizationProbe
 
         return failures;
     }
+
+    /// <summary>
+    /// Renders the thread pool as it stands at the moment a request produced no status. A pool with work
+    /// queued and no thread free to run it accepts a connection and never dispatches it, which is one of the
+    /// two faults the host counters distinguish and the only one this reading names.
+    /// </summary>
+    private static string Pool() => FormattableString.Invariant(
+        $", thread pool {ThreadPool.ThreadCount} thread(s) with {ThreadPool.PendingWorkItemCount} work item(s) pending");
 
     /// <summary>
     /// Renders what the host saw during ONE request, as the difference between the counters either side of it.


### PR DESCRIPTION
# What & why

#1508 made the walk say whether the host pipeline ever took a request that
produced no status. Where it did not, the line stops at "outside the pipeline"
and the reader has no way on to a cause.

One mechanism produces exactly that state, and I reproduced it on this host with
a throwaway probe that is not in the tree, driving the real fixture at
`5ed42ac3`. Against a saturated thread pool the request was accepted and never
dispatched, and died at the client timeout:

```
  at answer:  ThreadCount=5  PendingWorkItemCount=0
healthy: answered 405 after 89 ms; took 1 finished 1

min worker=32 io=1 available worker=32766 processors=32
queued 256 blockers, available worker now 32735
  at failure: ThreadCount=63 PendingWorkItemCount=229 CompletedWorkItemCount=38
threw TaskCanceledException / TimeoutException after 20333 ms; host pipeline took 0 and finished 0
```

That is the signature the red run on `#1444` left behind - no status, the cost
of a whole client timeout, nothing reaching the pipeline - produced by a named
mechanism rather than by waiting for it to happen again.

The line therefore carries the pool:

```
..., thread pool 63 thread(s) with 229 work item(s) pending
```

**The pending count and not the available count**, which is the half worth
reading carefully. While 229 work items sat queued,
`ThreadPool.GetAvailableThreads` still reported 32735 of 32766 free. A reader
checking the obvious counter would conclude the pool was healthy, which is
exactly how this mechanism stays invisible.

This reproduces the SIGNATURE, not the run. Nothing here says a starved pool is
what happened, no cause is named, and nothing is asked to be closed.

Part of #1444.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: the change is confined to the test suite, adds no production
code, and touches no login path, crypto, config persistence or release pipeline.
The boxes below are unticked because they were not exercised, not because they
passed.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No second reader looked at any of this.**

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

Proven by breaking it, with the build verified to have SUCCEEDED before the run
because a mutation that does not compile runs the previous executable and
reports green:

| mutation | result |
| --- | --- |
| drop `{Pool()}` from the no-status line | `TheNoStatusLineNamesTheThreadPoolItFailedUnder` **FAIL**, alone (9 tests, 1 failed) |

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3641, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,209s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3642, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 29,312s
```

0 warnings under `--warnaserror` on both target frameworks. No `.js`, `.html`,
`.md` or `.css` file is touched, so Prettier has nothing to say about this
change.

## Notes

The means is C# inside the existing xUnit v3 suite, for the reason #1508 gives:
the subject is that suite's own walk, the property is refusable by a unit
running on both target frameworks, and no dependency is added.

What is deliberately NOT here: no attempt to prevent the stall. Raising the
pool's minimum thread count from the fixture would open a process-wide door for
the whole suite, and nothing measured here says the run on `#1444` was a starved
pool rather than something else that produces the same state. Reporting it is
what the evidence supports; preventing it is a decision with a cost, and it is
not taken in this change.
