### PR TITLE
The roadmap names the rung the tree is on (#822)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,17 +6,24 @@ README and in the plugin's configuration page.
 
 ## Where it stands
 
-**Current stage: Beta** - the third rung of the ladder.
+**Current stage: Release Candidate** - the fourth rung of the ladder.
 
 ```
-○ In-Development  →  ○ Alpha  →  ● Beta  →  ○ Release Candidate  →  ○ Full Release
-                                 ▲ you are here
+○ In-Development  →  ○ Alpha  →  ○ Beta  →  ● Release Candidate  →  ○ Full Release
+                                                  ▲ you are here
 ```
 
-Beta means feature-complete and interface-stable: work is limited to bug fixes
-and hardening, and no new breaking change lands without a documented migration
-path. Wider testing on real but non-critical instances is encouraged; as with
-any auth change, keep a config backup.
+The build is frozen and treated as production-ready: only a release-blocking
+defect pulls a change in, and everything else waits for the next cycle.
+Cautious production trials are in scope on instances with a rollback plan; as
+with any auth change, keep a config backup.
+
+The four Beta→RC gates were met with their evidence on 2026-07-24 and the flip
+was made in the README status line and the plugin’s configuration page. This
+page kept saying Beta until 2026-09-04, so a reader arriving from either of
+those two places was told two different rungs. The promotion record lives in
+the P8 epic rather than in a sentence somebody has to remember to move, and
+this page now names the rung that record put the tree on.
 
 ## The maturity ladder
 
@@ -51,7 +58,7 @@ surface is not yet complete and breaking changes are still possible.
   - user-facing documentation complete for every shipped feature;
   - no open High or Critical security finding.
 
-### 3. Beta - _current_
+### 3. Beta
 
 Feature-complete and interface-stable. Work is limited to bug fixes and
 hardening; no new breaking change lands without a documented migration path.
@@ -77,7 +84,7 @@ hardening; no new breaking change lands without a documented migration path.
   all boxes are checked with their evidence** - the promotion is an auditable
   record, never a judgement call.
 
-### 4. Release Candidate
+### 4. Release Candidate - _current_
 
 _This is the deliberate name for the stage between Beta and Full Release - a
 frozen, production-ready candidate awaiting confirmation in the field, rather


### PR DESCRIPTION
`docs/ROADMAP.md` is the page that defines what the maturity labels in the README and in the plugin's configuration page mean, and it was the one place still saying the tree is on the third rung:

```
**Current stage: Beta** - the third rung of the ladder.
○ In-Development  →  ○ Alpha  →  ● Beta  →  ○ Release Candidate  →  ○ Full Release
### 3. Beta - _current_
```

against the README's `**Status: Release Candidate**, the fourth rung` and the configuration page's *"at the Release Candidate stage of its maturity ladder"*. The four Beta→RC gates were met with their evidence on 2026-07-24 (#716), the flip was made in those two places, and this page was not moved with them, so a reader who came here to learn what the label means was told a different rung than the label said.

The marker, the ladder diagram, the paragraph under it and the section heading now name Release Candidate, and the paragraph says what that rung *is* rather than repeating the Beta text: the build is frozen, only a release-blocking defect pulls a change in, cautious production trials with a rollback plan are in scope. The correction points at the promotion record for what moved the tree, so the next stage change is made where the evidence is rather than in a sentence somebody has to remember.

Read after the change: `Current stage: Release Candidate`, the filled circle on the fourth rung, `### 4. Release Candidate - _current_`, and no other file in the tree claims a current stage.

Part of #822's consistency line: status and version references agreeing across README, wiki, CHANGELOG and build.yaml.
