### PR TITLE
Retry a request the host never took instead of reddening the guard

### DIFF
--- a/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
+++ b/SSO-Auth.Tests/Http/AuthorizationProbeTests.cs
@@ -28,6 +28,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// The transport is scripted rather than a real host on purpose: a request that produces no status is the
 /// subject, and there is no way to make a live loopback server reliably not answer.
 /// </para>
+///
+/// <para>
+/// They also pin the repair that issue asks for: a red result from those five tests should mean the endpoints
+/// lost their attributes and nothing else, so a request the host pipeline never took is retried within a
+/// budget rather than reddening a guard it never reached, while one the pipeline took and did not finish stays
+/// red at the first occurrence.
+/// </para>
 /// </summary>
 public sealed class AuthorizationProbeTests
 {
@@ -196,6 +203,123 @@ public sealed class AuthorizationProbeTests
         Assert.Empty(failures);
     }
 
+    [Fact]
+    public async Task ARequestTheHostNeverTookIsRetriedAndTheAnswerIsWhatCounts()
+    {
+        // The repair #1444 asks for. The authorization stage cannot answer with NO status - an endpoint that
+        // lost its attribute answers with the wrong one - so a request the counters place before the dispatch
+        // reddens these five tests for a fault of the harness. Measured on this host, a saturated pool produces
+        // exactly that: accepted, never dispatched, dead at the client timeout. Take the retry out and this
+        // goes red with a no-status line for an endpoint that answered 401 the moment it was asked again.
+        var driven = 0;
+
+        var report = await Report(
+            Endpoints(1),
+            _ => ++driven == 1
+                ? throw new HttpRequestException("no connection")
+                : new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            traffic: () => (11L, 11L));
+
+        Assert.Equal(2, driven);
+        Assert.Empty(report.Failures);
+        var note = Assert.Single(report.Notes);
+        Assert.Contains("answered 401 on retry 1", note, StringComparison.Ordinal);
+        Assert.Contains("GET /e0 [RequiresElevation] (A0)", note, StringComparison.Ordinal);
+        Assert.Contains(" work item(s) pending", note, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ARetriedRequestThatAnswersWrongIsStillAFailure()
+    {
+        // The retry must not become an escape. It buys the endpoint another chance to ANSWER; what it answers
+        // is judged exactly as before, so a guard that admits an unauthenticated caller cannot be rescued by
+        // having stalled first.
+        var driven = 0;
+
+        var report = await Report(
+            Endpoints(1),
+            _ => ++driven == 1
+                ? throw new HttpRequestException("no connection")
+                : new HttpResponseMessage(HttpStatusCode.OK),
+            traffic: () => (11L, 11L));
+
+        Assert.Equal("GET /e0 [RequiresElevation] (A0) -> 200", Assert.Single(report.Failures));
+        Assert.Single(report.Notes);
+    }
+
+    [Fact]
+    public async Task ARequestTheHostTookAndDidNotFinishIsReportedAtOnce()
+    {
+        // The other side of the same reading, and the reason the retry is granted on evidence rather than on
+        // the exception type. A pipeline that TOOK the request and never answered is the endpoint hanging,
+        // which is a real fault and must stay red at the first occurrence. Retry it and this goes red at two
+        // attempts for a fault that asking again cannot change.
+        var entered = 4L;
+        var driven = 0;
+
+        var report = await Report(
+            Endpoints(1),
+            _ =>
+            {
+                driven++;
+                entered++;
+                throw new HttpRequestException("no connection");
+            },
+            traffic: () => (entered, 4L));
+
+        Assert.Equal(1, driven);
+        var line = Assert.Single(report.Failures);
+        Assert.Contains("the host pipeline took 1 request(s) and finished 0 while it ran", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("retried", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NoCountersMeansNoRetry()
+    {
+        // Fail closed where the question cannot be asked. Without the host's counters nothing separates a stall
+        // in front of the dispatch from an endpoint that hung inside it, and retrying on the exception type
+        // alone would quietly re-ask a request that a real fault killed.
+        var driven = 0;
+
+        var report = await Report(
+            Endpoints(1),
+            _ =>
+            {
+                driven++;
+                throw new HttpRequestException("no connection");
+            });
+
+        Assert.Equal(1, driven);
+        Assert.DoesNotContain("retried", Assert.Single(report.Failures), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheRetryBudgetIsSpentOnceForTheWholeWalk()
+    {
+        // The bound the retry is bought with, and it is per WALK rather than per endpoint. A walk in which
+        // every request dies before the dispatch is not something a retry rescues, and at the fixture's
+        // 30-second timeout an allowance per endpoint would multiply the worst case by three. So the first
+        // endpoint spends the budget, and the two after it are failed on their first attempt.
+        var driven = 0;
+
+        var report = await Report(
+            Endpoints(3),
+            _ =>
+            {
+                driven++;
+                throw new HttpRequestException("no connection");
+            },
+            traffic: () => (11L, 11L));
+
+        Assert.Equal(AuthorizationProbe.NoStatusRetryBudget + 3, driven);
+        Assert.Contains("retried 2 time(s) because the host pipeline never took the request", report.Failures[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("retried", report.Failures[1], StringComparison.Ordinal);
+        Assert.Equal(
+            "stopped after 3 consecutive requests that produced no status, leaving 0 of 3 endpoints undriven",
+            report.Failures[^1]);
+        Assert.Empty(report.Notes);
+    }
+
     private static bool IsOdd(string path) => (path[^1] - '0') % 2 == 1;
 
     private static string N(int i) => i.ToString(CultureInfo.InvariantCulture);
@@ -206,6 +330,15 @@ public sealed class AuthorizationProbeTests
             .ToList();
 
     private static async Task<IReadOnlyList<string>> Walk(
+        IReadOnlyList<GatedEndpoint> endpoints,
+        Func<HttpRequestMessage, HttpResponseMessage> answer,
+        string? role = null,
+        Func<(long Entered, long Completed)>? traffic = null)
+    {
+        return (await Report(endpoints, answer, role, traffic)).Failures;
+    }
+
+    private static async Task<ProbeReport> Report(
         IReadOnlyList<GatedEndpoint> endpoints,
         Func<HttpRequestMessage, HttpResponseMessage> answer,
         string? role = null,

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -185,10 +185,19 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The walk itself lives in AuthorizationProbe so a red run reports EVERY endpoint's outcome rather
         // than stopping at the first request that produced no status (#1444). What the assertion needs from
         // it is only the list; the host counters go with it so a no-status line says whether the host ever
-        // saw that request.
-        var failures = await AuthorizationProbe.CollectFailuresAsync(
+        // saw that request, and so that a request the host never took is retried rather than reddening a
+        // guard it never reached.
+        var report = await AuthorizationProbe.CollectFailuresAsync(
             _fixture.Client, endpoints, role, expected, () => _fixture.Traffic).ConfigureAwait(false);
 
-        Assert.True(failures.Count == 0, $"{because}, but these did not: {string.Join("; ", failures)}");
+        // A stall that the retry survived leaves the assertion green, so this line is the only place the run
+        // says it happened at all. It is a warning rather than a failure because the endpoint answered, and
+        // the alternative - dropping it - is how the evidence was lost in the first place.
+        foreach (var note in report.Notes)
+        {
+            TestContext.Current.AddWarning(note);
+        }
+
+        Assert.True(report.Failures.Count == 0, $"{because}, but these did not: {string.Join("; ", report.Failures)}");
     }
 }

--- a/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
+++ b/SSO-Auth.Tests/_Support/AuthorizationProbe.cs
@@ -12,6 +12,20 @@ using System.Threading.Tasks;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
+/// What one walk of a gated endpoint set produced: the endpoints that did not meet the expectation, and the
+/// stalls that were survived rather than failed on.
+/// </summary>
+/// <param name="Failures">
+/// One line per endpoint whose outcome did not satisfy the expectation. Empty means the walk met it everywhere.
+/// </param>
+/// <param name="Notes">
+/// One line per request that produced no status and answered on a retry. These are not failures - the endpoint
+/// answered - but a run in which one happened is not the same run as one in which none did, and a green result
+/// that says nothing about it destroys the only trace.
+/// </param>
+public sealed record ProbeReport(IReadOnlyList<string> Failures, IReadOnlyList<string> Notes);
+
+/// <summary>
 /// Drives one caller across a gated endpoint set and collects, per endpoint, whatever did not meet the
 /// expectation - an unexpected status, or no status at all.
 ///
@@ -31,6 +45,18 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// rather than total is deliberate - an isolated failure between answered requests is the case worth walking
 /// to the end, since its neighbours are what prove the host was alive around it.
 /// </para>
+///
+/// <para>
+/// A request the host pipeline NEVER TOOK is retried rather than failed on, within
+/// <see cref="NoStatusRetryBudget"/> for the whole walk (#1444). The authorization stage cannot produce that
+/// outcome: an endpoint that lost its attribute answers with the wrong STATUS, and every reading in which the
+/// guard answered wrongly leaves at least one of the five tests green, which is the elimination recorded on
+/// that issue. So a no-status result the counters place before the dispatch is the harness failing, and a run
+/// reddened by it says something about this machine rather than about the endpoints. The retry is granted only
+/// on that evidence: where the pipeline TOOK the request and did not finish it the endpoint itself hung and
+/// the walk reports it at once, and where no counters are available nothing separates the two, so nothing is
+/// retried.
+/// </para>
 /// </summary>
 public static class AuthorizationProbe
 {
@@ -41,9 +67,23 @@ public static class AuthorizationProbe
     public const int ConsecutiveNoStatusLimit = 3;
 
     /// <summary>
+    /// The number of retries the WHOLE walk may spend on requests the host pipeline never took. A budget for
+    /// the walk rather than an allowance per endpoint: the fault this covers is an isolated stall, and a walk
+    /// whose every request dies before the dispatch is not something a retry rescues - paying a client timeout
+    /// per endpoint for it is exactly the cost <see cref="ConsecutiveNoStatusLimit"/> exists to bound.
+    /// </summary>
+    public const int NoStatusRetryBudget = 2;
+
+    /// <summary>
+    /// The pause before a retry. The pool that produced the stall is drained by work items completing rather
+    /// than by asking again immediately, and it is short enough that spending the whole budget costs a second.
+    /// </summary>
+    private static readonly TimeSpan RetryBackoff = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
     /// Sends one request per endpoint as <paramref name="role"/> and returns one line for each endpoint whose
-    /// outcome did not satisfy <paramref name="expected"/>. An empty result means every endpoint answered as
-    /// expected.
+    /// outcome did not satisfy <paramref name="expected"/>. An empty failure list means every endpoint answered
+    /// as expected.
     /// </summary>
     /// <param name="client">The client bound to the running fixture host.</param>
     /// <param name="endpoints">The endpoints to drive, in order.</param>
@@ -51,10 +91,11 @@ public static class AuthorizationProbe
     /// <param name="expected">The predicate the returned status has to satisfy.</param>
     /// <param name="traffic">
     /// Reads the host's entered/completed request counters, or <c>null</c> where no host is being driven. It is
-    /// read either side of each request that produces no status, and the difference goes into that line.
+    /// read either side of each request that produces no status, and the difference goes into that line and
+    /// decides whether the request is retried.
     /// </param>
-    /// <returns>The failure lines, in the order the endpoints were driven.</returns>
-    public static async Task<IReadOnlyList<string>> CollectFailuresAsync(
+    /// <returns>The failures and the survived stalls, in the order the endpoints were driven.</returns>
+    public static async Task<ProbeReport> CollectFailuresAsync(
         HttpClient client,
         IReadOnlyList<GatedEndpoint> endpoints,
         string? role,
@@ -66,54 +107,91 @@ public static class AuthorizationProbe
         ArgumentNullException.ThrowIfNull(expected);
 
         var failures = new List<string>();
+        var notes = new List<string>();
         var consecutiveNoStatus = 0;
+        var retriesLeft = NoStatusRetryBudget;
 
         for (var i = 0; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
-            var before = traffic?.Invoke();
-            var elapsed = Stopwatch.StartNew();
-            int status;
+            var status = -1;
+            var retried = 0;
+            var lastNoStatus = string.Empty;
 
-            try
+            while (true)
             {
-                using var response = await SendAsync(client, endpoint, role).ConfigureAwait(false);
-                status = (int)response.StatusCode;
-            }
-            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-            {
-                // A request that never produced a status carries none of that in its own text: the transport
-                // exception names an address and, on a non-English host, says so in that host's language.
-                // The endpoint, the caller, the elapsed time and the bound that was in force are what the
-                // reader of a red run needs and cannot reconstruct - which is the evidence #1444 lost.
-                // The host counters are the last thing the elapsed time cannot say: an accepted connection
-                // Kestrel never dispatched and a pipeline that took the request and never answered cost the
-                // same wall clock and are different faults. The thread pool goes with them because a saturated
-                // pool produces the first of those exactly - measured on this host, a request under one was
-                // accepted, never dispatched and died at the client timeout - and ThreadPool.GetAvailableThreads
-                // does not show it, while the pending count does.
-                failures.Add(FormattableString.Invariant(
-                    $"the request produced no status: {endpoint} as {role ?? "an unauthenticated caller"} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}{Seen(before, traffic)}{Pool()}"));
+                var before = traffic?.Invoke();
+                var elapsed = Stopwatch.StartNew();
 
-                if (++consecutiveNoStatus >= ConsecutiveNoStatusLimit)
+                try
                 {
-                    failures.Add(FormattableString.Invariant(
-                        $"stopped after {ConsecutiveNoStatusLimit} consecutive requests that produced no status, leaving {endpoints.Count - i - 1} of {endpoints.Count} endpoints undriven"));
+                    using var response = await SendAsync(client, endpoint, role).ConfigureAwait(false);
+                    status = (int)response.StatusCode;
                     break;
+                }
+                catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+                {
+                    // A request that never produced a status carries none of that in its own text: the transport
+                    // exception names an address and, on a non-English host, says so in that host's language.
+                    // The endpoint, the caller, the elapsed time and the bound that was in force are what the
+                    // reader of a red run needs and cannot reconstruct - which is the evidence #1444 lost.
+                    // The host counters are the last thing the elapsed time cannot say: an accepted connection
+                    // Kestrel never dispatched and a pipeline that took the request and never answered cost the
+                    // same wall clock and are different faults. The thread pool goes with them because a
+                    // saturated pool produces the first of those exactly - measured on this host, a request
+                    // under one was accepted, never dispatched and died at the client timeout - and
+                    // ThreadPool.GetAvailableThreads does not show it, while the pending count does.
+                    var after = traffic?.Invoke();
+                    lastNoStatus = FormattableString.Invariant(
+                        $"the request produced no status: {endpoint} as {Caller(role)} after {elapsed.ElapsedMilliseconds} ms, client timeout {client.Timeout}, {ex.GetType().Name}: {ex.Message}{Seen(before, after)}{Pool()}");
+
+                    if (Entered(before, after) == 0 && retriesLeft > 0)
+                    {
+                        retriesLeft--;
+                        retried++;
+                        await Task.Delay(RetryBackoff).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    break;
+                }
+            }
+
+            if (status >= 0)
+            {
+                consecutiveNoStatus = 0;
+
+                if (retried > 0)
+                {
+                    notes.Add(FormattableString.Invariant(
+                        $"a request produced no status and answered {status} on retry {retried}: {endpoint} as {Caller(role)}, the host pipeline having taken none of the {retried} failed attempt(s){Pool()}"));
+                }
+
+                if (!expected(status))
+                {
+                    failures.Add(FormattableString.Invariant($"{endpoint} -> {status}"));
                 }
 
                 continue;
             }
 
-            consecutiveNoStatus = 0;
-            if (!expected(status))
+            failures.Add(retried == 0
+                ? lastNoStatus
+                : FormattableString.Invariant($"{lastNoStatus}, retried {retried} time(s) because the host pipeline never took the request"));
+
+            if (++consecutiveNoStatus >= ConsecutiveNoStatusLimit)
             {
-                failures.Add(FormattableString.Invariant($"{endpoint} -> {status}"));
+                failures.Add(FormattableString.Invariant(
+                    $"stopped after {ConsecutiveNoStatusLimit} consecutive requests that produced no status, leaving {endpoints.Count - i - 1} of {endpoints.Count} endpoints undriven"));
+                break;
             }
         }
 
-        return failures;
+        return new ProbeReport(failures, notes);
     }
+
+    /// <summary>How a caller is named in a line, so the unauthenticated one reads as a caller rather than as nothing.</summary>
+    private static string Caller(string? role) => role ?? "an unauthenticated caller";
 
     /// <summary>
     /// Renders the thread pool as it stands at the moment a request produced no status. A pool with work
@@ -124,20 +202,27 @@ public static class AuthorizationProbe
         $", thread pool {ThreadPool.ThreadCount} thread(s) with {ThreadPool.PendingWorkItemCount} work item(s) pending");
 
     /// <summary>
+    /// How many requests the host pipeline took while the failed request ran, or <c>null</c> where no host is
+    /// being driven and the question cannot be asked. Zero is the reading that separates a stall in front of
+    /// the dispatch from an endpoint that hung inside it.
+    /// </summary>
+    private static long? Entered((long Entered, long Completed)? before, (long Entered, long Completed)? after)
+        => before is null || after is null ? null : after.Value.Entered - before.Value.Entered;
+
+    /// <summary>
     /// Renders what the host saw during ONE request, as the difference between the counters either side of it.
     /// Empty where no host is being driven, so a scripted transport reports nothing rather than zeroes it cannot
     /// know the meaning of.
     /// </summary>
-    private static string Seen((long Entered, long Completed)? before, Func<(long Entered, long Completed)>? traffic)
+    private static string Seen((long Entered, long Completed)? before, (long Entered, long Completed)? after)
     {
-        if (before is null || traffic is null)
+        if (before is null || after is null)
         {
             return string.Empty;
         }
 
-        var after = traffic();
         return FormattableString.Invariant(
-            $", the host pipeline took {after.Entered - before.Value.Entered} request(s) and finished {after.Completed - before.Value.Completed} while it ran");
+            $", the host pipeline took {after.Value.Entered - before.Value.Entered} request(s) and finished {after.Value.Completed - before.Value.Completed} while it ran");
     }
 
     private static async Task<HttpResponseMessage> SendAsync(HttpClient client, GatedEndpoint endpoint, string? role)


### PR DESCRIPTION
# What & why

Closes #1444.

One `net10.0` run of the suite went red in the five authorization-conformance
tests without the tree changing, and those five are the ones asserting that no
unauthenticated or non-administrator caller reaches an authenticated or
elevation endpoint. #1444 carries the whole reading: the excess wall clock puts
at least one request on the far side of the accept, and the signature was then
reproduced deliberately on the real fixture by saturating the thread pool - the
client's wait expires while the request is still queued and the host never sees
it.

The Done-when asks for a red result from those five to mean the endpoints lost
their attributes and nothing else. This is that repair.

**The authorization stage cannot answer with no status at all.** An endpoint
that lost its attribute answers with the WRONG STATUS, and #1444 records the
elimination: every reading in which the guard answered wrongly but consistently
leaves at least one of the five green, and all five were red. So a no-status
result that the host counters place BEFORE the dispatch is the harness failing,
and the walk now retries it within a budget rather than failing on it.

**The retry is granted on evidence, never on the exception type.** Where the
pipeline TOOK the request and did not finish it, the endpoint itself hung, which
is a real fault and stays red at the first occurrence. Where no counters are
available nothing separates the two, so nothing is retried - fail closed.

**The budget is per WALK, not per endpoint.** The fault it covers is an isolated
stall; a walk whose every request dies before the dispatch is not something a
retry rescues, and an allowance per endpoint would multiply the worst case by
three at the fixture's 30-second client timeout.

**A survived stall is not silently dropped.** It becomes a warning on the test,
naming the endpoint, the attempt it answered on, and the pool it failed under,
so a green run still says it happened. The lead judgement on #1444 asks that
whatever lands keeps a red run able to say which of the two faults it was by
itself; the counters #1508 added do that for a failure, and this line does it
for a recovery.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable in the sense the section means: no production file is touched.
The diff is three files under `SSO-Auth.Tests/`, and `git diff --stat` against
the base names no other path. The guard being proven is unchanged - what changes
is what the proof does when the machine underneath it stalls.

The one direction that would be a real weakening is a retry that rescues a wrong
answer, and it is refused by a unit rather than by this sentence:
`ARetriedRequestThatAnswersWrongIsStillAFailure` drives a stall followed by a
200 where a 401 is required and expects the failure to stand.

## Quality checklist

- [x] No duplicated logic; the retry lives in the one walk every one of the five
      tests already goes through.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass; this change establishes no new
      structural property.
- [x] Docs impact considered: no README or wiki surface describes the test
      harness, so nothing there moves.

## Verification

- [x] `dotnet build --warnaserror` green with 0 warnings on both target
      frameworks, `--no-incremental` on `net9.0` to be sure the analyzers ran.
- [x] `dotnet test` green on both.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

Whole output kept per run rather than filtered to the summary, which is what
#1444 asks every run of this suite to do from now on:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q --no-incremental
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3646, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 61,720s
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3647, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 47,293s
```

Four skipped on each: the tests binding a listener off loopback, which needs an
administrator on this host (#1227) and is disclosed rather than worked around.

## Each part broken, and what reddens

Five units are added and none of them is asserted to pass in place of being
proven. Each break was made on the tree above, run, and reverted before the
next.

| break | what reddens |
| --- | --- |
| the retry removed (`if (false && …)`) | `ARequestTheHostNeverTookIsRetriedAndTheAnswerIsWhatCounts`, `ARetriedRequestThatAnswersWrongIsStillAFailure`, `TheRetryBudgetIsSpentOnceForTheWholeWalk` |
| the retry granted without reading the counters (`if (retriesLeft > 0)`) | `NoCountersMeansNoRetry`, `ARequestTheHostTookAndDidNotFinishIsReportedAtOnce`, and three that were already there: `ATransportFailureDoesNotStopTheWalk`, `ConsecutiveTransportFailuresStopTheWalkAndSayWhatWasLeftUndriven`, `AWalkWithNoHostBehindItReportsNoCountersRatherThanZeroes` |
| the budget reset per endpoint | `TheRetryBudgetIsSpentOnceForTheWholeWalk` |

```
   SSO-Auth.Tests  Total: 14, Errors: 0, Failed: 3, Skipped: 0, Not Run: 0, Time: 0,398s    # break 1
   SSO-Auth.Tests  Total: 14, Errors: 0, Failed: 5, Skipped: 0, Not Run: 0, Time: 11,429s   # break 2
   SSO-Auth.Tests  Total: 14, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0, Time: 4,351s    # break 3
```

The second break is the interesting one: retrying on the exception type alone
also breaks three properties that were already proven, because the walk's
continuation and its consecutive bound both count attempts. That is the reason
the condition reads the counters rather than the exception.

## Notes

**What this does NOT do.** It does not prevent the stall. Preventing it means
raising the thread pool's minimum thread count from a test fixture, which is a
process-wide door for the whole suite, taken against a mechanism that has been
shown capable of the signature and never shown to have caused the run of
2026-08-27. #1444 leaves that decision open and this change does not take it.

It also does not reproduce the original run. Nothing here claims the 2026-08-27
failure was a starved pool; what it claims is that a request the host never took
says nothing about the endpoint it was aimed at, which is true whichever fault
produced it.

**The residual.** A walk in which the pipeline never takes the request three
times over is still red, and it must be: at that point the harness is not
stalling, it is not working. Such a run now carries the retry count, the pool
reading and the counters in its own text, so it names itself rather than needing
a probe nobody committed.

**Base.** `4.4`, the default branch for the length of the 4.3 soak. #1444 is
judged on the issue as a harness fault rather than a release-blocking defect, so
nothing here is proposed for the stable line.

No second reader looked at this.
