### PR TITLE
Pin the four refusal messages the migration pages quote, in full

### DIFF
--- a/SSO-Auth.Tests/Config/LinkImportTests.cs
+++ b/SSO-Auth.Tests/Config/LinkImportTests.cs
@@ -32,6 +32,20 @@ public class LinkImportTests
     private static readonly Guid TargetBob = Guid.Parse("7a19e700-0000-0000-0000-00000000000b");
     private static readonly Guid TargetMallory = Guid.Parse("7a19e700-0000-0000-0000-00000000000c");
 
+    // The four refusal messages `docs/SERVER-MIGRATION.md` and `docs/ACCOUNT-MANAGEMENT-API.md` quote to an
+    // operator, held here in full rather than as the prefixes these assertions carried before #1514. The tail
+    // is the half that tells the operator what to do: `; unlink it first` is the instruction, and `for that
+    // protocol on this instance` is what separates a provider that is missing from one that is named
+    // differently. Nothing outside those two pages held those tails, so editing one left the build, the suite
+    // and every gate green while both pages went on quoting a sentence the plugin no longer emits.
+    private const string NoSuchProvider =
+        "no provider of that name is configured for that protocol on this instance";
+    private const string NoSuchAccount = "no Jellyfin account is named 'nobody' on this instance";
+    private const string AlreadyLinkedElsewhere =
+        "this instance already links that identity to a different account; unlink it first";
+    private const string AlreadyBoundToAnotherIssuer =
+        "this instance already binds that link to a different issuer; unlink it first";
+
     [Fact]
     public void ExportOnOneServer_ImportsOntoAnother_ReboundToTheTargetsOwnIds()
     {
@@ -114,7 +128,7 @@ public class LinkImportTests
         var refusal = Assert.Throws<ArgumentException>(() =>
             LinkImport.Apply(target, Document(Entry("OpenID", "some-other-idp", "sub-alice", "alice")), TargetDirectory));
 
-        Assert.Contains("no provider of that name is configured", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(NoSuchProvider, refusal.Message, StringComparison.Ordinal);
         AssertNoLinksWereWritten(target);
     }
 
@@ -142,7 +156,7 @@ public class LinkImportTests
         var refusal = Assert.Throws<ArgumentException>(() =>
             LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "nobody")), TargetDirectory));
 
-        Assert.Contains("no Jellyfin account is named 'nobody'", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(NoSuchAccount, refusal.Message, StringComparison.Ordinal);
         AssertNoLinksWereWritten(target);
     }
 
@@ -158,7 +172,7 @@ public class LinkImportTests
         var refusal = Assert.Throws<ArgumentException>(() =>
             LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "alice")), TargetDirectory));
 
-        Assert.Contains("already links that identity to a different account", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(AlreadyLinkedElsewhere, refusal.Message, StringComparison.Ordinal);
         Assert.Equal(TargetMallory, target.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
     }
 
@@ -177,7 +191,7 @@ public class LinkImportTests
             Document(Entry("OpenID", "idp", "sub-alice", "alice", "https://forged.example.test")),
             TargetDirectory));
 
-        Assert.Contains("binds that link to a different issuer", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(AlreadyBoundToAnotherIssuer, refusal.Message, StringComparison.Ordinal);
         Assert.Equal("https://idp.example.test", target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"]);
     }
 
@@ -283,7 +297,7 @@ public class LinkImportTests
         var refusal = Assert.Throws<ArgumentException>(() =>
             LinkImport.Apply(target, Document(Entry("OpenID", "broken", "sub-alice", "alice")), TargetDirectory));
 
-        Assert.Contains("no provider of that name is configured", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains(NoSuchProvider, refusal.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
# What & why

`docs/SERVER-MIGRATION.md` and `docs/ACCOUNT-MANAGEMENT-API.md` reproduce four of `LinkImport`'s refusal messages and send an operator looking for that exact sentence. The suite asserted each of the four only up to a prefix, and the remainder of every one of them was asserted nowhere in the tree:

```
$ for s in "for that protocol on this instance" "unlink it first" "on this instance"; do
    printf 'hits=%s  %s\n' "$(grep -rc -F -- "$s" SSO-Auth.Tests/ | awk -F: '{s+=$NF} END{print s+0}')" "$s"
  done
hits=0  for that protocol on this instance
hits=0  unlink it first
hits=0  on this instance
```

So editing the tail of any of the four left the build, the suite and every gate green while both pages went on quoting a sentence the plugin no longer emits. The tail is the half that tells the operator what to do: `; unlink it first` is the instruction, and `for that protocol on this instance` is what separates a provider that is missing from one that is named differently, which is the distinction the migration page sends a reader to that message for.

The four literals move into named constants and the five assertion sites compare against them, so each message has one spelling in the tests instead of two prefixes of it. Nothing under `SSO-Auth/` changes: a message edited to fit an assertion would be the defect rather than the fix.

Base is `4.4` rather than `main`, which is frozen for the 4.3 soak (#1511) and is not the default branch while the clock runs.

Closes #1514

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, and stated rather than ticked. The diff is one test file. It changes no login path, no SAML or OIDC validation, no config persistence and no release pipeline, so the section's own precondition is not met and no security review was run for it.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the last two: the conformance tests run inside the full suite below and are green; this change establishes no new structural property, so it locks in no new rule. It needs no documentation update either - the two pages already carry these sentences correctly, character for character, which is what this change makes them able to keep.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, 0 warnings under `--warnaserror`, and the full suite on each:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
  build succeeded, 0 warnings, 0 errors
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
  build succeeded, 0 warnings, 0 errors

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3646, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 40,979s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3647, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 43,415s
```

Prettier: the diff contains no `.js`, `.html`, `.md`, `.css` or `.scss` file, so there is nothing for it to judge here.

### The proof that the assertions bite, in both directions

The near-miss is the mistake somebody actually makes: editing the end of a message. Each tail was mutated in `SSO-Auth/Config/LinkImport.cs` alone, and every mutation was run twice - once against the assertions this pull request installs, and once against the assertions exactly as they stood before it, so the second column is what the change bought rather than a restatement of the first.

| tail mutated                                                     | new assertions | assertions before |
| ---------------------------------------------------------------- | -------------- | ----------------- |
| `for that protocol on this instance` to `... on this server`     | 2 failed       | 0 failed          |
| `'{Username}' on this instance` to `... on this server`           | 1 failed       | 0 failed          |
| `to a different account; unlink it first` to `; remove it first` | 1 failed       | 0 failed          |
| `to a different issuer; unlink it first` to `; remove it first`  | 1 failed       | 0 failed          |

The first row fails two tests because `NoSuchProvider` is asserted at two sites. Every mutation was checked to have compiled before its run was read, because a mutation that fails to build re-runs the previous binary and reports green - that trap is what makes an unread build exit an invisible false pass.

The four literals were then read against each other across `SSO-Auth/Config/LinkImport.cs`, `docs/SERVER-MIGRATION.md`, `docs/ACCOUNT-MANAGEMENT-API.md` and the tests, and all four agree. The account message is quoted with a placeholder for the username on both pages, and the test pins the interpolated form the fixture produces plus the ` on this instance` tail, which is the part that was free before.

## Notes

**No second reader.** Nobody but me has read this diff. The board's checks run on GitHub and are the gate here; the mutation table above is offered in place of a second pair of eyes, not as equivalent to one.

How it was found: re-resolving every citation on `docs/SERVER-MIGRATION.md` against the tree while reading #1135. Every other citation on that page resolves - the member names, the five route templates, the two settings-page blocks, the `[JsonIgnore]` on both link maps, and the anchors into `docs/ACCOUNT-MANAGEMENT-API.md`. This is the one thing that came back short, and it is the same class as #1424 one step earlier: that issue repaired citations after they had drifted, this one stops a documented literal being free to drift at all.

Out of scope, deliberately: #1135's Done clause, which asks for these messages quoted from a run against a scratch server rebuild rather than from the source. This change does not touch it and does not shorten it. `docs/SERVER-MIGRATION.md` still says in its own second paragraph that the procedure has not been walked, and that admission stays.
