### PR TITLE
Make the posted link backup arrive with its entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,20 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **Restoring an account-link backup restored nothing, and said it had worked
+  (#1517).** `POST /sso/Config/Links/Import`, and the **Import Account Links**
+  button that posts to it, accepted the file the matching export produces,
+  answered success and wrote no link at all: the document arrived with its
+  entries dropped, because the property holding them could not be assigned by
+  the serializer the host binds a request body with. The version check ran, so
+  a wrong file was still refused; only the payload was silently lost. An
+  operator who migrated or rebuilt a server on any beta from `4.3.0-beta.43`
+  has an empty link table and no sign of it, and every account that signed in
+  through SSO is unlinked - **re-run the import after upgrading**, and read the
+  audit line it writes: it names how many links were rebound, and said 0. The
+  four refusals both operator pages quote were unreachable for the same reason
+  and answer again.
+
 - **The OpenID provider API stored a post-logout return URL the configuration
   page would have refused (#1504).** `OID/Add` writes the provider it is given
   without the configuration save's checks, and the check that a post-logout

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RequestBody.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RequestBody.cs
@@ -146,6 +146,53 @@ internal static class Whatever
         Assert.False(HoldsASecondBodyRead(Source));
     }
 
+    /// <summary>
+    /// Every property of a type the host binds from a request body must be assignable by that binder
+    /// (#1517). A property the binder cannot set is not an error and not a warning: System.Text.Json skips
+    /// it and hands the action a document with that member missing, so the endpoint acts on less than was
+    /// posted and answers as though it acted on all of it.
+    /// <para>
+    /// This is the rule the account-link restore was missing. `LinkExportDocument.Links` was a get-only
+    /// collection, the whole payload was dropped, and `POST /sso/Config/Links/Import` answered 204 while
+    /// restoring nothing - a migration that looked complete and left every account unlinked. Nothing
+    /// caught it because every test of the importer built its document in process; the boundary the
+    /// operator posts across was crossed by no test at all.
+    /// </para>
+    /// <para>
+    /// A source scan decides this, like its neighbour above, rather than an assertion about the
+    /// formatter: the test process does not load the System.Text.Json the plugin binds in production. What
+    /// is checked is a fact about this tree - the reflected shape of the bound types - and it holds
+    /// whichever serializer the host brings, because no serializer can assign a property with no setter.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void RequestBodyTypes_HaveNoPropertyTheBinderCannotAssign()
+    {
+        var unassignable = RequestBodyTypes()
+            .SelectMany(type => type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => property.GetMethod is not null && property.SetMethod is null)
+                .Select(property => $"{type.Name}.{property.Name}"))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Empty(unassignable);
+
+        // Vacuous-pass guard: a scan that found no bound type would be empty for the wrong reason.
+        Assert.NotEmpty(RequestBodyTypes());
+    }
+
+    // The types the controller binds from a request body, deduplicated. Primitives are excluded: a
+    // [FromBody] string has no properties to drop and is bound whole.
+    private static IReadOnlyList<Type> RequestBodyTypes() =>
+        typeof(Jellyfin.Plugin.SSO_Auth.Api.Http.SSOController)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .SelectMany(method => method.GetParameters())
+            .Where(parameter => parameter.GetCustomAttribute<FromBodyAttribute>() is not null)
+            .Select(parameter => parameter.ParameterType)
+            .Where(type => type.IsClass && type != typeof(string))
+            .Distinct()
+            .OrderBy(type => type.FullName, StringComparer.Ordinal)
+            .ToList();
     // Whether a source text reaches a request body outside the host's binder, on a code line.
     private static bool HoldsASecondBodyRead(string source) =>
         SecondBodyReadSpellings.Any(spelling => SourceCallsInCode(source, spelling));

--- a/SSO-Auth.Tests/Config/LinkExportDocumentJsonTests.cs
+++ b/SSO-Auth.Tests/Config/LinkExportDocumentJsonTests.cs
@@ -19,6 +19,17 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// turns the restore into a success that restores nothing: HTTP 204, an audit line reading `0 link(s)
 /// rebound`, and an empty link table on a server whose administrator has just been told the migration
 /// worked. Silence is the whole danger here, so the property is pinned where the bytes are.
+///
+/// <para>
+/// WHAT THIS BOUNDARY IS NOT is the endpoint's, and the difference is measured rather than assumed.
+/// These cases deserialize with <c>JsonDefaults.Options</c>, which is where Jellyfin declares its
+/// serializer defaults; the MVC input formatter the endpoint is actually bound by is configured FROM
+/// those and is not identical to them. A member spelled <c>links</c> binds nothing here and binds fine at
+/// the endpoint, read off a running 10.11.11 with this build installed - so the formatter is
+/// case-insensitive where these options are not. The property below survives that difference, because a
+/// property no serializer can assign is dropped by every one of them, and the endpoint behaviour itself
+/// was verified against a real server rather than inferred from here.
+/// </para>
 /// </summary>
 public class LinkExportDocumentJsonTests
 {

--- a/SSO-Auth.Tests/Config/LinkExportDocumentJsonTests.cs
+++ b/SSO-Auth.Tests/Config/LinkExportDocumentJsonTests.cs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Text.Json;
+using Jellyfin.Extensions.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The account-link backup crosses a JSON boundary that no other test in this suite crosses. Every
+/// <see cref="LinkImportTests"/> case hands <c>LinkImport.Apply</c> a document built in process, so the
+/// importer's refusals are all proven against an object that never went over the wire - while the endpoint
+/// an operator actually posts to receives one that did, bound by the host's serializer.
+///
+/// The two are not the same document. A get-only collection property is dropped by System.Text.Json, which
+/// turns the restore into a success that restores nothing: HTTP 204, an audit line reading `0 link(s)
+/// rebound`, and an empty link table on a server whose administrator has just been told the migration
+/// worked. Silence is the whole danger here, so the property is pinned where the bytes are.
+/// </summary>
+public class LinkExportDocumentJsonTests
+{
+    private static readonly Guid SourceBob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+    private static readonly Guid TargetBob = Guid.Parse("7a19e700-0000-0000-0000-00000000000b");
+
+    /// <summary>
+    /// The whole migration in one property: export on the source, send it as JSON exactly as the endpoint
+    /// receives it, and restore on the target. Deleting the creation-handling attribute on
+    /// <c>LinkExportDocument.Links</c> makes this fail with zero restored links.
+    /// </summary>
+    [Fact]
+    public void ExportedDocument_SurvivesTheJsonBoundary_AndStillRestores()
+    {
+        var json = JsonSerializer.Serialize(LinkExport.Build(Source(), id => id == SourceBob ? "bob" : null), JsonDefaults.Options);
+
+        var received = JsonSerializer.Deserialize<LinkExportDocument>(json, JsonDefaults.Options);
+
+        Assert.NotNull(received);
+        Assert.Single(received!.Links);
+
+        var target = Target();
+        LinkImport.Apply(target, received, username => username == "bob" ? TargetBob : null);
+
+        Assert.Equal(TargetBob, target.OidConfigs["idp"].CanonicalLinks["sub-bob"]);
+    }
+
+    /// <summary>
+    /// The refusals the operator documentation quotes are reachable only if the entries arrive. Before the
+    /// fix this posted document produced HTTP 204 rather than the refusal, because the entry naming an
+    /// account this instance does not hold was dropped before the importer ever saw it.
+    /// </summary>
+    [Fact]
+    public void EntryNamingAnUnknownAccount_StillRefuses_AfterTheJsonBoundary()
+    {
+        const string Json = """
+            {"FormatVersion":1,"Links":[{"Protocol":"OpenID","Provider":"idp","CanonicalName":"sub-bob","Username":"nobody"}]}
+            """;
+
+        var received = JsonSerializer.Deserialize<LinkExportDocument>(Json, JsonDefaults.Options);
+
+        var refusal = Assert.Throws<ArgumentException>(() => LinkImport.Apply(Target(), received!, _ => null));
+        Assert.Contains("no Jellyfin account is named 'nobody' on this instance", refusal.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A posted <c>"Links": null</c> means what an omitted member has always meant - nothing to restore -
+    /// and never a null reference reaching the importer. The read-only shape with creation handling could
+    /// not express this: System.Text.Json cannot assign null to a property it may only populate, and the
+    /// throw escapes the input formatter as a 500, past the endpoint's own null check and rate limiter.
+    /// </summary>
+    [Fact]
+    public void NullLinksMember_BindsToAnEmptyDocument_RatherThanThrowing()
+    {
+        var received = JsonSerializer.Deserialize<LinkExportDocument>("""{"FormatVersion":1,"Links":null}""", JsonDefaults.Options);
+
+        Assert.NotNull(received);
+        Assert.Empty(received!.Links);
+    }
+
+    /// <summary>
+    /// A repeated member takes the LAST one, which is what `jq`, `JSON.parse` and every other reader an
+    /// operator inspects a backup file with do. Populating a read-only collection appends instead, so what
+    /// the operator reads and what the server applies would differ on a file carrying a hidden first array.
+    /// </summary>
+    [Fact]
+    public void RepeatedLinksMember_TakesTheLastOne_AsEveryJsonReaderDoes()
+    {
+        const string Json = """
+            {"FormatVersion":1,"Links":[{"Protocol":"OpenID","Provider":"idp","CanonicalName":"hidden","Username":"admin"}],"Links":[{"Protocol":"OpenID","Provider":"idp","CanonicalName":"sub-bob","Username":"bob"}]}
+            """;
+
+        var received = JsonSerializer.Deserialize<LinkExportDocument>(Json, JsonDefaults.Options);
+
+        var only = Assert.Single(received!.Links);
+        Assert.Equal("sub-bob", only.CanonicalName);
+    }
+
+    private static PluginConfiguration Source()
+    {
+        var configuration = new PluginConfiguration();
+        var provider = new OidConfig { Enabled = true, OidEndpoint = "https://idp.example.test" };
+        provider.CanonicalLinks["sub-bob"] = SourceBob;
+        configuration.OidConfigs["idp"] = provider;
+        return configuration;
+    }
+
+    private static PluginConfiguration Target()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["idp"] = new OidConfig { Enabled = true, OidEndpoint = "https://idp.example.test" };
+        return configuration;
+    }
+}

--- a/SSO-Auth/Config/LinkExportDocument.cs
+++ b/SSO-Auth/Config/LinkExportDocument.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
@@ -22,6 +23,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// </remarks>
 public class LinkExportDocument
 {
+    private Collection<LinkExportEntry> _links = new();
+
     /// <summary>
     /// Gets or sets the document format version. It is its own sequence, independent of
     /// <see cref="ConfigExport.FormatVersion"/>, because the two documents change shape for unrelated
@@ -30,11 +33,34 @@ public class LinkExportDocument
     public int FormatVersion { get; set; }
 
     /// <summary>
-    /// Gets the exported links, one entry per canonical link across every provider of both protocols. A
-    /// link whose Jellyfin user id no longer resolves to an account is absent rather than exported with a
-    /// blank username, so the document never carries an entry nothing could be restored to.
+    /// Gets or sets the exported links, one entry per canonical link across every provider of both
+    /// protocols. A link whose Jellyfin user id no longer resolves to an account is absent rather than
+    /// exported with a blank username, so the document never carries an entry nothing could be restored to.
+    /// <para>
+    /// THE SETTER IS LOAD-BEARING AND REMOVING IT BREAKS THE RESTORE SILENTLY. System.Text.Json - which is
+    /// what the host binds a posted body with - ignores a property it cannot set, and this one is posted:
+    /// with a get-only collection here the import received an EMPTY link list, restored nothing, answered
+    /// 204 and audited <c>0 link(s) rebound</c> at an administrator who had just been told the migration
+    /// worked. <c>FormatVersion</c> binds either way, so the document was parsed and version-checked while
+    /// only the payload was dropped. Found by walking <c>docs/SERVER-MIGRATION.md</c> against a scratch
+    /// server rebuild (#1135), pinned by <c>SSO-Auth.Tests/Config/LinkExportDocumentJsonTests.cs</c>.
+    /// </para>
+    /// <para>
+    /// The setter coalesces null rather than storing it, because a posted <c>"Links": null</c> must not
+    /// reach the importer as a null reference. It leaves such a document meaning what a document omitting
+    /// the member has always meant - no links to restore - instead of a 500. The creation-handling
+    /// attribute that would keep the property read-only was rejected for the same reason: it cannot assign
+    /// null and throws out of model binding, past the null check and the rate limiter both, and it makes
+    /// repeated <c>Links</c> members APPEND where every JSON reader an operator inspects the file with
+    /// takes the last one - a difference between what they read and what the server applies.
+    /// </para>
     /// </summary>
-    public Collection<LinkExportEntry> Links { get; } = new();
+    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "JSON transport shape: the deserializer must be able to assign this property, and a read-only one is silently dropped by System.Text.Json. See the remarks above.")]
+    public Collection<LinkExportEntry> Links
+    {
+        get => _links;
+        set => _links = value ?? new Collection<LinkExportEntry>();
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
# What & why

`POST /sso/Config/Links/Import` accepted the exact document `GET /sso/Config/Links/Export` produces, answered **204**, audited **`0 link(s) rebound`** and restored nothing. `LinkExportDocument.Links` had no setter, and System.Text.Json - which the host binds a request body with - ignores a property it cannot set. `FormatVersion` is settable and binds, so the document was parsed and version-checked while only the payload was dropped: a migration that looked complete and left every SSO account unlinked. The four refusal messages `docs/SERVER-MIGRATION.md` and `docs/ACCOUNT-MANAGEMENT-API.md` quote sit behind those entries, so none of them was reachable over HTTP either.

Found by walking `docs/SERVER-MIGRATION.md` end to end against a scratch server rebuild, which is what #1135 asks for. The walk did not get past step 4.

Closes #1517

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The change reaches the importer's
      refusals rather than altering them; all four were read back from a run.
- [x] No secrets logged; secrets are redacted on config export. Verified on the
      walk: after step 3 the provider secret is `ssoenc:v1:` at rest and the
      export carries none.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      6 / PLAUSIBLE 0** as raised.

  **Round 1, against the first shape** (a read-only property under
  `JsonObjectCreationHandling.Populate`), both lenses NEEDS_IMPROVEMENT:

  - _bypass_ - (1) `"Links": null` becomes an unhandled **500**: `Populate`
    cannot assign null and throws `InvalidOperationException`, which the input
    formatter does not convert, so it escapes past the endpoint's own null check
    and its rate limiter. **FIX.** (2) a repeated `Links` member **appends**
    where every JSON reader an operator inspects the file with takes the last
    one, so what they read and what the server applies differ. **FIX.** (3) no
    entry-count bound beyond the 1 MiB request cap. **DEFER (#1522).** (4) the
    documented 400 literal for a null body is unreachable because
    `[ApiController]` answers first - pre-existing. **DEFER (#1520).**
  - _availability_ - (1) the same 500. **FIX.** (2) the import stamps an
    operator-supplied issuer that nothing validates, and a mismatch refuses
    every login for that link with no self-heal, where the no-op self-healed.
    **DEFER (#1518)** - changing stamping semantics is a login-path decision of
    its own and not this bug's topic. (3) the page's rollback claim is false: a
    wrong-file import wedges the migration and there is no bulk unlink. **DEFER
    (#1519).** (4) `MutateConfiguration` mutates the live object before it
    persists, so a persist failure leaves memory ahead of disk - shared with
    `ConfigImport`. **DEFER (#1521).** (5) `PropertyNameCaseInsensitive=False`,
    so a hand-mixed `"links"` still binds nothing. **DEFER (#1520).**

  Both fixes were made and both lenses re-run against the fixed state: **PASS**
  and **PASS**, each having re-measured the two behaviours through a real MVC
  pipeline seeded with the host's `JsonDefaults` options, on both target ABIs
  (`PreferredObjectCreationHandling = Replace` on `jellyfin.extensions` 10.11.11
  and 12.0.0-rc2, so the setter is the production path).

  One thing this body said and a later reading refuted: the four tests were
  described as crossing the boundary "with the options the host binds with", and
  they do not, quite. Under `JsonDefaults.Options` a member spelled `links`
  yields 0 entries and `Links` yields 1; posted at the endpoint on a running
  10.11.11 carrying this build, a fully lower-cased document restores its link,
  so the MVC formatter is case-insensitive where those options are not. The
  property the tests pin survives it - a property no serializer can assign is
  dropped by every one of them - and the endpoint behaviour was read off a real
  server rather than inferred. The correction is in the tests' own comment, in a
  second commit, because the first is pushed and a rewrite is not available.

- [x] Log inputs from the IdP are sanitized inline at the log call. Untouched;
      the `ReplaceLineEndings` at the two emission points was effectively dead
      before this fix and is now live.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture. The
      remarks at the property say why the setter is load-bearing and why the
      read-only alternative was rejected, because deleting it breaks the
      restore silently.
- [x] Architecture-conformance tests pass, and the new structural property is
      locked in: `RequestBodyTypes_HaveNoPropertyTheBinderCannotAssign` walks
      every type the controller binds from a body and refuses a property the
      binder cannot assign. Reverting the property to its old shape makes it
      fail naming `LinkExportDocument.Links`.
- [x] Docs impact considered. `CHANGELOG.md` carries what an operator who
      already migrated on an affected beta has to do. The runbook's own "not
      walked end to end yet" paragraph is #1135's to retire and follows there.

## Verification

- [x] `dotnet build --warnaserror` is green - **0 warnings** on `net9.0` and
      `net10.0`.
- [x] `dotnet test` is green - **3651** passing on `net9.0`, **3652** on
      `net10.0`, 4 environment skips on each, 0 failures.
- [x] Prettier is clean for the one `.md` this touches (`CHANGELOG.md`).

The guard bites, per part and for the reason it names:

| delete this                          | what goes red                                                        |
| ------------------------------------ | -------------------------------------------------------------------- |
| the setter (back to `{ get; }`)      | the round trip restores nothing; the refusal test throws no refusal; the conformance rule names `LinkExportDocument.Links` |
| the `?? new(...)` in the setter      | the null-member test dereferences null                               |

And the end-to-end walk, on a fresh Jellyfin 10.11.11 with this build installed:

```
== STEP 4  import the account links last ==
POST /sso/Config/Links/Import  HTTP 204
the target's own link export afterwards: {"FormatVersion":1,"Links":[{...},{...}]}
[SSO Audit] Account-link backup restored by migadmin: 2 link(s) rebound to this
instance's accounts, with no identity-provider response redeemed. Per provider:
OpenID 'probe': 2.
```

against the same request on the soak candidate 4.3.0.61, with the same two
prerequisites satisfied:

```
POST /sso/Config/Links/Import  HTTP 204
the target's own link export afterwards: {"FormatVersion":1,"Links":[]}
[SSO Audit] ... 0 link(s) rebound ... Per provider: .
```

## Notes

**This targets `4.4`, and `4.3.0-stable` ships the defect unless somebody decides otherwise.** `main` is frozen for the 14-day soak on #1511 and `4.4` is the default branch for its length, so this is the branch the work belongs on. Landing it on `main` instead would restart the soak clock, which #1511 reserves to the promotion; the trade is that the first stable release documents a migration runbook whose decisive step does not work. #1517 is assigned so that call is held rather than assumed.

Every finding not fixed here is deferred to its own issue rather than dropped: #1518 (the unvalidated issuer stamp), #1519 (the false rollback claim and the missing bulk unlink), #1520 (a restore that restored nothing answers exactly like one that restored everything, and the unreachable documented literal beside it), #1521 (a failed persist leaves the live configuration ahead of the file), #1522 (nothing bounds the entry count). None is caused by this change. #1518 is made REACHABLE by it, and both lenses judged shipping the binding fix and deferring the semantics the safer ordering, because the unfixed state is a silent no-op that is strictly worse for a migrating administrator.

There was no second human reader for this change. The two review lenses above are the evidence in place of one, and their round-1 findings and dispositions are written out rather than summarised.
