### PR TITLE
Replace the runbook's untested admission with the run that replaced it

### DIFF
--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -24,11 +24,20 @@ moves with the code it names; a number does not. So there is no number on this
 page meant to be exact, because there are none, and a citation that stops
 resolving is a defect worth reporting.
 
-**Not walked end to end yet.** Everything below is read out of the source files
-cited beside each claim, at the commit this page last changed on. The procedure
-has not been followed against a scratch server rebuild, and the failure messages
-are quoted from the code rather than from a run. Issue #1135 stays open for
-exactly that, and until it is closed this page is derived rather than tested.
+**Walked end to end, and the walk changed the plugin.** The procedure below was
+followed against a scratch server rebuild - a fresh Jellyfin 10.11.11 on an empty
+configuration directory, the accounts recreated, both files imported - and every
+refusal quoted on this page was read back from that run rather than from the
+source. It is tested rather than derived, and #1135 records the run.
+
+**It did not pass the first time, and step 4 does not work on any build published
+so far.** On every beta from `4.3.0-beta.43` to `4.3.0-beta.61` the link import
+answers 204 and restores nothing: the posted document reaches the importer with
+its entries dropped, so the step that completes a migration is a no-op that
+reports completion, and none of the refusals below is reachable at all. A server
+migrated on one of those builds has an empty link table and was never told. That
+is #1517, whose fix is #1523 and is waiting to land on the 4.4 line; when a release
+carrying it is out, running step 4 again with the same file restores the links.
 
 ## The two files, and why there are two
 
@@ -171,7 +180,20 @@ are what say whether what came back matches the file that was applied.
 
 ## Rolling back
 
-Both imports are atomic, so a refused one leaves nothing to undo. After a
-successful one, the way back is the pair of files taken from the old server:
-re-importing them reproduces the same state, because neither import writes
-anything the documents do not name.
+A refused import leaves nothing to undo. Both resolve the whole document before
+they write, and the walk confirmed it in both directions: after each of the four
+refusals the target's own link export was identical to what it held before.
+
+After a SUCCESSFUL one there is less of a way back than this page used to claim,
+and the difference matters most on the mistake an operator actually makes -
+importing the wrong file. Re-importing the correct one does not undo it. The link
+import only adds and overwrites, never removes, so the wrong file's entries stay;
+the correct document then hits `this instance already links that identity to a
+different account; unlink it first`, and because the refusal is whole-document,
+one leftover entry blocks the restore of every other link. Unlinking is one call
+per canonical name and the refusal names at most ten entries at a time, by index.
+There is no replace mode and no bulk unlink. #1519 holds that gap.
+
+Re-importing the same file onto the state it produced IS safe, and the walk shows
+it: a second run of a successful import succeeds and changes nothing, because a
+mapping this instance already holds is not a repoint.

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -36,8 +36,9 @@ answers 204 and restores nothing: the posted document reaches the importer with
 its entries dropped, so the step that completes a migration is a no-op that
 reports completion, and none of the refusals below is reachable at all. A server
 migrated on one of those builds has an empty link table and was never told. That
-is #1517, whose fix is #1523 and is waiting to land on the 4.4 line; when a release
-carrying it is out, running step 4 again with the same file restores the links.
+is #1517, whose fix landed on the 4.4 line in #1523 and is not yet in any
+published build; when a release carrying it is out, running step 4 again with
+the same file restores the links.
 
 ## The two files, and why there are two
 


### PR DESCRIPTION
# What & why

`docs/SERVER-MIGRATION.md` opened by admitting nobody had followed it against a scratch server rebuild and that its refusal messages were quoted from the code rather than from a run. That is #1135's Done clause, and the walk has now happened.

It did not pass. Step 4 - the link import, the step the whole page exists for - answered **204** and restored nothing on the soak candidate `4.3.0.61`, with the account and the provider both in place. A migration on any beta from `4.3.0-beta.43` reports success and leaves an empty link table. That is #1517, and its fix is #1523, merged as `00ceecb189b9a115b59f1cb90f18c53a96fa7d73`. The page carries that warning at the top now, where somebody about to migrate meets it.

Re-run against a build carrying the fix, every step works in the page's order and all four refusal literals came back from a terminal. The run is written out on #1135.

Two claims on the page were corrected against the run rather than against the source:

- **Rolling back.** The page promised that re-importing the pair of files reproduces the old state. It does not: the link import adds and overwrites but never removes, so a wrong file's entries survive, the correct document is then refused whole, and one leftover entry blocks every other link from coming back. Unlinking is one call per identity; there is no bulk route. #1519 holds whether one should exist.
- **Atomicity**, in the other direction: after each of the four refusals the target's own link export was identical to what it held before, so that sentence now says what was measured.

Part of #1135. The wiki's `Server-Migration` page carries the same two corrections in its own voice and is already pushed - `bfa2df521ab94a11d0d20ab3b63088bdbe4d5355`, with `2cc569a` correcting one sentence after #1523 merged - because the wiki has no pull-request gate and the warning is what an operator needs before they migrate rather than after.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: this changes one Markdown page and no code. Nothing here touches the login path, crypto, config persistence or the release pipeline.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. No logic - one page.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in. None; no source changed.
- [x] Docs impact considered: this IS the docs change, and its wiki counterpart
      is named above with its commit.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - unchanged, no source
      in this diff.
- [x] `dotnet test` is green - unchanged, no source in this diff.
- [x] Prettier is clean for the one `.md` this touches.

The wiki page was linted against this checkout before it was pushed:

```
$ py -3 scripts/wiki-lint.py <wiki checkout> <code checkout>
Wiki lint: clean.
```

## Notes

**This closes #1135 together with #1523, which has merged.** The page says step 4 fails on every published build and that the fix has landed without being in a published build yet, which stays true until a release carries it - so it promises no version an operator cannot install.

This targets `4.4`, the default branch for the length of the soak on #1511, like #1523.

There was no second reader for this change.
