### PR TITLE
Run the push-time workflows on the 4.x and 5.x lines as on main (#1530)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "4.*", "5.*" ]
   pull_request:
     branches: [ "**" ]
 

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -14,7 +14,7 @@ name: Repo Invariant Lint (Opengrep)
 
 on:
   push:
-    branches: [main]
+    branches: [main, "4.*", "5.*"]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,7 +2,7 @@ name: Prettier Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "4.*", "5.*" ]
   pull_request:
     branches: [ "**" ]
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ name: Workflow Security Analysis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "4.*", "5.*" ]
   pull_request:
     branches: [ "**" ]
 


### PR DESCRIPTION
# What & why

The ruleset protects `main`, `4.4` and `5.0` alike with the same twelve required checks, but `dotnet.yml`, `prettier.yml`, `zizmor.yml` and `opengrep.yml` ran on push to `main` only, so a merge into `4.4` left its head with six check runs where `main` shows twenty-five. `push.branches` now names `main`, `4.*` and `5.*`, the pattern `codeql.yml` already uses, so every numeric release line is rebuilt after a merge the way `main` is. Closes #1530

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not the login path, not crypto, not config persistence, and not the release pipeline: the four workflows are verification legs, and the publish workflows are untouched. The gate's own audit of workflows (zizmor) runs on this change.

- [x] Fail-closed preserved: nothing here accepts anything; the change adds runs and removes none.
- [x] No secrets logged; no secret is read by the four workflows.
- [ ] A security review was performed: not applicable, see above.
- [ ] Review record: not applicable, see above.
- [ ] Log inputs from the IdP are sanitized inline: not applicable, no IdP input.

## Quality checklist

- [x] No duplicated logic; the four filters take the one pattern `codeql.yml` already carries.
- [x] The change adds no more code than the problem requires: four lines.
- [x] Self-documenting: the filter reads as what it does, and the commit says why.
- [x] Architecture-conformance tests pass; no structural property changes.
- [x] Docs impact considered: no page describes the push filters, so none changes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green: no C# changes; the pull request's own build run is the verification.
- [x] `dotnet test` is green: unchanged, same run.
- [x] Prettier is clean: no `.js` / `.html` / `.md` / `.css` change; the YAML was parsed after the edit and each file's `push.branches` reads `['main', '4.*', '5.*']`.

## Notes

The proof the issue asks for is the first push to `4.4` after this lands: its head shows the build, prettier, zizmor and opengrep runs. I read it there and write it on #1530.
