### PR TITLE
Write the configuration before it goes live, and undo it when the write fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,29 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A configuration write that could not reach the disk was applied anyway
+  (#1521).** Every configuration change - a link import, a configuration
+  import, adding a provider, the canonical link a first login writes - was
+  applied to the running plugin and only then written to the XML. If that write
+  failed, which is what a full disk or a read-only volume produces and what a
+  freshly built migration target can hit, the running server kept the change
+  while the file did not have it: logins behaved as though the import had
+  succeeded until the next restart, and the next unrelated settings save
+  committed it silently, at a moment nobody would connect to the import. Both
+  imports and the operator page promised the opposite - "no step
+  half-applies", "either gets its complete link table back or is left exactly
+  as it was" - and those sentences covered a rejected document but not a
+  refused write. The write now happens first and the change is rolled back out
+  of the running plugin if it fails, so the server goes back to what it had
+  stored. The same applies to the settings page, which previously made the
+  whole posted page live before serializing a byte of it. Retry the import or
+  the save once the disk or the mount is fixed. What this does **not** cover is
+  the write itself: Jellyfin's plugin base class serializes straight over the
+  file with no temporary copy, so a disk that fills mid-write still leaves a
+  truncated one, and an unloadable configuration file is replaced by an empty
+  one on the next start - copy `SSO-Auth.xml` before a migration step and check
+  it after a failed one, before restarting (#1532).
+
 - **Restoring an account-link backup restored nothing, and said it had worked
   (#1517).** `POST /sso/Config/Links/Import`, and the **Import Account Links**
   button that posts to it, accepted the file the matching export produces,

--- a/SSO-Auth.Tests/Config/FailedPersistTests.cs
+++ b/SSO-Auth.Tests/Config/FailedPersistTests.cs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// End-to-end cover for #1521, one level above <see cref="ProviderConfigStoreTests"/>: those exercise the
+/// store against a persist delegate a test wrote, and these run the real one, so what is pinned here is
+/// the whole road to disk - <c>MutateConfiguration</c>, the store, the secret-protection bridge and the
+/// plugin base class - rather than the store's half of it.
+/// <para>
+/// The failure is the one a migration produces and nothing else does: the mutation is valid, the write is
+/// not. Measured on 2026-09-05, <c>BasePlugin&lt;T&gt;.UpdateConfiguration</c> assigns
+/// <c>Configuration</c> BEFORE it serializes, so a write that threw left the plugin running on settings
+/// that are not on disk - the live configuration ahead of the file that both imports promise is atomic.
+/// The plugin now writes through <c>SaveConfiguration</c>, which is the write alone.
+/// </para>
+/// <para>
+/// In the <c>SSOController</c> collection because constructing a plugin sets the static
+/// <see cref="SSOPlugin.Instance"/> every other test in that collection reads.
+/// </para>
+/// </summary>
+[Collection("SSOController")]
+public class FailedPersistTests
+{
+    [Fact]
+    public void AMutationWhoseWriteFails_LeavesTheServerOnTheStoredConfiguration()
+    {
+        var (plugin, xml) = Plugin(stored => stored.OidConfigs["kept"] = new OidConfig { OidClientId = "client-1" });
+        var live = plugin.Configuration;
+        Fail(xml, "read-only volume");
+
+        Assert.Throws<IOException>(() => plugin.MutateConfiguration(configuration =>
+        {
+            configuration.OidConfigs["arrived"] = new OidConfig();
+            configuration.OidConfigs["kept"].OidClientId = "overwritten";
+        }));
+
+        // Nothing reached the XML, so nothing may be live: an operator who reads the 500 and retries
+        // must not be logging in against a provider table only this process knows about, and the next
+        // unrelated save must not commit it for them.
+        Assert.False(plugin.Configuration.OidConfigs.ContainsKey("arrived"));
+        Assert.Equal("client-1", plugin.Configuration.OidConfigs["kept"].OidClientId);
+
+        // And it is still the same configuration object, which is what every reader in the plugin holds.
+        Assert.Same(live, plugin.Configuration);
+    }
+
+    [Fact]
+    public void AMutationWhoseWriteSucceeds_TakesEffect()
+    {
+        // The positive control: the guard above bites on a failed write and on nothing else. Without
+        // this, a plugin that discarded every mutation would satisfy the test above.
+        var (plugin, _) = Plugin(_ => { });
+        var live = plugin.Configuration;
+
+        plugin.MutateConfiguration(configuration => configuration.OidConfigs["arrived"] = new OidConfig { OidClientId = "client-2" });
+
+        Assert.Equal("client-2", plugin.Configuration.OidConfigs["arrived"].OidClientId);
+        Assert.Same(live, plugin.Configuration);
+    }
+
+    [Fact]
+    public void AConfigPageSaveWhoseWriteFails_LeavesTheServerOnTheStoredConfiguration()
+    {
+        // The config-page save enters through the override rather than through Mutate, and it broke the
+        // same promise more loudly: the posted configuration became live before the serializer was ever
+        // called, so a full disk left the whole settings page applied to a server that had not stored a
+        // byte of it.
+        var (plugin, xml) = Plugin(stored => stored.OidConfigs["kept"] = new OidConfig { OidClientId = "client-1" });
+        Fail(xml, "no space left on device");
+
+        var posted = new PluginConfiguration();
+        posted.OidConfigs["kept"] = new OidConfig { OidClientId = "posted" };
+        posted.DisablePasswordLogin = true;
+
+        Assert.Throws<IOException>(() => plugin.UpdateConfiguration(posted));
+
+        Assert.Equal("client-1", plugin.Configuration.OidConfigs["kept"].OidClientId);
+        Assert.False(plugin.Configuration.DisablePasswordLogin);
+    }
+
+    [Fact]
+    public void AConfigPageSaveWhoseWriteSucceeds_TakesEffect()
+    {
+        var (plugin, _) = Plugin(stored => stored.OidConfigs["kept"] = new OidConfig { OidClientId = "client-1" });
+        var live = plugin.Configuration;
+
+        var posted = new PluginConfiguration();
+        posted.OidConfigs["kept"] = new OidConfig { OidClientId = "posted" };
+
+        plugin.UpdateConfiguration(posted);
+
+        Assert.Equal("posted", plugin.Configuration.OidConfigs["kept"].OidClientId);
+        Assert.Same(live, plugin.Configuration);
+    }
+
+    [Fact]
+    public void ConfigurationChanged_IsRaisedByAWriteThatReturned_AndByNothingElse()
+    {
+        // The base-class update this plugin replaced raised this event as part of persisting, so the
+        // replacement owes it too - and owes it only where the state is durable. A subscriber that
+        // learned of a change the disk refused would push it on to whoever it notifies.
+        var (plugin, xml) = Plugin(_ => { });
+        var raised = 0;
+        plugin.ConfigurationChanged += (_, _) => raised++;
+
+        plugin.MutateConfiguration(configuration => configuration.EnableSingleLogout = true);
+        Assert.Equal(1, raised);
+
+        Fail(xml, "read-only volume");
+        Assert.Throws<IOException>(() => plugin.MutateConfiguration(configuration => configuration.EnableSingleLogout = false));
+        Assert.Equal(1, raised);
+    }
+
+    [Fact]
+    public void AConfigurationChangedSubscriberThatThrows_CannotUndoTheWriteItIsBeingToldAbout()
+    {
+        // The event is raised from inside the store's persist delegate, and the store rolls a write back
+        // on ANY exception out of that delegate. So a subscriber that throws would have reverted the live
+        // configuration away from a file that already has the change - the exact divergence #1521 exists
+        // to abolish, arriving through the fix for it. ConfigurationChanged is a public settable property
+        // on the base class, so who subscribes is not a closed set.
+        var (plugin, _) = Plugin(_ => { });
+        plugin.ConfigurationChanged += (_, _) => throw new InvalidOperationException("a subscriber failed");
+
+        plugin.MutateConfiguration(configuration => configuration.EnableSingleLogout = true);
+
+        Assert.True(plugin.Configuration.EnableSingleLogout);
+    }
+
+    [Fact]
+    public void AConfigurationChangedSubscriber_SeesTheSavedConfiguration_NotThePreviousOne()
+    {
+        // The base-class update assigned before it raised, so a subscriber that re-reads the plugin saw
+        // the new state. Writing the file first moved the raise after the write; the adoption has to move
+        // with it, or a caching subscriber refreshes itself from the configuration that was just replaced.
+        var (plugin, _) = Plugin(stored => stored.OidConfigs["kept"] = new OidConfig { OidClientId = "client-1" });
+        string? seen = null;
+        plugin.ConfigurationChanged += (_, _) => seen = plugin.ReadConfiguration(c => c.OidConfigs["kept"].OidClientId);
+
+        var posted = new PluginConfiguration();
+        posted.OidConfigs["kept"] = new OidConfig { OidClientId = "posted" };
+        plugin.UpdateConfiguration(posted);
+
+        Assert.Equal("posted", seen);
+    }
+
+    private static (SSOPlugin Plugin, IXmlSerializer Xml) Plugin(Action<PluginConfiguration> stored)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sso-persist-" + Guid.NewGuid());
+        var appPaths = Substitute.For<IApplicationPaths>();
+        appPaths.PluginConfigurationsPath.Returns(root);
+        appPaths.PluginsPath.Returns(Path.Combine(root, "plugins"));
+
+        var configuration = new PluginConfiguration();
+        stored(configuration);
+
+        var xml = Substitute.For<IXmlSerializer>();
+        xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(configuration);
+
+        var plugin = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
+        _ = plugin.Configuration; // load it before the serializer is told to fail
+        return (plugin, xml);
+    }
+
+    // Turns the write half of the mocked serializer into the failure a full disk or a read-only volume
+    // produces. The read half keeps working, which is what makes this a WRITE failure rather than a
+    // plugin that could never load.
+    private static void Fail(IXmlSerializer xml, string reason) =>
+        xml.When(x => x.SerializeToFile(Arg.Any<object>(), Arg.Any<string>())).Do(_ => throw new IOException(reason));
+}

--- a/SSO-Auth.Tests/Config/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigStoreTests.cs
@@ -3,7 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
@@ -286,5 +290,269 @@ public class ProviderConfigStoreTests
         Assert.Throws<ArgumentNullException>(() => store.Read<bool>(null!));
         Assert.Throws<ArgumentNullException>(() => store.Mutate(null!));
         Assert.Throws<ArgumentNullException>(() => store.Mutate<bool>(null!));
+    }
+
+    [Fact]
+    public void Mutate_PersistThrows_LeavesTheLiveConfigurationExactlyAsItWas()
+    {
+        // #1521: the failure the promise was false for. MutateConfiguration's own remarks and the
+        // operator page both say a refused import leaves the server exactly as it was; that was true
+        // for a mutation that threw and false for a PERSIST that threw - a full disk, a read-only
+        // volume, exactly the conditions a freshly built migration target hits. The live object kept
+        // every change while nothing reached the XML, so logins behaved as though the import had
+        // succeeded until the process restarted, and the next unrelated save committed the changes
+        // silently. Delete the rollback in Mutate and this test reads "hijacked" back out of the live
+        // configuration.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1" };
+        var store = new ProviderConfigStore(() => live, _ => throw new IOException("read-only volume"), new CapturingLogger());
+
+        // What a restart would load out of the file, which is the state the rollback owes rather than
+        // "the object as it stood": a round trip through the persisted form normalizes a null role-map
+        // list to an empty one, so the live object and the file it came from are not byte-identical to
+        // begin with. The equality below is therefore against the file's content, not against the
+        // object's history - and without the rollback it reads "hijacked" and fails either way.
+        var onDisk = live.DetachedCopy().ToPersistedForm();
+
+        Assert.Throws<IOException>(() => store.Mutate(c =>
+        {
+            c.OidConfigs["idp"].OidClientId = "hijacked";
+            c.OidConfigs["second"] = new OidConfig();
+            c.DisablePasswordLogin = true;
+        }));
+
+        Assert.Equal(onDisk, live.ToPersistedForm());
+        Assert.Equal("client-1", live.OidConfigs["idp"].OidClientId);
+        Assert.False(live.OidConfigs.ContainsKey("second"));
+        Assert.False(live.DisablePasswordLogin);
+    }
+
+    [Fact]
+    public void Mutate_WithResult_PersistThrows_LeavesTheLiveConfigurationExactlyAsItWas()
+    {
+        // The result-returning overload is the one the removal endpoints and the link import use, so it
+        // carries the same obligation: a removal that could not be written down did not happen.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig();
+        var store = new ProviderConfigStore(() => live, _ => throw new IOException("no space left on device"), new CapturingLogger());
+        var onDisk = live.DetachedCopy().ToPersistedForm();
+
+        Assert.Throws<IOException>(() => store.Mutate(c => c.OidConfigs.Remove("idp")));
+
+        Assert.Equal(onDisk, live.ToPersistedForm());
+        Assert.True(live.OidConfigs.ContainsKey("idp"));
+    }
+
+    [Fact]
+    public void Mutate_PersistThrows_RollsBackWithoutSwappingTheLiveObject()
+    {
+        // The rollback restores the live configuration IN PLACE, and this is the half of that which is
+        // load-bearing: the store hands the SAME configuration object out on every read, so a rollback
+        // that swapped the reference would leave every holder of a read - the plugin's own
+        // Configuration property among them - pointing at an object the store had abandoned.
+        //
+        // How far it reaches is stated rather than implied. The provider objects UNDER the
+        // configuration are replaced by the restored ones, so a caller that took a reference to a
+        // provider before this mutation keeps an object carrying the rejected values. That caller is
+        // receiving this exception rather than carrying on, and the live configuration - which is what
+        // the next login reads - is correct.
+        var live = new PluginConfiguration();
+        var provider = new OidConfig { OidClientId = "client-1" };
+        live.OidConfigs["idp"] = provider;
+        var store = new ProviderConfigStore(() => live, _ => throw new IOException("read-only volume"), new CapturingLogger());
+
+        Assert.Throws<IOException>(() => store.Mutate(c => c.OidConfigs["idp"].OidClientId = "hijacked"));
+
+        Assert.Same(live, store.Read(c => c));
+        Assert.Equal("client-1", live.OidConfigs["idp"].OidClientId);
+        Assert.NotSame(provider, live.OidConfigs["idp"]);
+        Assert.Equal("hijacked", provider.OidClientId);
+    }
+
+    [Fact]
+    public void Mutate_PersistReturns_KeepsTheChange()
+    {
+        // The positive control the three above need: the rollback fires on a failed write and on
+        // nothing else. Without it, a Mutate that rolled back every time would pass all three.
+        var (store, live, persisted) = CreateStore();
+
+        store.Mutate(c => c.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1" });
+
+        Assert.Equal("client-1", live.OidConfigs["idp"].OidClientId);
+        Assert.Same(live, Assert.Single(persisted));
+    }
+
+    [Fact]
+    public void Save_PersistThrows_LeavesTheLiveConfigurationExactlyAsItWas()
+    {
+        // The config-page save carries the same promise and used to break it in a louder way: the base
+        // class made the posted configuration live BEFORE serializing it, so a failed write left the
+        // server running on settings that are not on disk.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1" };
+        var store = new ProviderConfigStore(() => live, _ => throw new IOException("read-only volume"), new CapturingLogger());
+        var onDisk = live.DetachedCopy().ToPersistedForm();
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidClientId = "posted" };
+
+        Assert.Throws<IOException>(() => store.Save(incoming));
+
+        Assert.Equal(onDisk, live.ToPersistedForm());
+        Assert.Equal("client-1", live.OidConfigs["idp"].OidClientId);
+    }
+
+    [Fact]
+    public void Save_PersistThrows_UndoesWhatThePipelineDidToTheLiveObject()
+    {
+        // Why Save needs the rollback even though the posted object is a different one: the pipeline
+        // hands the LIVE logout-session map to the posted configuration (ServerManagedFields.Preserve),
+        // and the real persist delegate encrypts the secrets inside those shared objects in place. A
+        // write that throws after that would leave the live configuration carrying state the file does
+        // not have. Simulated here by a persist that mutates what it was handed and then fails, which is
+        // the shape rather than the encryption itself.
+        var live = new PluginConfiguration();
+        live.LogoutSessions["session"] = new LogoutSession { IdToken = "plaintext" };
+        var onDisk = live.DetachedCopy().ToPersistedForm();
+
+        var store = new ProviderConfigStore(
+            () => live,
+            posted =>
+            {
+                ((PluginConfiguration)posted).LogoutSessions["session"].IdToken = "ssoenc:rewritten";
+                throw new IOException("read-only volume");
+            },
+            new CapturingLogger());
+
+        var incoming = new PluginConfiguration();
+
+        Assert.Throws<IOException>(() => store.Save(incoming));
+
+        Assert.Equal(onDisk, live.ToPersistedForm());
+        Assert.Equal("plaintext", live.LogoutSessions["session"].IdToken);
+    }
+
+    [Fact]
+    public void AdoptFrom_CarriesEveryPersistedField()
+    {
+        // AdoptFrom derives its field set from the type instead of listing it, and this is what makes
+        // that derivation checkable: a property added to the configuration model tomorrow that the
+        // reflection walk does not carry makes these two persisted forms differ, and the rollback above
+        // would otherwise restore a configuration missing that field WITHOUT anything going red.
+        var source = new PluginConfiguration
+        {
+            DisablePasswordLogin = true,
+            EnableSingleLogout = true,
+            ManageLoginPageButtons = true,
+            EnableRateLimit = true,
+            RateLimitMaxAttempts = 7,
+            RateLimitWindowSeconds = 11,
+            BreakGlassAdminUsername = "root",
+        };
+        source.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1", Enabled = true };
+        source.SamlConfigs["saml"] = new SamlConfig { SamlClientId = "sp" };
+        source.ProvisioningProfiles["profile"] = new ProvisioningPolicyTemplate { MaxActiveSessions = 3 };
+        source.SsoOnlyRepointedUserIds.Add(User);
+        source.LogoutSessions["session"] = new LogoutSession();
+
+        var target = new PluginConfiguration();
+        target.AdoptFrom(source);
+
+        Assert.Equal(source.ToPersistedForm(), target.ToPersistedForm());
+    }
+
+    [Fact]
+    public void AdoptFrom_TheSameObject_IsANoOp()
+    {
+        // Save hands the live object to AdoptFrom when a caller posts it back, so self-adoption has to
+        // be harmless rather than a walk that assigns every property to itself.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1" };
+        var before = live.ToPersistedForm();
+
+        live.AdoptFrom(live);
+
+        Assert.Equal(before, live.ToPersistedForm());
+    }
+
+    [Fact]
+    public void Mutate_MutationThrowsHalfWay_LeavesNothingBehind()
+    {
+        // The import endpoints promise their callers that a rejected document changes nothing, and
+        // ConfigImport.Apply writes the provisioning profiles before it merges the providers - so a
+        // throw in the second half used to leave the first half applied in memory with no undo. The
+        // guarded region covers the mutation as well as the write, so it does not any more.
+        var live = new PluginConfiguration();
+        var store = new ProviderConfigStore(() => live, _ => { }, new CapturingLogger());
+        var onDisk = live.DetachedCopy().ToPersistedForm();
+
+        Assert.Throws<InvalidOperationException>(() => store.Mutate(c =>
+        {
+            c.ProvisioningProfiles["guest"] = new ProvisioningPolicyTemplate();
+            throw new InvalidOperationException("the second half refused");
+        }));
+
+        Assert.Equal(onDisk, live.ToPersistedForm());
+        Assert.Empty(live.ProvisioningProfiles);
+    }
+
+    [Fact]
+    public void Mutate_SnapshotCannotBeTaken_StillWrites_AndSaysSo()
+    {
+        // The rollback is bought with a serialization, and that serializer refuses characters that can
+        // reach a canonical-link key: neither LinkImport nor the login-path writer checks for them.
+        // Refusing the write when the snapshot cannot be taken would make a configuration that once
+        // reached this state permanently unwritable - including the DELETE that would repair it - so the
+        // write goes ahead without an undo and the log carries the loss. Fail-open on the rollback,
+        // deliberately, because the alternative is a write outage nothing can clear.
+        // Built rather than written as a literal: a raw control byte in a source file is the kind of
+        // thing an editor, a diff or a normalization step eats without saying so, and this test is
+        // entirely about that byte.
+        var unserializable = "sub" + (char)0x01 + "one";
+
+        var live = new PluginConfiguration();
+        var provider = new OidConfig();
+        live.OidConfigs["idp"] = provider;
+        provider.CanonicalLinks[unserializable] = User;
+        Assert.ThrowsAny<Exception>(() => live.ToPersistedForm()); // the premise, read rather than assumed
+
+        var logger = new CapturingLogger();
+        var persisted = new List<BasePluginConfiguration>();
+        var store = new ProviderConfigStore(() => live, persisted.Add, logger);
+
+        store.Mutate(c => c.OidConfigs["idp"].CanonicalLinks.Remove(unserializable));
+
+        Assert.Single(persisted);
+        Assert.False(live.OidConfigs["idp"].CanonicalLinks.ContainsKey(unserializable));
+        Assert.Contains(logger.Entries, e => e.Message.Contains("without a rollback", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AdoptableSet_CoversEveryFieldTheSerializerPersists()
+    {
+        // The derivation-proof half of AdoptFrom_CarriesEveryPersistedField, which compares only fields a
+        // test remembered to populate. This one asks the SERIALIZER what it persists - every top-level
+        // element it emits - and refuses a name AdoptFrom's rule does not select, so a property added to
+        // the configuration model tomorrow bites here without anybody remembering this test.
+        //
+        // What it does NOT prove is stated rather than implied: the rule is restated here rather than
+        // read out of the production field, which is private. It catches a new PERSISTED property the
+        // rule misses - a get-only collection is the shape that would - and not a change to the rule
+        // itself, which the behavioural tests above are for.
+        var persistedNames = XDocument
+            .Parse(new PluginConfiguration().ToPersistedForm())
+            .Root!
+            .Elements()
+            .Select(element => element.Name.LocalName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var adopted = typeof(PluginConfiguration)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(persistedNames);
+        Assert.Empty(persistedNames.Except(adopted));
     }
 }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -239,6 +239,67 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records that a subscriber to the plugin's <c>ConfigurationChanged</c> event threw (#1521). The write
+    /// it is being told about is already on disk and already live, so the failure is contained here rather
+    /// than unwound: letting it out would reach the store's rollback and revert a durable change. Warning
+    /// rather than Error: whoever subscribed did not get its update, and nothing this plugin owns is wrong.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="error">What the subscriber threw. No configuration content is recorded.</param>
+    internal static void ConfigurationChangedSubscriberFailed(ILogger logger, Exception error)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] A ConfigurationChanged subscriber failed after a completed configuration save ({Reason}). The save itself is stored and live; whatever that subscriber keeps in step with the configuration may not be.",
+            error?.Message?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
+    /// Records that a configuration write went ahead without an undo, because the state it would have
+    /// restored could not be serialized (#1521). The write itself is NOT refused: refusing it would make a
+    /// configuration that once reached this state permanently unwritable, including the delete that would
+    /// repair it. Warning, because the all-or-nothing property the import endpoints promise does not hold
+    /// for this one write and an operator reading a later 500 deserves to find this line above it.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="error">What refused the serialization. No configuration content is recorded.</param>
+    internal static void ConfigurationRollbackUnavailable(ILogger logger, Exception error)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Configuration write proceeding without a rollback: the current configuration could not be serialized for one ({Reason}). If this write fails, the running server keeps the change while the file does not, until the next restart.",
+            error?.Message?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
+    /// Records that a configuration write failed AND the undo for it failed too (#1521), so the running
+    /// server is left carrying a change the file does not have. Error rather than Warning: this is the state
+    /// the rollback exists to prevent, the exception the caller sees names the write rather than this, and a
+    /// restart is what puts the server back on the file.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="error">What the restore threw. No configuration content is recorded.</param>
+    internal static void ConfigurationRollbackFailed(ILogger logger, Exception error)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
+        logger.LogError(
+            "[SSO Audit] Configuration write failed and could not be rolled back ({Reason}): the running server is carrying a change that is not in the file. Restart the server to put it back on the stored configuration.",
+            error?.Message?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
     /// Records a config-page save whose changes to a declaratively managed provider were ignored (#1102). The
     /// provider is decided by the mounted document or the environment, so the stored value was kept and the
     /// posted one discarded. Warning rather than Information: an administrator has just made an edit the

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1766,9 +1766,12 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <remarks>
     /// Fail-closed and atomic. The whole document is validated before a single link is written, and the
-    /// mutation runs inside <c>MutateConfiguration</c>, which persists nothing when the lambda throws, so
-    /// a rebuilt server either gets its complete link table back or is left exactly as it was. A
-    /// half-applied link table is the worst outcome available here, because it looks restored and is not.
+    /// mutation runs inside <c>MutateConfiguration</c>, which persists nothing when the lambda throws and
+    /// rolls the change back out of the live configuration when the WRITE throws (#1521), so a rebuilt
+    /// server either gets its complete link table back or goes back to what it had stored. A
+    /// half-applied link table is the worst outcome available here, because it looks restored and is
+    /// not. The rollback reaches the running server and not the file: the write is the plugin base
+    /// class's and is not atomic, which is #1532.
     /// <para>
     /// The refusal that matters is the repoint: a canonical name this instance already links to a
     /// DIFFERENT account is rejected rather than overwritten, so a crafted backup file cannot remap an

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -32,7 +32,8 @@ internal static class ConfigImport
     /// <summary>
     /// Validates and merges the export document into <paramref name="live"/>. Throws before any mutation on a
     /// document with an unsupported version, an absent payload, or an invalid provider, so the caller's
-    /// <c>MutateConfiguration</c> persists nothing.
+    /// <c>MutateConfiguration</c> persists nothing - and where the merge is valid but the WRITE fails, that
+    /// same caller rolls the merge back out of the live configuration (#1521).
     /// </summary>
     /// <param name="live">The live configuration to merge into (mutated in place).</param>
     /// <param name="document">The import document.</param>

--- a/SSO-Auth/Config/LinkImport.cs
+++ b/SSO-Auth/Config/LinkImport.cs
@@ -29,9 +29,10 @@ internal readonly record struct LinkImportCount(string Protocol, string Provider
 /// <list type="bullet">
 /// <item>Validate first, mutate second. Every entry is checked before a single link is written, and the
 /// first failure rejects the WHOLE document. Called inside <c>MutateConfiguration</c>, which persists only
-/// when the mutation returns without throwing, so a rebuilt server either gets its complete link table
-/// back or is left exactly as it was. A half-applied link table is the worst outcome available here: it
-/// looks restored and silently is not.</item>
+/// when the mutation returns without throwing AND rolls the change back out of the live configuration when
+/// the write itself fails (#1521), so a rebuilt server either gets its complete link table back or is left
+/// exactly as it was. A half-applied link table is the worst outcome available here: it looks restored and
+/// silently is not.</item>
 /// <item>No silent repoint. A canonical name this instance already links to a DIFFERENT account is
 /// refused rather than overwritten, because otherwise a crafted backup file is a primitive for remapping
 /// an identity-provider subject onto an administrator's account. An administrator unlinks first and then

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -15,6 +15,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// </summary>
 public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfiguration
 {
+    // Resolved once: reflection over the type is a startup cost, not a per-write one, and a write happens
+    // on the login path. See AdoptFrom for why the set is derived rather than listed.
+    private static readonly System.Reflection.PropertyInfo[] AdoptableProperties = Array.FindAll(
+        typeof(PluginConfiguration).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance),
+        property => property.CanRead && property.CanWrite && property.GetIndexParameters().Length == 0);
+
     private List<Guid>? _ssoOnlyRepointedUserIds;
     private SerializableDictionary<string, LogoutSession>? _logoutSessions;
 
@@ -191,9 +197,19 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     /// on it and decide whether to keep it while the live object never holds a half-applied state (#1095).
     /// </summary>
     /// <returns>An independent configuration carrying the same persisted fields.</returns>
-    internal PluginConfiguration DetachedCopy()
+    internal PluginConfiguration DetachedCopy() => FromPersistedForm(ToPersistedForm());
+
+    /// <summary>
+    /// Reads back a configuration from what <see cref="ToPersistedForm"/> produced. Split out of
+    /// <see cref="DetachedCopy"/> so a caller that needs only to be ABLE to reconstruct - a mutation
+    /// holding an undo for a write that might fail (#1521) - pays one serialization and keeps the string,
+    /// instead of paying the parse as well for a reconstruction it will almost never use.
+    /// </summary>
+    /// <param name="persisted">The persisted form to read back.</param>
+    /// <returns>An independent configuration carrying the fields that form holds.</returns>
+    internal static PluginConfiguration FromPersistedForm(string persisted)
     {
-        // These bytes are this object's own output rather than anything that arrived from outside, and the
+        // These bytes are this plugin's own output rather than anything that arrived from outside, and the
         // reader is still hardened the way every other XML read in this plugin is: no DTD, no resolver. A
         // parse that is safe only because of where its input came from is one refactor away from not being.
         var settings = new XmlReaderSettings
@@ -202,9 +218,35 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
             XmlResolver = null,
         };
 
-        using var text = new StringReader(ToPersistedForm());
+        using var text = new StringReader(persisted);
         using var reader = XmlReader.Create(text, settings);
         return (PluginConfiguration)new XmlSerializer(typeof(PluginConfiguration)).Deserialize(reader)!;
+    }
+
+    /// <summary>
+    /// Takes over every persisted field of <paramref name="source"/> in place, so this object carries that
+    /// state without any holder of it seeing a different instance (#1521). This is the swap at the end of a
+    /// mutation: the change is prepared on a <see cref="DetachedCopy"/>, written to disk, and adopted here
+    /// only once the write returned, so a persist that throws leaves this object exactly as it was.
+    /// </summary>
+    /// <param name="source">The configuration whose state to take over. Its sub-objects are adopted by
+    /// reference, which is safe because a detached copy is reachable from nowhere else.</param>
+    internal void AdoptFrom(PluginConfiguration source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (ReferenceEquals(this, source))
+        {
+            return;
+        }
+
+        // The field set is DERIVED from the type rather than listed here, and it is the same set the XML
+        // serializer persists: public instance properties with both a getter and a setter (this model
+        // declares no [XmlIgnore], which AdoptFromCarriesEveryPersistedField proves by comparing the two
+        // persisted forms). A property added tomorrow is carried without anybody remembering to add it.
+        foreach (var property in AdoptableProperties)
+        {
+            property.SetValue(this, property.GetValue(source));
+        }
     }
 }
 

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -90,23 +90,18 @@ internal sealed class ProviderConfigStore
     }
 
     /// <summary>
-    /// Applies a mutation to the live configuration under a single lock and persists it, so a
-    /// read-modify-write cannot race another and lose its update.
+    /// Applies a mutation under a single lock and persists it, so a read-modify-write cannot race
+    /// another and lose its update, and so a persist that fails leaves nothing behind (#1521).
     /// </summary>
-    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    /// <param name="mutate">The mutation to apply.</param>
     public void Mutate(Action<PluginConfiguration> mutate)
     {
         ArgumentNullException.ThrowIfNull(mutate);
-        lock (Sync)
+        Mutate<object?>(configuration =>
         {
-            var configuration = _live();
             mutate(configuration);
-
-            // Persists directly instead of routing through Save: the object being written IS the live
-            // one, so Save's fresh-config pipeline (validate/preserve/audit) would be skipped by its
-            // identity guard anyway - same observable behavior, without the reentrant detour.
-            _persist(configuration);
-        }
+            return null;
+        });
     }
 
     /// <summary>
@@ -115,17 +110,51 @@ internal sealed class ProviderConfigStore
     /// atomic operation.
     /// </summary>
     /// <typeparam name="T">The value the mutation returns.</typeparam>
-    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    /// <param name="mutate">The mutation to apply.</param>
     /// <returns>The value returned by <paramref name="mutate"/>.</returns>
     public T Mutate<T>(Func<PluginConfiguration, T> mutate)
     {
         ArgumentNullException.ThrowIfNull(mutate);
         lock (Sync)
         {
-            var configuration = _live();
-            var result = mutate(configuration);
-            _persist(configuration);
-            return result;
+            var live = _live();
+
+            // Taken BEFORE the mutation and thrown away on the way out of a successful write: it exists
+            // only so that a persist which throws can be undone (#1521). A failed persist used to leave
+            // the live configuration carrying every change while nothing reached the XML, so logins
+            // behaved as though the import had succeeded until the process restarted and the next
+            // unrelated save committed the changes silently, at a moment nobody connects to the import.
+            // A full disk and a read-only volume are exactly what a freshly built migration target hits.
+            //
+            // The persisted FORM rather than a detached copy, because this path runs on the login side:
+            // the string is one serialization and the parse back is paid only by the failure that needs
+            // it. It is not free and the number is not small, so it is stated rather than implied.
+            // Measured 2026-09-05, Release net9.0, 200 iterations, one OpenID provider carrying a link,
+            // an issuer stamp and a last-login stamp per subject: 0.127 ms at no links, 1.576 ms at 100,
+            // 6.092 ms at 1000, 33.555 ms at 5000 - against 0.480 / 5.152 / 17.481 / 88.919 ms for a
+            // detached copy. It is paid inside this process-wide lock, on top of the serialization the
+            // write itself does, and #1532 holds whether a large installation needs a cheaper undo.
+            var snapshot = Snapshot(live);
+
+            try
+            {
+                var result = mutate(live);
+
+                // Persists directly instead of routing through Save: the object being written IS the live
+                // one, so Save's fresh-config pipeline (validate/preserve/audit) would be skipped by its
+                // identity guard anyway - same observable behavior, without the reentrant detour.
+                _persist(live);
+                return result;
+            }
+            catch
+            {
+                // The mutation is inside the try as well as the write, so a lambda that throws half way
+                // through leaves nothing behind either - which is what the import endpoints promise
+                // their callers and could not previously deliver for a merge that failed after its
+                // first write.
+                Restore(live, snapshot);
+                throw;
+            }
         }
     }
 
@@ -146,36 +175,22 @@ internal sealed class ProviderConfigStore
         var declarativeProfileWritesIgnored = new List<string>();
         lock (Sync)
         {
-            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
+            // The same undo as Mutate, and it is not redundant even though the posted object is a
+            // different one (#1521): the pipeline below hands the LIVE object's server-managed maps and
+            // declaratively managed providers to the posted one, and the persist delegate then encrypts
+            // the secrets inside those shared objects in place. A write that throws afterwards would
+            // otherwise leave the live configuration carrying envelopes the file does not have.
+            var snapshot = Snapshot(_live());
+
+            try
             {
-                // Reject the save fail-closed before anything is persisted if a base-URL override is
-                // malformed (#139), a SAML signing certificate is not loadable (#206), or a NEWLY
-                // registered provider name contains control, URI-reserved, or backslash characters
-                // (#336/#360 - the live config is passed so names it already holds stay saveable). This validates the config-page save
-                // (a fresh incoming config); the OID/SAML Add endpoints write through Mutate (the live
-                // object, so this branch is skipped) and validate their own incoming provider at the
-                // controller via the Reject* guards. Login-path writes (canonical links) also reuse the
-                // live object and are intentionally not revalidated here, so a slow/bad override can
-                // never throw on the login path.
-                ProviderConfigValidator.Validate(incoming, _live());
-
-                ServerManagedFields.Preserve(incoming, _live());
-
-                // #1102: a provider a declarative source named is decided by that source, so the config-page
-                // save gets the stored (declarative) provider back rather than the posted one. AFTER the
-                // re-injection above, never before: that is what makes an untouched provider compare equal to
-                // the stored one, so the audit below reports a save that actually tried to change a managed
-                // provider instead of firing on every unrelated settings change. Nothing happens here on an
-                // installation that configures no declarative source.
-                ManagedProviders.Reinject(incoming, _live(), declarativeWritesIgnored, declarativeProfileWritesIgnored);
-
-                // Snapshot which providers were saved with an insecure option (#140) while under the
-                // lock, but emit the warnings AFTER releasing it (below) - logging must not run inside
-                // the global config lock, where a slow provider would block concurrent config access.
-                insecureToAudit = CollectInsecureOptions(incoming);
+                Persist(configuration, insecure => insecureToAudit = insecure, declarativeWritesIgnored, declarativeProfileWritesIgnored);
             }
-
-            _persist(configuration);
+            catch
+            {
+                Restore(_live(), snapshot);
+                throw;
+            }
         }
 
         // Outside the lock, and after the save is durably persisted: a slow or misbehaving logging
@@ -199,6 +214,97 @@ internal sealed class ProviderConfigStore
             {
                 SsoAudit.DeclarativeProfileWriteIgnored(_logger, profile);
             }
+        }
+    }
+
+    // The body of Save, under the caller's lock and inside its rollback: validate a replacement config,
+    // re-inject what the server owns, and write. Split out so the snapshot/restore around it reads as one
+    // thing rather than as a try wrapped around forty lines.
+    private void Persist(
+        BasePluginConfiguration configuration,
+        Action<List<(string Protocol, string Provider, IReadOnlyList<string> Options)>> collectInsecure,
+        List<(string Protocol, string Provider)> declarativeWritesIgnored,
+        List<string> declarativeProfileWritesIgnored)
+    {
+        if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
+        {
+            // Reject the save fail-closed before anything is persisted if a base-URL override is
+            // malformed (#139), a SAML signing certificate is not loadable (#206), or a NEWLY
+            // registered provider name contains control, URI-reserved, or backslash characters
+            // (#336/#360 - the live config is passed so names it already holds stay saveable). This validates the config-page save
+            // (a fresh incoming config); the OID/SAML Add endpoints write through Mutate (the live
+            // object, so this branch is skipped) and validate their own incoming provider at the
+            // controller via the Reject* guards. Login-path writes (canonical links) also reuse the
+            // live object and are intentionally not revalidated here, so a slow/bad override can
+            // never throw on the login path.
+            ProviderConfigValidator.Validate(incoming, _live());
+
+            ServerManagedFields.Preserve(incoming, _live());
+
+            // #1102: a provider a declarative source named is decided by that source, so the config-page
+            // save gets the stored (declarative) provider back rather than the posted one. AFTER the
+            // re-injection above, never before: that is what makes an untouched provider compare equal to
+            // the stored one, so the audit below reports a save that actually tried to change a managed
+            // provider instead of firing on every unrelated settings change. Nothing happens here on an
+            // installation that configures no declarative source.
+            ManagedProviders.Reinject(incoming, _live(), declarativeWritesIgnored, declarativeProfileWritesIgnored);
+
+            // Snapshot which providers were saved with an insecure option (#140) while under the
+            // lock, but emit the warnings AFTER releasing it (below) - logging must not run inside
+            // the global config lock, where a slow provider would block concurrent config access.
+            collectInsecure(CollectInsecureOptions(incoming));
+        }
+
+        // The persist delegate makes the written configuration live once the write has returned
+        // (SSOPlugin.PersistBase), so a throw here leaves the live one on the stored state.
+        _persist(configuration);
+    }
+
+    // The undo for a write that fails (#1521), taken under the caller's lock before anything is touched.
+    // NOT fatal when it cannot be taken: the serializer that produces it refuses characters the one on
+    // the way to disk may accept, and a configuration already holding such a byte would otherwise have
+    // EVERY write refused from here on - including the delete that would remove it. So a snapshot that
+    // cannot be made costs the rollback for that one write, which is where this plugin stood before
+    // #1521, rather than costing the write itself. Null means "no undo available", and the caller says
+    // so in the log rather than silently.
+    private string? Snapshot(PluginConfiguration live)
+    {
+        try
+        {
+            return live.ToPersistedForm();
+        }
+        catch (InvalidOperationException ex)
+        {
+            SsoAudit.ConfigurationRollbackUnavailable(_logger, ex);
+            return null;
+        }
+        catch (ArgumentException ex)
+        {
+            SsoAudit.ConfigurationRollbackUnavailable(_logger, ex);
+            return null;
+        }
+    }
+
+    // Puts the live configuration back on what the file still holds. Guarded, because the exception the
+    // caller is about to rethrow is the one that says what actually went wrong: a restore that threw and
+    // replaced it would leave an operator debugging the undo instead of the full disk underneath it. A
+    // restore that fails leaves the live configuration mutated, which is the pre-#1521 state, and says so.
+    private void Restore(PluginConfiguration live, string? snapshot)
+    {
+        if (snapshot is null)
+        {
+            return;
+        }
+
+        try
+        {
+            live.AdoptFrom(PluginConfiguration.FromPersistedForm(snapshot));
+        }
+#pragma warning disable CA1031 // the original failure must reach the caller, whatever the undo did
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            SsoAudit.ConfigurationRollbackFailed(_logger, ex);
         }
     }
 

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Duende.IdentityModel.OidcClient.Infrastructure;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
@@ -29,6 +30,8 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     // page identity - like the root namespace, they must NOT track a display-name change (a rename here
     // would break every existing config page's load path). The display Name is free to change; this is not.
     private const string PageId = "SSO-Auth";
+
+    private readonly ILogger _logger;
 
     private readonly Lazy<SecretStore> _secrets;
 
@@ -57,6 +60,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // Handing out `() => Configuration` here is safe: BasePlugin's constructor only records the
         // config path and loads the configuration lazily on first access, so nothing calls back into
         // UpdateConfiguration (and thus ConfigStore) before this assignment completes.
+        _logger = logger;
         ConfigStore = new ProviderConfigStore(() => Configuration, PersistBase, logger);
 
         // Lazy with the default thread-safe mode: the SecretStore (and thus the data-encryption key) is
@@ -122,6 +126,14 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// through this rather than reading <see cref="BasePlugin{T}.Configuration"/>, mutating, and
     /// calling <c>UpdateConfiguration</c> separately.
     /// </summary>
+    /// <remarks>
+    /// All-or-nothing against BOTH failures, which is what callers document to their operators (#1521):
+    /// a mutation that throws persists nothing, and a WRITE that throws - a full disk, a read-only
+    /// volume - is rolled back out of the live configuration before the exception reaches the caller.
+    /// The residual is named rather than implied: a caller holding a reference to a PROVIDER object
+    /// taken before the mutation keeps an object carrying the rejected values, and is receiving the
+    /// exception rather than carrying on.
+    /// </remarks>
     /// <param name="mutate">The mutation to apply to the live configuration.</param>
     public void MutateConfiguration(Action<PluginConfiguration> mutate) => ConfigStore.Mutate(mutate);
 
@@ -163,12 +175,47 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     // so re-persisting is a no-op and a legacy plaintext value is rewritten encrypted on its next save.
     private void PersistBase(BasePluginConfiguration configuration)
     {
-        if (configuration is PluginConfiguration incoming)
+        if (configuration is not PluginConfiguration incoming)
         {
-            ConfigSecretProtection.ProtectAll(incoming, Secrets);
+            // Not this plugin's configuration type, so there is nothing to encrypt and nothing this
+            // method knows how to swap in; hand it to the base class unchanged.
+            base.UpdateConfiguration(configuration);
+            return;
         }
 
-        base.UpdateConfiguration(configuration);
+        ConfigSecretProtection.ProtectAll(incoming, Secrets);
+
+        // The file FIRST (#1521). Measured rather than assumed: base.UpdateConfiguration assigns
+        // Configuration BEFORE it serializes, so a write that threw - a full disk, a read-only volume -
+        // left the plugin running on a configuration that is not on disk, with no error path back.
+        // SaveConfiguration is the write half alone: it creates the configuration directory and
+        // serializes to the same file, and it neither assigns Configuration nor raises
+        // ConfigurationChanged. So a throw here reaches the caller with nothing made live.
+        SaveConfiguration(incoming);
+
+        // Then the live object, in place rather than by reference: every reader in this plugin holds the
+        // object Configuration returns, and Jellyfin core hands it out on GET /Plugins/{id}/Configuration
+        // without taking the store's lock, so replacing the reference would leave holders on an
+        // abandoned configuration. A no-op when the caller handed in the live object itself, which is
+        // every Mutate.
+        Configuration.AdoptFrom(incoming);
+
+        // Last, and it cannot undo either of the two above. The base-class update this method replaces
+        // raised this event, so the replacement owes it; but the store rolls a write back on any
+        // exception out of this delegate, and the write is already durable here - a subscriber that
+        // threw would otherwise revert the live configuration away from a file that has the change.
+        // Swallowed for the same reason the insecure-option audit is emitted outside the config lock: a
+        // misbehaving subscriber must not turn a completed save into a failure.
+        try
+        {
+            ConfigurationChanged?.Invoke(this, Configuration);
+        }
+#pragma warning disable CA1031 // any subscriber failure, and none of them may unwind a durable write
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            SsoAudit.ConfigurationChangedSubscriberFailed(_logger, ex);
+        }
     }
 
     // Both tables below are the plugin's public URL contract (#370): the first element of each Page()

--- a/docs/ACCOUNT-MANAGEMENT-API.md
+++ b/docs/ACCOUNT-MANAGEMENT-API.md
@@ -298,10 +298,15 @@ Every entry is checked before a single link is written, and the first failure
 rejects the whole document: `LinkImport.Resolve` collects every refusal and
 throws before `LinkImport.Write` is reached, and `LinkImport.Apply` is what
 `ImportLinks` hands to `MutateConfiguration`, which persists nothing when the
-mutation throws. So a rejected import leaves the stored link table exactly as it
-was. This is the property to know before running it once: the instance either
-gets its complete link table back or is left untouched, and there is no
-half-applied state that looks restored and is not.
+mutation throws and rolls the change back out of the running instance when the
+write itself fails - a full disk, a read-only volume. So a rejected import
+leaves the stored link table exactly as it was, and a running instance goes back
+to what it had stored rather than carrying links that never reached the file.
+The rollback reaches the running instance and not the file itself, whose write
+is the plugin base class's and is not atomic (#1532). This is the property to know
+before running it once: the instance either gets its complete link table back or
+is left untouched, and there is no half-applied state that looks restored and is
+not.
 
 ### What is refused, and why
 

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -112,6 +112,25 @@ when the mutation throws - the remarks on `ImportConfig` and `ImportLinks` say
 so - so a step run too early leaves the instance exactly as it was and is simply
 re-run once the step before it is done.
 
+The other failure is the write, and it is covered as far as this plugin
+reaches. A valid import whose persist fails - a full disk, a read-only volume,
+which is exactly what a freshly built target can hit - used to leave the
+running instance carrying the whole import while nothing reached the XML, so
+logins behaved as though it had succeeded until the next restart.
+`MutateConfiguration` now rolls the change back out of the live configuration
+before the `500` reaches you, so the running instance goes back to the stored
+state. Retry the import once the disk or the mount is fixed.
+
+**What that does not promise, stated rather than implied.** The write itself is
+the Jellyfin plugin base class's, and it serializes straight over
+`SSO-Auth.xml` with no temporary file and no rename, so a disk that fills
+mid-write leaves a truncated file. The rollback puts the running instance back
+on what was stored; it cannot repair the file. A truncated `SSO-Auth.xml` does
+not load on the next start, and the base class replaces an unloadable one with
+an empty configuration - so **take a copy of `SSO-Auth.xml` before a migration
+step, and check it after a failed one, before restarting the server.** #1532
+holds the change that would make the write itself atomic.
+
 Re-running the link import after a partial migration is safe: re-importing a
 mapping this instance already holds is not a repoint and succeeds, because the
 refusal in `LinkImport.Resolve` fires only when the stored link resolves to a


### PR DESCRIPTION
# What & why

Closes #1521.

Every configuration change — a link import, a configuration import, adding a provider, the canonical link a first login writes — was applied to the live in-memory configuration and only then serialized. If the write failed, the running server kept the change while the file did not: logins behaved as though an import had succeeded until the next restart, and the next unrelated save committed it silently, at a moment nobody connects to the import. Both imports and the operator pages promised the opposite; the promise covered a rejected document but not a refused write.

**Measured before it was changed, not reasoned about.** Probes against the real base class on 2026-09-05:

- `BasePlugin<T>.UpdateConfiguration` assigns `Configuration` **before** it serializes, then raises `ConfigurationChanged`. That ordering is the defect.
- `BasePlugin<T>.SaveConfiguration(T)` is the write alone: it creates the configuration directory, serializes to the same path, assigns nothing and raises nothing.
- `Configuration`'s setter is `protected`; `ConfigurationChanged` is a public get/set delegate property.

So the plugin writes first and makes the result live second, and the store keeps an undo across the whole mutation: the persisted form is taken before anything is touched, and a mutation **or** a write that throws restores the live configuration **in place** before the exception reaches the caller. In place rather than by reference, because every reader holds the object the store hands out, and Jellyfin core serves it on `GET /Plugins/{id}/Configuration` without taking this lock.

`Save` (the settings page) gets the same undo, and it is not redundant there: the pipeline hands the live object's server-managed maps to the posted configuration and the persist delegate then encrypts the secrets inside those shared objects in place.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted. Untouched. The change moves closer to fail-closed on the persistence path: a write that does not land now changes nothing.
- [x] No secrets logged; secrets are redacted on config export. The three new audit lines carry an exception message and no configuration content.
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [x] Review record below.
- [x] Log inputs from the IdP are sanitized inline at the log call — `error?.Message?.ReplaceLineEndings(string.Empty)` at each of the three new call sites, not through a helper.

### Review record

Two refute-by-default lenses on the staged diff, each reading the full files and their callers. **CONFIRMED 9 / PLAUSIBLE 3.** No second human reader; the evidence below stands in place of one, and that is a statement about what this PR has, not a claim that it is equivalent.

**Correctness lens — NEEDS_IMPROVEMENT.** Could not refute the core rollback. Seven findings:

1. The docs asserted end-to-end atomicity the non-atomic host write does not support — **FIX** (claims narrowed in `SERVER-MIGRATION.md`, `ACCOUNT-MANAGEMENT-API.md`, `SSOController`, CHANGELOG) plus **DEFER** #1532 for a temp-file-and-rename.
2. `Save` had no rollback while the pipeline mutates live's shared maps in place — **FIX** (`Save` now snapshots and restores; `Save_PersistThrows_UndoesWhatThePipelineDidToTheLiveObject` pins it).
3. Declarative boot records the managed-provider freeze before the write, so a rolled-back document still freezes — **DEFER** #1534 (the repair is in the loader, not in this store).
4. `ToPersistedForm` refuses characters the write path may accept, so every write could have started throwing — **FIX** (the snapshot is non-fatal; the write proceeds without an undo and says so). `Mutate_SnapshotCannotBeTaken_StillWrites_AndSaysSo` builds the offending key and reads the refusal rather than assuming it.
5. The guarded region started after the mutation lambda — **FIX** (widened; `Mutate_MutationThrowsHalfWay_LeavesNothingBehind`).
6. `AdoptFrom_CarriesEveryPersistedField` only compares fields a test remembered to populate — **FIX** (`AdoptableSet_CoversEveryFieldTheSerializerPersists` derives the expected set from the serializer's own output; its bound is written in the test).
7. `ConfigurationChanged` fired before the live object was updated — **FIX** (adoption moved into `PersistBase`, ahead of the raise).

**Availability / mass-lockout lens — NEEDS_IMPROVEMENT.** Confirmed startup is safe (both declarative loaders keep their catch-all), that SSO-only *enable* is improved rather than regressed, and that no best-effort login write became fatal. Findings:

1. HIGH — a throwing `ConfigurationChanged` subscriber rolled back a durable write, reproduced — **FIX** (raise is contained and audited; `AConfigurationChangedSubscriberThatThrows_CannotUndoTheWriteItIsBeingToldAbout`).
2. A subscriber re-reading the plugin saw the pre-save configuration, reproduced — **FIX** (same move as correctness 7; `AConfigurationChangedSubscriber_SeesTheSavedConfiguration_NotThePreviousOne`).
3. HIGH — a first login whose link write is rolled back leaves the Jellyfin account it created, which blocks every later attempt for that identity — **DEFER** #1533. This is a real behaviour change: before this PR the link survived in memory and a later write committed it, which was the defect and, on this one path, an accidental self-heal. The repair belongs on the login path with its own threat model, not appended here.
4. The benchmark in the comment understated the cost — **FIX**, re-measured myself with the issuer and last-login side maps a real provider carries.
5. The host write is not atomic — same as correctness 1.
6. The rollback itself was unguarded, so a failing restore would replace the original exception — **FIX** (guarded, and it audits at Error). **No falsifier**: with all setters being plain field assignments and the snapshot already parsed, I could not construct an input that makes the restore throw, so this branch ships as a safety net with no proof that it bites. Stated rather than left for a reader to notice.
7. `AdoptFrom` turns an atomic reference swap into an N-property mutation, so core's unlocked `GET .../Configuration` can observe a half-adopted configuration — **DECLINE**. That read was already unsynchronised against every in-place `Mutate` in the tree; this narrows nothing and widens one path. Not worth a lock core does not take.

## Quality checklist

- [x] No duplicated logic; `Snapshot`/`Restore` are one pair used by both write paths, and `DetachedCopy` is now `FromPersistedForm(ToPersistedForm())` rather than a second copy of the parse.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318): the store owns the undo, the plugin owns the road to disk.
- [x] Architecture-conformance tests pass. No new structural property.
- [x] Docs impact: included here — `docs/SERVER-MIGRATION.md`, `docs/ACCOUNT-MANAGEMENT-API.md`, the CHANGELOG, and the remarks on `ImportLinks` / `LinkImport` / `ConfigImport` / `MutateConfiguration` that stated the old, narrower promise.

## Verification

- [x] `dotnet build --warnaserror` green on **both** TFMs (`net9.0`, `net10.0`), 0 warnings.
- [x] Full suite green on both: **3669** and **3670**, 0 failed, 4 skipped.
- [x] Prettier clean for the three changed `.md` files.

Every guard here was falsified before it was trusted — the change reverted, the suite watched go red, the change restored:

| removed | red |
| --- | --- |
| `SaveConfiguration` → `base.UpdateConfiguration` | 3 |
| the rollback in `Mutate` | 4 |
| the adoption in `PersistBase` | 2 |
| the containment around the event raise | 1 |
| one property excluded from the adoptable set | 1 |

## Notes

- The residual is named in `MutateConfiguration`'s remarks rather than implied: a caller holding a reference to a **provider** object taken before a mutation keeps an object carrying the rejected values after a rollback. That caller is receiving the exception rather than carrying on, and the live configuration — what the next login reads — is correct.
- The undo costs one serialization per write, inside the process-wide config lock, on the login path. Measured 2026-09-05, Release `net9.0`, 200 iterations, one OpenID provider carrying a link, an issuer stamp and a last-login stamp per subject: 0.127 ms at no links, 1.576 ms at 100, 6.092 ms at 1000, 33.555 ms at 5000. #1532 holds whether a large installation needs a cheaper one; there is no before/after comparison on the same fixture yet, and that is what #1532 asks for first.
- The rollback restores what a **restart would load**, not the object's own history: the round trip normalizes a null role-map list to an empty one. That is the correct target — the file is what the live configuration is required to agree with — and the tests compare against it rather than against the object as it stood.
- Follow-ups opened and assigned: #1532 (cost and the non-atomic write), #1533 (orphaned account after a rolled-back first-login link write), #1534 (declarative freeze recorded for a rolled-back document).
