### PR TITLE
Delete the account a first login created when it cannot finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,22 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A first login that failed half way left an account nobody could use
+  (#1533).** When SSO creates a Jellyfin account for a new user, several
+  things still have to happen before that account is usable: it is given the
+  SSO routing and a password, it is stored, and the link between it and the
+  identity provider is written. If any of those failed — a full disk, a
+  provider an administrator deleted while the login was in flight — the
+  account stayed behind with no link and no usable password, and it then
+  blocked that person from ever being provisioned again under the same name,
+  because SSO refuses to adopt an account it did not link. Fixing the original
+  problem did not clear it; only deleting the account by hand did. The account
+  is now removed again when the login cannot be completed, so there is nothing
+  left behind and the person can sign in once the underlying problem is fixed.
+  The log says when this happens, and says it louder if the removal itself
+  fails and the account has to be deleted manually after all. Accounts that
+  already existed before a login are never touched by this.
+
 - **A configuration write that could not reach the disk was applied anyway
   (#1521).** Every configuration change - a link import, a configuration
   import, adding a provider, the canonical link a first login writes - was

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -328,6 +328,71 @@ public class SsoAuditTests
         Assert.Empty(off.Entries);
     }
 
+    [Fact]
+    public void TheRollbackAndPersistenceLines_RespectIsEnabled_AndTolerateNoLoggerAtAll()
+    {
+        // The same IsEnabled contract as the row above, for the lines #1521 and #1533 added, and at BOTH
+        // severities: two of them are Error, which a sink filtered to Warning would still take, so the
+        // level has to be off entirely to prove the guard rather than the sink. The null arm is not
+        // decoration either - ProviderConfigStore is constructed with a null logger by callers that want
+        // no audit at all, and an audit line that dereferenced it would fail the write it is reporting on.
+        var off = new LevelFilteredLogger(minimum: LogLevel.None);
+
+        SsoAudit.ConfigurationRollbackUnavailable(off, new InvalidOperationException("x"));
+        SsoAudit.ConfigurationRollbackFailed(off, new InvalidOperationException("x"));
+        SsoAudit.ConfigurationChangedSubscriberFailed(off, new InvalidOperationException("x"));
+        SsoAudit.ProvisionedAccountRolledBack(off, "SAML", "corp", "alice");
+        SsoAudit.ProvisionedAccountRollbackFailed(off, "alice", new InvalidOperationException("x"));
+
+        Assert.Empty(off.Entries);
+
+        SsoAudit.ConfigurationRollbackUnavailable(null!, new InvalidOperationException("x"));
+        SsoAudit.ConfigurationRollbackFailed(null!, new InvalidOperationException("x"));
+        SsoAudit.ConfigurationChangedSubscriberFailed(null!, new InvalidOperationException("x"));
+        SsoAudit.ProvisionedAccountRolledBack(null!, "SAML", "corp", "alice");
+        SsoAudit.ProvisionedAccountRollbackFailed(null!, "alice", new InvalidOperationException("x"));
+    }
+
+    [Fact]
+    public void TheRollbackLines_CarryThePrefix_AndStripLineEndings()
+    {
+        // A rollback line is what an operator finds above the failure that caused it, so it has to be
+        // filterable by the same prefix as every other audit line and carry no injected line break - the
+        // exception message and the username both arrive from outside this plugin.
+        var log = new CapturingLogger();
+
+        SsoAudit.ProvisionedAccountRolledBack(log, "SAML", "corp\nEVIL", "ali\nce");
+        SsoAudit.ProvisionedAccountRollbackFailed(log, "ali\nce", new InvalidOperationException("boom\nEVIL"));
+        SsoAudit.ConfigurationRollbackUnavailable(log, new InvalidOperationException("boom\nEVIL"));
+        SsoAudit.ConfigurationRollbackFailed(log, new InvalidOperationException("boom\nEVIL"));
+        SsoAudit.ConfigurationChangedSubscriberFailed(log, new InvalidOperationException("boom\nEVIL"));
+
+        Assert.Equal(5, log.Entries.Count);
+        Assert.All(log.Entries, e => Assert.StartsWith("[SSO Audit]", e.Message, StringComparison.Ordinal));
+        Assert.All(log.Entries, e => Assert.DoesNotContain("\n", e.Message, StringComparison.Ordinal));
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Error);
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void TheRollbackLines_SurviveNullFields()
+    {
+        // Every field on these lines is null-conditional, and this is what proves those arms are reachable
+        // rather than decoration. A rollback line reports a failure that has already happened; one that
+        // threw on a null provider name would replace the diagnosis with a second fault, on the exact path
+        // an operator is trying to read.
+        var log = new CapturingLogger();
+
+        SsoAudit.ProvisionedAccountRolledBack(log, null!, null!, null!);
+        SsoAudit.ProvisionedAccountRollbackFailed(log, null!, null!);
+        SsoAudit.ConfigurationRollbackUnavailable(log, null!);
+        SsoAudit.ConfigurationRollbackFailed(log, null!);
+        SsoAudit.ConfigurationChangedSubscriberFailed(log, null!);
+
+        Assert.Equal(5, log.Entries.Count);
+        Assert.All(log.Entries, e => Assert.StartsWith("[SSO Audit]", e.Message, StringComparison.Ordinal));
+    }
+
     private sealed class LevelFilteredLogger : ILogger
     {
         private readonly LogLevel _minimum;

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -13,6 +14,8 @@ using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using MediaBrowser.Model.Plugins;
 using NSubstitute;
 using Xunit;
 
@@ -148,6 +151,163 @@ public class CanonicalLinkServiceTests
 
         await users.Received(1).DeleteUserAsync(Other);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_LinkWriteFails_RollsBackTheAccountAndFailsClosed()
+    {
+        // #1533, and the shape only became reachable with #1521: the store now undoes a configuration write
+        // that could not reach the disk, so the link is gone while the account this login created is not.
+        // That account then blocks every later attempt for the same identity - the create-or-adopt gate
+        // refuses to adopt it - so a full disk turned into a permanent per-identity lockout that fixing the
+        // disk did not clear. Deleting it leaves nothing behind, which is what the two persist rollbacks
+        // above already do for their own failure.
+        var (service, cfg, users, _) = BuildWithPersist(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true },
+            _ => throw new IOException("no space left on device"));
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        await users.Received(1).DeleteUserAsync(Other);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_LinkWriteSucceeds_KeepsTheAccount()
+    {
+        // The positive control the rollback needs: it fires on a failed link write and on nothing else.
+        // Without this, a service that deleted every account it created would satisfy the test above.
+        var (service, cfg, users, _) = BuildWithPersist(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true },
+            _ => { });
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Other, resolved);
+        await users.DidNotReceive().DeleteUserAsync(Arg.Any<Guid>());
+        Assert.Equal(Other, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_AdoptedAccount_LinkWriteFails_LeavesTheAccountAlone()
+    {
+        // The boundary the rollback must not cross. The adopt arm links an account that existed before this
+        // login; a failed link write there must fail the login and leave the account exactly where it was.
+        // Deleting one would turn a disk error into account destruction, which is the worst outcome this
+        // file has.
+        var existing = TestUsers.Named("alice", Existing);
+        var (service, cfg, users, _) = BuildWithPersist(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true, AllowExistingAccountLink = true },
+            _ => throw new IOException("no space left on device"));
+        users.GetUserByName("alice").Returns(existing);
+        users.GetUserById(Existing).Returns(existing);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
+
+        await users.DidNotReceive().DeleteUserAsync(Arg.Any<Guid>());
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_ProviderDisabledMidFlight_RollsBackTheAccountToo()
+    {
+        // The rollback is not exception-type-blind by accident. LinkCanonicalIfAbsent also refuses when the
+        // provider was deleted or disabled between the candidate read and the write, and an account
+        // provisioned for a login that is then refused is the same orphan as one whose disk was full. The
+        // provider is removed here during the account persist, which is exactly that window.
+        var (service, cfg, users, _) = BuildWithPersist(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true },
+            _ => { });
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+        users.When(u => u.UpdateUserAsync(created)).Do(_ => cfg.OidConfigs.Remove("kc"));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        await users.Received(1).DeleteUserAsync(Other);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_RollbackItselfFails_TheOriginalFailureStillReachesTheCaller()
+    {
+        // A delete that throws from inside a finally replaces the exception being unwound, and that
+        // exception is the only thing that says what went wrong - the completion path catches the refusal
+        // BY TYPE to answer 403 rather than 500, and an operator reading a 500 needs to see the disk. So
+        // the rollback swallows its own failure and says so in the log instead.
+        var (service, cfg, users, log) = BuildWithPersist(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true },
+            _ => throw new IOException("no space left on device"));
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+        users.When(u => u.DeleteUserAsync(Other)).Do(_ => throw new InvalidOperationException("the delete failed too"));
+
+        var thrown = await Assert.ThrowsAsync<IOException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        Assert.Equal("no space left on device", thrown.Message);
+        Assert.Contains(log.Entries, e => e.Message.Contains("could not be rolled back", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NewAccount_ThrowBeforeThePersist_RollsBackTheAccount()
+    {
+        // The window the single guard closed. The password mint and the template application run between
+        // the create and the persist, and a throw in either used to leave behind the account this arm
+        // exists to prevent: enabled, without the SSO routing, without a password - the empty-password door
+        // on the ordinary login form - and unlinked.
+        // A concrete implementation rather than a substitute: NSubstitute cannot proxy the
+        // ReadOnlySpan<char> overload, which is why FakeCryptoProvider exists beside it in the first place.
+        var crypto = new RefusingCryptoProvider();
+
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var users = Substitute.For<IUserManager>();
+        var service = new CanonicalLinkService(users, crypto, new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger()), new CapturingLogger(), new IntervalGate(TimeSpan.FromMinutes(1)));
+
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        await users.Received(1).DeleteUserAsync(Other);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    // The same wiring as Build, with the store's persist delegate handed to the caller so a test can make
+    // the configuration write fail. Kept beside Build rather than folded into it: every other test in this
+    // file wants a persist that does nothing, and an optional parameter there would put the interesting
+    // case behind a default nobody reads.
+    private static (CanonicalLinkService Service, PluginConfiguration Config, IUserManager Users, CapturingLogger Log) BuildWithPersist(
+        Action<PluginConfiguration> seed,
+        Action<BasePluginConfiguration> persist)
+    {
+        var cfg = new PluginConfiguration();
+        seed(cfg);
+        var store = new ProviderConfigStore(() => cfg, persist, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        var log = new CapturingLogger();
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, log, new IntervalGate(TimeSpan.FromMinutes(1)));
+        return (service, cfg, users, log);
     }
 
     [Fact]
@@ -1838,4 +1998,24 @@ public class CanonicalLinkServiceTests
 
         Assert.DoesNotContain(log.Entries, e => e.Message.Contains("orphaned", StringComparison.Ordinal));
     }
+}
+
+/// <summary>
+/// An <see cref="ICryptoProvider"/> that refuses to hash, so a test can make the account-provisioning path
+/// throw BETWEEN the account create and the account persist (#1533). NSubstitute cannot proxy the
+/// <c>ReadOnlySpan&lt;char&gt;</c> overload, which is why this is a class rather than a substitute - the same
+/// reason <see cref="FakeCryptoProvider"/> beside it is one.
+/// </summary>
+internal sealed class RefusingCryptoProvider : ICryptoProvider
+{
+    public string DefaultHashMethod => "PBKDF2-SHA512";
+
+    public PasswordHash CreatePasswordHash(ReadOnlySpan<char> password) =>
+        throw new InvalidOperationException("the host crypto refused");
+
+    public bool Verify(PasswordHash hash, ReadOnlySpan<char> password) => true;
+
+    public byte[] GenerateSalt() => Array.Empty<byte>();
+
+    public byte[] GenerateSalt(int length) => new byte[length];
 }

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -242,6 +242,27 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_SamlNewAccount_LinkWriteFails_RollsBackAndNamesTheProtocol()
+    {
+        // The SAML arm of the same guard. It is not a copy for symmetry's sake: the rollback names the
+        // protocol in its audit line, and an operator filtering the log by protocol has to find the SAML
+        // one too.
+        var (service, cfg, users, log) = BuildWithPersist(
+            c => c.SamlConfigs["idp"] = new SamlConfig { Enabled = true },
+            _ => throw new IOException("no space left on device"));
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        await Assert.ThrowsAsync<IOException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Saml, "idp", "nameid-1", "alice", allowExistingAccountLink: false));
+
+        await users.Received(1).DeleteUserAsync(Other);
+        Assert.Contains(log.Entries, e => e.Message.Contains("SAML", StringComparison.Ordinal) && e.Message.Contains("rolled back", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ResolveOrCreateAsync_NewAccount_RollbackItselfFails_TheOriginalFailureStillReachesTheCaller()
     {
         // A delete that throws from inside a finally replaces the exception being unwound, and that

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -41,6 +41,51 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records that an account this login had just created was deleted again because the login could not be
+    /// completed (#1533). Warning rather than Information: the lines the provisioning already emitted - the
+    /// created-account metric, the pending-approval audit, the legacy-orphan warning - all describe an
+    /// account that no longer exists, and this is what makes that stretch of the log readable.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="username">The Jellyfin username the account had been created under.</param>
+    internal static void ProvisionedAccountRolledBack(ILogger logger, string protocol, string provider, string username)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Provisioning rolled back for {Protocol} provider '{Provider}': the account '{Username}' was created and then deleted again because the login could not be completed. Nothing was left behind, and the failure that stopped it is logged separately. The user can sign in once that failure is fixed.",
+            protocol?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty),
+            username?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
+    /// Records that the rollback above could not delete the account (#1533), so a half-provisioned one
+    /// survives. Error, and it names what an administrator has to do: this account carries no link and no
+    /// usable password, and it blocks that identity from being provisioned again under the same name.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="username">The Jellyfin username the account was created under.</param>
+    /// <param name="error">What the delete threw. No credential material is recorded.</param>
+    internal static void ProvisionedAccountRollbackFailed(ILogger logger, string username, Exception error)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
+        logger.LogError(
+            "[SSO Audit] Provisioning could not be rolled back ({Reason}): the account '{Username}' was created for a login that then failed, and deleting it again did not work. It holds no SSO link and no usable password, and it will refuse that identity a fresh account under the same name - delete it manually.",
+            error?.Message?.ReplaceLineEndings(string.Empty),
+            username?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
     /// Records a new SSO identity being provisioned as a disabled account pending administrator approval
     /// (#737, ProvisionNewUsersDisabled). No session was issued; an administrator must enable the account.
     /// </summary>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -639,91 +639,139 @@ internal sealed class CanonicalLinkService
         }
 
         var user = await _userManager.CreateUserAsync(provisionedName).ConfigureAwait(false);
-        user.AuthenticationProviderId = SsoManagedProviderId.Value;
 
-        // #1139: counted where the account comes into existence, not at the pending-approval audit below.
-        // That line fires only for a provider that holds new accounts for approval, so counting there would
-        // report zero creations on every server that does not - the majority - while accounts were being made
-        // on each of them.
-        SsoMetrics.AccountProvisioned(ProvisioningOutcome.Created);
-
-        // The provider's static provisioning template (#1099), applied HERE and only here: this is the one
-        // arm on which an account is brand new, which is what lets an administrator's later per-user edit
-        // survive every subsequent login. It writes only the fields the template names, so a provider
-        // carrying none provisions byte-identically to before. Ahead of the pending-approval branch below so
-        // an account created inert already carries its policy when an administrator comes to enable it,
-        // rather than getting it on a first login that may never happen.
-        var template = ProvisioningTemplateFor(mode, provider, provisioningProfile);
-        ProvisioningPolicy.ApplyAtProvisioning(user, template);
-        // The manual-login door (#1440), shut as the account comes into existence: a Jellyfin user created
-        // with no password accepts the EMPTY one on the ordinary login form. Minted through the one shared
-        // helper the boot-time sweep also uses, so the two writers cannot drift into two ideas of random.
-        user.Password = ProvisionedPassword.Mint(_cryptoProvider);
-
-        // PERSISTED HERE, once, and this write is the door rather than the two assignments above it (#1440).
-        // The session mint re-resolves the account by id and writes THAT object, so everything set on the
-        // instance CreateUserAsync returned reached no database: the account was persisted routed at
-        // Jellyfin's own password provider with no password stored, which is a Jellyfin account that accepts
-        // the EMPTY password on the ordinary login form. Found by the end-to-end harness reading the account
-        // back after a real login, never by a unit test - every one of them asserts on the in-memory object,
-        // where both writes were always present.
+        // ONE guard from here to the link write, rather than one around each write inside it (#1533).
+        // What it holds is the whole sentence this arm is for: an account created here either ends up
+        // LINKED, or does not exist. Anything that throws in between - the persist (#1440/#737), the
+        // password mint, the template application, the link write - otherwise leaves an account that
+        // exists, is ENABLED, carries neither the SSO routing nor a password, and has no link: reachable
+        // from the ordinary login form with the empty password (#1440), and blocking every later attempt
+        // for the same identity, because the create-or-adopt gate refuses to adopt it. Fixing whatever
+        // failed does not clear that; only an administrator deleting the account does.
         //
-        // The pending-approval hold (#737) is applied BEFORE this write rather than after it, so one write
-        // carries the routing, the password and the disabled flag. IsDisabled is otherwise never written by
-        // this plugin and is barred from SSO role mapping (PermissionRolePolicy) precisely so no login can
-        // disable an EXISTING account; this is the one sanctioned write, and it targets ONLY a brand-new
-        // account on this create arm - never an existing or adopted one. No permissions are applied - the
-        // account carries Jellyfin's default new-user policy until an administrator enables it, and the
-        // caller reads the disabled state and refuses the login.
-        if (provisionDisabled)
-        {
-            user.SetPermission(PermissionKind.IsDisabled, true);
-        }
-
-        var persisted = false;
+        // Two of those throws already had a rollback of their own and the rest did not. The link write
+        // became a failure of this shape only when the configuration store learned to undo a write that
+        // could not reach the disk (#1521): before that the link survived in memory and a later write
+        // committed it, which was the defect there and, on this one path, an accidental self-heal.
+        //
+        // What reaches the rollback is NOT only a persistence failure, and that is deliberate rather than
+        // incidental: LinkCanonicalIfAbsent also refuses when the provider was deleted or disabled between
+        // the candidate read and the write (AccountLinkForbiddenException), and an account provisioned for
+        // a login that is then refused is the same orphan as one whose disk was full.
+        //
+        // THIS ARM ONLY, and that boundary is the load-bearing half: the adopt arm links an account that
+        // existed before this login and must never delete one. Every account this guard can reach was
+        // created by this invocation, seconds ago, carries no link, and is unreachable by any login.
+        var linked = false;
         try
         {
+            user.AuthenticationProviderId = SsoManagedProviderId.Value;
+
+            // #1139: counted where the account comes into existence, not at the pending-approval audit below.
+            // That line fires only for a provider that holds new accounts for approval, so counting there would
+            // report zero creations on every server that does not - the majority - while accounts were being made
+            // on each of them.
+            SsoMetrics.AccountProvisioned(ProvisioningOutcome.Created);
+
+            // The provider's static provisioning template (#1099), applied HERE and only here: this is the one
+            // arm on which an account is brand new, which is what lets an administrator's later per-user edit
+            // survive every subsequent login. It writes only the fields the template names, so a provider
+            // carrying none provisions byte-identically to before. Ahead of the pending-approval branch below so
+            // an account created inert already carries its policy when an administrator comes to enable it,
+            // rather than getting it on a first login that may never happen.
+            var template = ProvisioningTemplateFor(mode, provider, provisioningProfile);
+            ProvisioningPolicy.ApplyAtProvisioning(user, template);
+            // The manual-login door (#1440), shut as the account comes into existence: a Jellyfin user created
+            // with no password accepts the EMPTY one on the ordinary login form. Minted through the one shared
+            // helper the boot-time sweep also uses, so the two writers cannot drift into two ideas of random.
+            user.Password = ProvisionedPassword.Mint(_cryptoProvider);
+
+            // PERSISTED HERE, once, and this write is the door rather than the two assignments above it (#1440).
+            // The session mint re-resolves the account by id and writes THAT object, so everything set on the
+            // instance CreateUserAsync returned reached no database: the account was persisted routed at
+            // Jellyfin's own password provider with no password stored, which is a Jellyfin account that accepts
+            // the EMPTY password on the ordinary login form. Found by the end-to-end harness reading the account
+            // back after a real login, never by a unit test - every one of them asserts on the in-memory object,
+            // where both writes were always present.
+            //
+            // The pending-approval hold (#737) is applied BEFORE this write rather than after it, so one write
+            // carries the routing, the password and the disabled flag. IsDisabled is otherwise never written by
+            // this plugin and is barred from SSO role mapping (PermissionRolePolicy) precisely so no login can
+            // disable an EXISTING account; this is the one sanctioned write, and it targets ONLY a brand-new
+            // account on this create arm - never an existing or adopted one. No permissions are applied - the
+            // account carries Jellyfin's default new-user policy until an administrator enables it, and the
+            // caller reads the disabled state and refuses the login.
+            if (provisionDisabled)
+            {
+                user.SetPermission(PermissionKind.IsDisabled, true);
+            }
+
             await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-            persisted = true;
+
+            // The home-screen layout (#1101) is a second persistence surface with its own store, written only
+            // once the account row above is persisted: an account that exists is complete without it, and
+            // nothing about a layout may fail a login or roll an account back. Sequenced after the persist for
+            // that reason, and isolated inside.
+            SeedHomeScreen(user.Id, provisionedName, template);
+
+            if (provisionDisabled)
+            {
+                // Audited here, at the actual provisioning event, so the line fires exactly once (not on every
+                // later refused login of the now-pending account) and is always accurate - the completion-path
+                // gate that refuses the login covers any disabled account, including one an admin disabled, so
+                // auditing there would mislabel a deliberate ban as a fresh provisioning.
+                SsoAudit.ProvisionedPendingApproval(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, provisionedName);
+            }
+
+            // Atomic check-then-link (#133): if a concurrent first-login for the same identity
+            // linked meanwhile, use its account - this freshly created user is left unlinked rather
+            // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
+            // link write stamps the login's issuer (#186), so the new link is issuer-bound.
+            // The role-mapped access duration (#1146) travels with the link write and is stamped only when THIS
+            // call actually wrote the link, in the same transaction. That placement is the whole guarantee: the
+            // #133 race loser writes no link and therefore stamps no deadline over the winner's, and a deadline
+            // can only ever come into existence beside a live link, which is what bounds the map.
+            var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer, provisionedAccessDuration);
+
+            // The race loser is the one case that reaches here having written no link and still keeps its
+            // account: LinkCanonicalIfAbsent returns the winner's id rather than throwing, so the guard
+            // closes normally. That orphan is the pre-existing #133 outcome and is not what this guard is
+            // about - it is left exactly as it was rather than quietly widened into an account deletion.
+            linked = true;
+            return effectiveUserId;
         }
         finally
         {
-            if (!persisted)
+            if (!linked)
             {
-                // A create whose persist failed leaves an account that exists, is ENABLED, carries neither
-                // the SSO routing nor a password, and has no link - the exact shape this arm exists to
-                // prevent, reachable from the ordinary login form and adoptable by a later login (with
-                // AllowExistingAccountLink on). Roll it back so the login fails closed with no orphan. The
-                // original failure still propagates out of this finally.
-                await _userManager.DeleteUserAsync(user.Id).ConfigureAwait(false);
+                await RollBackProvisionedAccountAsync(user.Id, provisionedName, mode, provider).ConfigureAwait(false);
             }
         }
+    }
 
-        // The home-screen layout (#1101) is a second persistence surface with its own store, written only
-        // once the account row above is persisted: an account that exists is complete without it, and
-        // nothing about a layout may fail a login or roll an account back. Sequenced after the persist for
-        // that reason, and isolated inside.
-        SeedHomeScreen(user.Id, provisionedName, template);
-
-        if (provisionDisabled)
+    // Deletes an account this login created and could not finish (#1533). Its failure is SWALLOWED, and
+    // that is the whole reason it is a method rather than a line in the finally: a delete that throws
+    // from inside a finally replaces the exception being unwound, and that exception is the only thing
+    // that says what actually went wrong - the full disk, or the refusal the completion path catches by
+    // type to answer 403 rather than 500. The neighbouring rollback claimed "the original failure still
+    // propagates" and did not hold to it; this one does, and says out loud what it cost when it could not.
+    //
+    // The audit line is the second half. The provisioning that preceded this emitted its own lines - the
+    // pending-approval audit, the created-account metric, the legacy-orphan warning - and every one of
+    // them describes an account that no longer exists. This is the line that makes the log coherent again.
+    private async Task RollBackProvisionedAccountAsync(Guid userId, string provisionedName, ProviderMode mode, string provider)
+    {
+        try
         {
-            // Audited here, at the actual provisioning event, so the line fires exactly once (not on every
-            // later refused login of the now-pending account) and is always accurate - the completion-path
-            // gate that refuses the login covers any disabled account, including one an admin disabled, so
-            // auditing there would mislabel a deliberate ban as a fresh provisioning.
-            SsoAudit.ProvisionedPendingApproval(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, provisionedName);
+            await _userManager.DeleteUserAsync(userId).ConfigureAwait(false);
+            SsoAudit.ProvisionedAccountRolledBack(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, provisionedName);
         }
-
-        // Atomic check-then-link (#133): if a concurrent first-login for the same identity
-        // linked meanwhile, use its account - this freshly created user is left unlinked rather
-        // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
-        // link write stamps the login's issuer (#186), so the new link is issuer-bound.
-        // The role-mapped access duration (#1146) travels with the link write and is stamped only when THIS
-        // call actually wrote the link, in the same transaction. That placement is the whole guarantee: the
-        // #133 race loser writes no link and therefore stamps no deadline over the winner's, and a deadline
-        // can only ever come into existence beside a live link, which is what bounds the map.
-        var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer, provisionedAccessDuration);
-        return effectiveUserId;
+#pragma warning disable CA1031 // the failure being unwound must reach the caller, whatever the delete did
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            SsoAudit.ProvisionedAccountRollbackFailed(_logger, provisionedName, ex);
+        }
     }
 
     // Writes the template's home-screen layout (#1101) for a freshly persisted account, and never lets the


### PR DESCRIPTION
# What & why

Closes #1533.

When SSO provisions a new account, several things still have to happen before it is usable: the SSO routing and a minted password, the account write, and the canonical link. A throw anywhere in between left the account behind — existing, **enabled**, carrying neither the routing nor a password, and unlinked. That is the empty-password door on the ordinary login form (#1440), and it also blocks the identity from ever being provisioned again under the same name, because the create-or-adopt gate refuses to adopt an account SSO did not link. Fixing the original failure did not clear it; only a manual deletion did.

Two of those throws already had a rollback of their own; the rest did not. The link write became a failure of this shape only with #1521: before that the link survived in memory and a later write committed it, which was the defect there and, on this one path, an accidental self-heal.

So the two rollbacks become **one guard** from the create to the link write, holding the whole sentence the arm is for — an account created here either ends up linked, or does not exist. That also closes the window between the create and the persist (the password mint, the template application) that neither previous rollback covered.

It is deliberately **not** narrowed to persistence failures: the link write also refuses when the provider was deleted or disabled mid-flight, and an account provisioned for a login that is then refused is the same orphan as one whose disk was full.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. The change strengthens it: the login still fails, and it now fails with nothing left behind. The account it removes is one this invocation created seconds earlier, holds no link, and is unreachable by any login.
- [x] No secrets logged. The two new audit lines carry a protocol, a provider, a username and an exception message; no credential material.
- [x] A security review was performed.
- [x] Review record below.
- [x] Log inputs sanitized inline at the log call — `?.ReplaceLineEndings(string.Empty)` on every field of both new lines, not through a helper.

### Review record

One refute-by-default availability / account-destruction lens on the staged diff, reading the full `CanonicalLinkService.cs`, its only production caller, the resolver, the policy and the shipped Jellyfin metadata. **CONFIRMED 4 / PLAUSIBLE 0** — every finding was reproduced with a probe before it was reported. No second human reader; the evidence below stands in place of one, and that is a statement about what this PR has, not a claim of equivalence.

**The boundary held.** The lens could not refute any of it, and each was checked rather than argued:

- The delete can never reach a pre-existing account. `CreateUserAsync` throws on a name collision per the shipped contract, so `user` is always this invocation's creation; the adopt arm is untouched.
- The #133 race cannot make two logins delete each other — the loser gets the winner's id back rather than an exception, so the guard closes normally. That loser's own orphan is the pre-existing #133 outcome and is left exactly as it was rather than quietly widened into a deletion.
- No last-admin lockout is reachable: `IsAdministrator` is barred from the provisioning template and the grant happens later, past this path.
- No orphaned display preferences: they cascade with the user over a required foreign key.
- No unbounded growth, no lock contention (the delete runs outside the config lock), and no dangling per-user state — the pending-approval check is a live read, not a set.

**Findings, all fixed:**

1. The rollback also fires on the provider-refused exception, which the comment did not admit and no test covered — **FIX**, and it is now the documented intent rather than an accident. `ResolveOrCreateAsync_NewAccount_ProviderDisabledMidFlight_RollsBackTheAccountToo` pins it, and the callee's now-false comment about a "benign orphan" is corrected.
2. A failing delete replaced the exception being unwound, turning a typed 403 into an unhandled 500 and hiding the disk failure — **FIX**. The rollback swallows its own failure and audits it at Error. The neighbouring rollback claimed "the original failure still propagates" and did not hold to it; this one does. `ResolveOrCreateAsync_NewAccount_RollbackItselfFails_TheOriginalFailureStillReachesTheCaller`.
3. The created-account metric, the pending-approval audit and the legacy-orphan warning all described an account that had just been destroyed — **FIX**, a rollback audit line makes that stretch of the log coherent again.
4. A throw between the create and the persist still left an orphan, so "nothing left behind" was not yet true — **FIX**, which is what made this one guard rather than a third one. `ResolveOrCreateAsync_NewAccount_ThrowBeforeThePersist_RollsBackTheAccount`.

The lens also noted the diff touched no operator-facing docs. **FIX** for the CHANGELOG, **DEFER** #1536 for the wiki page (wiki edits are gated on the owner's approval).

## Quality checklist

- [x] No duplicated logic — the change removes two hand-rolled rollbacks and leaves one helper.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting and on the target architecture (#318). The net effect on the create arm is one guard where there were two, plus a named helper.
- [x] Architecture-conformance tests pass. No new structural property.
- [x] Docs impact: the CHANGELOG is here; the wiki half is #1536.

## Verification

- [x] `dotnet build --warnaserror` green on both TFMs, 0 warnings.
- [x] Full suite green on both: **3675** and **3676**, 0 failed, 4 skipped.
- [x] Prettier clean for the changed `.md`.

Falsified before trusted:

| removed | red |
| --- | --- |
| the `DeleteUserAsync` rollback | 3 (including both pre-existing rollback tests) |
| `throw;` restored in the rollback's catch | 1 |

## Notes

- Six tests now cover this arm: three that must roll back (persist failure, link-write failure, pre-persist failure), one that must **not** (the write succeeded), one that must not touch an adopted account, and one that must not lose the original exception.
- The behaviour is operator-visible and new: a user reports a failed sign-in and no account appears in the user list. That is the wanted outcome, and the log says so above the failure that caused it. #1536 carries the wiki text for review.
- What the guard still does not cover, stated rather than implied: the #133 race loser keeps its unlinked account, unchanged from before. That is the same lockout shape, reached by a different route, and it is not this PR's to widen into a deletion without its own reasoning.

### What the coverage bar caught after the first push

The first push was refused by the security-surface **branch** bar at 85.8% against 86.0%, and it was right to be. The five audit lines #1521 and #1533 added each carry an `IsEnabled` guard, a null-logger guard and a null-conditional per field, and the tests reached none of those arms; the SAML arm of the rollback was unreached too, so the line an operator filters by protocol was written by nothing. Three tests now cover them, and the rollback is exercised on both protocols.

Measured with the gate's own command against the artefact it reads, locally before the second push:

```
Security-surface branch coverage: 86.5% (3168/3662 branches)
Security-surface branch bar:      86.0%
Coverage gate: PASS
```

from 85.8% (3142/3662). This is recorded rather than quietly fixed because a bar that refuses a change is evidence about the change, not about the bar.

