### PR TITLE
Record the declarative freeze only once the document is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A declarative document that could not be written still locked its providers
+  against the settings page (#1534).** A provider document mounted as a file or
+  set through the environment freezes the providers it names, so the settings
+  page refuses an edit and points at the document instead. The freeze was
+  recorded before the document was written, and since #1521 a write that cannot
+  reach the disk - a read-only volume, a full disk on a freshly built server -
+  is undone again. The two then disagreed: the document was gone and the freeze
+  stayed, so for the rest of that run the plugin reverted every edit an
+  administrator made to those providers back to values that were in effect
+  nowhere, while the boot log said nothing had been changed. The freeze is now
+  recorded only once the write has landed, so a document that never reached the
+  file locks nothing and the providers stay editable. A document that was
+  already current still freezes its providers, since it writes nothing and has
+  nothing to wait for.
+
 - **A first login that failed half way left an account nobody could use
   (#1533).** When SSO creates a Jellyfin account for a new user, several
   things still have to happen before that account is usable: it is given the

--- a/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeManagedProvidersTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -312,6 +313,30 @@ public class DeclarativeManagedProvidersTests
         Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, document));
         Assert.True(store.ManagedProviders.IsEmpty);
         Assert.Empty(persisted);
+        Assert.Empty(live.OidConfigs);
+    }
+
+    [Fact]
+    public void ADocumentWhosePersistFailed_ManagesNothing()
+    {
+        // The third rejection arm, and the only one that gets all the way past the merge: a valid document
+        // whose write cannot reach the disk - a read-only volume, a full disk, which is what a freshly built
+        // target hits. Since #1521 the store rolls such a write back out of the running configuration, so a
+        // freeze recorded ahead of the write outlives the values it was a freeze FOR: Reinject would spend
+        // the rest of that process reverting an administrator's config-page edits to a document in effect
+        // nowhere, while the boot log said nothing had been changed (#1534). The window is one process
+        // lifetime, and it is exactly the dead end #1415 set out to remove.
+        var live = new PluginConfiguration();
+        var store = new ProviderConfigStore(() => live, _ => throw new IOException("read-only volume"), new CapturingLogger());
+        var document = new PluginConfiguration();
+        document.OidConfigs["keycloak"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "from-the-file" };
+
+        Assert.Throws<IOException>(() => Load(store, document));
+
+        Assert.True(store.ManagedProviders.IsEmpty);
+
+        // And the rollback the freeze must agree with actually happened, so this is a test of the ORDER
+        // rather than of a store that quietly kept the document.
         Assert.Empty(live.OidConfigs);
     }
 

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -327,14 +327,15 @@ internal static class DeclarativeProviderConfig
             return Reject(logger, sourcePath, rejection);
         }
 
-        // Recorded before both accepting returns below, and on BOTH of them (#1102). A document that changed
-        // nothing still decided the providers it names - it agrees with the store rather than being absent
-        // from it - so releasing those providers to the config page whenever a restart happens to find the
-        // mount already applied would make the freeze depend on whether anything moved.
-        store.RecordDeclarativelyManaged(document.Configuration, sourcePath);
-
         if (!changed)
         {
+            // Recorded on this arm too (#1102). A document that changed nothing still decided the providers
+            // it names - it agrees with the store rather than being absent from it - so releasing those
+            // providers to the config page whenever a restart happens to find the mount already applied
+            // would make the freeze depend on whether anything moved. Nothing is written here, so there is
+            // no write for the record to wait on.
+            store.RecordDeclarativelyManaged(document.Configuration, sourcePath);
+
             if (logger?.IsEnabled(LogLevel.Debug) == true)
             {
                 logger.LogDebug(
@@ -356,6 +357,15 @@ internal static class DeclarativeProviderConfig
             // before anything was written and the store persisted nothing.
             return Reject(logger, sourcePath, ex.Message);
         }
+
+        // Recorded only once the write has landed, and the ORDER is the whole of #1534. It used to be taken
+        // before the mutation, and the two agreed until the rollback arrived: a persist failure at boot - a
+        // read-only volume, a full disk - now undoes the document out of the running configuration (#1521)
+        // while the freeze it had already recorded stayed, so Reinject spent the rest of that process
+        // reverting an administrator's config-page edits back to values in effect nowhere, with the boot log
+        // saying nothing had changed. A persist failure escapes past this line - the catch above names
+        // ArgumentException only - so a document that never reached the file freezes nothing.
+        store.RecordDeclarativelyManaged(document.Configuration, sourcePath);
 
         if (logger?.IsEnabled(LogLevel.Information) == true)
         {

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -365,6 +365,15 @@ internal static class DeclarativeProviderConfig
         // reverting an administrator's config-page edits back to values in effect nowhere, with the boot log
         // saying nothing had changed. A persist failure escapes past this line - the catch above names
         // ArgumentException only - so a document that never reached the file freezes nothing.
+        //
+        // WHAT THIS ORDER RESTS ON, so that removing it is a decision rather than an accident: the freeze
+        // is now conditional on the rollback in ProviderConfigStore.Mutate actually undoing a failed write,
+        // and that rollback is allowed to give up - its snapshot may be null and its restore swallows. What
+        // keeps it from giving up here is the DetachedCopy above, which is the same persisted-form round
+        // trip on the same live object under the same lock, moments earlier: a configuration the round trip
+        // cannot survive throws there and never reaches Mutate. That call exists for change detection, not
+        // as a pre-flight for the undo, so an optimisation that replaces it with a cheaper predicate brings
+        // the fail-open back - the document live in memory, its providers editable from the settings page.
         store.RecordDeclarativelyManaged(document.Configuration, sourcePath);
 
         if (logger?.IsEnabled(LogLevel.Information) == true)


### PR DESCRIPTION
# What & why

Closes #1534.

A provider document mounted as a file or set through the environment freezes the
providers it names against the settings page, so a config-page edit to one is
refused and points at the document instead. `DeclarativeProviderConfig.ApplyDocument`
recorded that freeze **before** the `store.Mutate(...)` that applies the document,
and the `catch` around that call names `ArgumentException` only.

The two halves agreed until #1521. A persist failure at boot - a read-only volume,
a full disk, which is exactly what a freshly built target hits - now rolls the
document back out of the running configuration, and the freeze stayed behind. So
for the rest of that process `DeclarativeManagedProviders.Reinject` reverted an
administrator's config-page edits to providers whose declarative values were in
effect nowhere, while the boot log said nothing had changed. That is the dead end
#1415 set out to remove, arriving through the fix for something else.

The record now sits on the already-current arm, which writes nothing and has no
write to wait for, and after `Mutate` returns on the arm that does write.

**Means check:** C#, in the file that already holds the decision. The change is a
reordering of two existing calls in `DeclarativeProviderConfig`; any other means
would be a second home for one rule.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the freeze is a restriction, and it is now taken on the
      same signal that decides whether the document is in effect at all. A document
      that never reached the file freezes nothing because it changes nothing.
- [x] No secrets logged; no log call was added or moved. `sourcePath.ReplaceLineEndings(string.Empty)`
      stays inline at each emission point.
- [x] A security review was performed (see the record below).
- [x] Review record: one lens, `bypass` (auth-bypass / fail-open), run against the
      full files and every caller of `RecordDeclarativelyManaged` and `ManagedProviders`.
      **VERDICT: PASS. CONFIRMED 0 / PLAUSIBLE 0.** Six refutation attempts, each
      failing for a stated reason: nothing between `Mutate` returning and the record;
      `PersistBase` writes the file before it adopts, so there is no "written then
      threw" shape; the merge never removes a key, so the recorded set cannot shrink;
      the only reader of `ManagedProviders` inside a write is `Save`, which `Mutate`
      bypasses; both loaders share the one record site; and the fail-open that would
      matter - the rollback giving up while the document stays live - is pre-empted by
      the `DetachedCopy` round trip `ApplyDocument` already performs on `live` before
      it mutates. One residual, not a defect today: that coupling is invisible at the
      site depending on it. **Disposition: FIX** - the second commit writes it down
      where an optimisation to a cheaper predicate would be made.
- [x] Log inputs are sanitized inline at the log call (unchanged).

**Second reader:** none tonight. The lens record above and the falsifier below are
what stand in place of one, and this line is the disclosure rather than a substitute.

## Quality checklist

- [x] No duplicated logic. The record moves; it is not copied into a new helper. It
      appears twice because the two accepting arms are two different facts - one
      writes and one does not - which is the shape the code already had.
- [x] The change adds no more code than the problem requires: two moved calls, one
      test, one CHANGELOG entry, and comments naming what each order rests on.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. No new structural property: the ordering is
      a fact about one method, and a conformance rule over call order would be a source
      scan pinning a shape rather than the property.
- [x] Docs impact: none. The freeze is described in the wiki as behaviour, and the
      behaviour it describes is what this restores rather than changes - a document
      that was applied still freezes its providers.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj --warnaserror` green on both
      target frameworks: `net9.0` and `net10.0`, 0 warnings, 0 errors.
- [x] Full suite green on both: `net9.0` Total 3680, Failed 0, Skipped 4; `net10.0`
      Total 3681, Failed 0, Skipped 4. (The four skips are the pre-existing LAN-bind
      tests that would raise a Windows firewall consent dialog, #1227.)
- [x] Prettier: only `CHANGELOG.md` is a Prettier subject in this change, and it is
      clean.

**The guard bites.** Putting the call back ahead of the two arms makes
`ADocumentWhosePersistFailed_ManagesNothing` fail - `Assert.True(store.ManagedProviders.IsEmpty)`,
Actual: False - and restoring it makes it pass. The test asserts the rollback happened
as well, so it is a test of the ORDER rather than of a store that quietly kept the
document.

## Notes

The already-current arm keeps its freeze deliberately (#1102): a restart that finds
the mount already applied has not made those providers any less decided by the file,
and a freeze that depended on whether anything moved would release them on exactly the
boot nobody looks at.
