### PR TITLE
Measure what one link import costs, and say why there is no entry cap

### DIFF
--- a/SSO-Auth.Bench/LinkImportCost.cs
+++ b/SSO-Auth.Bench/LinkImportCost.cs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Jellyfin.Plugin.SSO_Auth.Tests;
+using NSubstitute;
+
+namespace Jellyfin.Plugin.SSO_Auth.Bench;
+
+/// <summary>
+/// What one account-link import costs at a realistic migration size (#1522). Nothing bounds how many
+/// entries a document may carry except the one-mebibyte request-size limit, and a minimal entry is small,
+/// so a single body holds on the order of ten thousand of them. The writes and the configuration persist
+/// run inside the process-wide configuration lock - the lock every login waits on - so the number that
+/// matters to an operator planning a migration is how long that lock is held, and nothing said what it was.
+/// </summary>
+/// <remarks>
+/// It measures the endpoint, in process, through the same harness the login benchmark uses, so what is
+/// timed is the real <c>ImportLinks</c> and not a re-implementation of it.
+/// <para>
+/// TWO BOUNDS, PRINTED ON EVERY RUN RATHER THAN LEFT FOR A READER TO INFER. The harness persists through a
+/// mocked <c>IXmlSerializer</c>, so the host's own write to <c>SSO-Auth.xml</c> is not in these numbers and
+/// every figure is a FLOOR. And the username resolution is deliberately outside the lock in
+/// <c>ImportLinks</c>, so the harness resolves from a dictionary rather than a user database: the
+/// per-username cost a real server pays there is real, and it is not lock-held time.
+/// </para>
+/// </remarks>
+internal static class LinkImportCost
+{
+    // The sizes an operator actually plans for. The top of the range is roughly what the one-mebibyte
+    // request-size limit admits, so it is the ceiling this endpoint has today rather than a round number.
+    private static readonly int[] Sizes = { 100, 1000, 5000, 10000 };
+
+    private const string Provider = "bench-idp";
+
+    internal static async Task<int> RunAsync(int iterations, int warmup)
+    {
+        Console.WriteLine("SSO-Auth account-link import cost");
+        Console.WriteLine(Setting("runtime", Environment.Version.ToString() + "  " + System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture));
+        Console.WriteLine(Setting("iterations", iterations.ToString(CultureInfo.InvariantCulture) + " measured, " + warmup.ToString(CultureInfo.InvariantCulture) + " warmup discarded"));
+        Console.WriteLine();
+        Console.WriteLine("The host's own write to SSO-Auth.xml is NOT in these numbers - the harness persists");
+        Console.WriteLine("through a mocked serializer - so every figure is a floor. The username resolution is");
+        Console.WriteLine("outside the configuration lock in ImportLinks and is not lock-held time.");
+        Console.WriteLine();
+        Console.WriteLine(LatencySamples.Header());
+
+        foreach (var size in Sizes)
+        {
+            var samples = new LatencySamples();
+            for (var i = 0; i < warmup + iterations; i++)
+            {
+                // A fresh target per iteration. An import onto a configuration that already holds the
+                // links writes the same keys again, which is a different and cheaper shape than the
+                // restore this measures - and it is the restore an operator runs once, onto an empty
+                // target, that decides how long the lock is held.
+                var harness = Harness();
+                var document = Document(size);
+
+                var started = Stopwatch.GetTimestamp();
+                await harness.Controller.ImportLinks(document).ConfigureAwait(false);
+                var elapsed = Stopwatch.GetTimestamp() - started;
+
+                if (i >= warmup)
+                {
+                    samples.Add(elapsed);
+                }
+            }
+
+            Console.WriteLine(samples.Row("import", size.ToString(CultureInfo.InvariantCulture) + " entries"));
+        }
+
+        return 0;
+    }
+
+    // One provider holding every link, which is the shape a migration off one identity provider has.
+    // Spreading the entries over several providers would move work into the grouping and out of the two
+    // maps the writes go through, and it is not the case an operator plans for.
+    private static SsoControllerHarness Harness()
+    {
+        var harness = new SsoControllerHarness(configuration =>
+            configuration.OidConfigs[Provider] = new OidConfig { Enabled = true });
+
+        // ONE configured call answering every username, and the shape is load-bearing rather than
+        // tidy. Configuring one return per username makes the substitute match an invocation against a
+        // list that grows with the size, so the harness itself becomes quadratic and the numbers it
+        // prints are its own. Measured on the way to this line: a ten-thousand-entry run read 1871 ms at
+        // p50 with per-username returns, against 40 ms with this one - the difference is the mock.
+        harness.UserManager.GetUserByName(Arg.Any<string>()).Returns(call =>
+        {
+            var name = (string)call[0]!;
+            return TestUsers.Named(name, UserId(int.Parse(name[UsernamePrefix.Length..], CultureInfo.InvariantCulture)));
+        });
+
+        return harness;
+    }
+
+    private static LinkExportDocument Document(int size)
+    {
+        var links = new Collection<LinkExportEntry>();
+        for (var i = 0; i < size; i++)
+        {
+            links.Add(new LinkExportEntry
+            {
+                // The literal rather than LinkExport.OpenIdProtocol: that class is internal to the
+                // plugin and this project is not one of its two friends. The protocol name is part of
+                // the document format an operator posts, so it is stable in the same way the field
+                // names around it are.
+                Protocol = "OpenID",
+                Provider = Provider,
+                CanonicalName = "sub-" + i.ToString(CultureInfo.InvariantCulture),
+                Username = Username(i),
+
+                // Carried, because a document taken from a server running any build since #186 carries it
+                // and it is a second map write per entry. A document without it would measure the cheaper
+                // half of the population.
+                Issuer = "https://bench-idp.example.com",
+            });
+        }
+
+        return new LinkExportDocument { FormatVersion = 1, Links = links };
+    }
+
+    private const string UsernamePrefix = "bench-user-";
+
+    private static string Username(int index) => UsernamePrefix + index.ToString(CultureInfo.InvariantCulture);
+
+    // Deterministic and distinct: the import refuses a document mapping one identity to two accounts, and
+    // a fixture that reused an id would be measuring the refusal path instead of the write.
+    private static Guid UserId(int index) =>
+        new Guid(0x7a19e700, 0, 0, 0, 0, 0, 0, 0, (byte)(index >> 16), (byte)(index >> 8), (byte)index);
+
+    private static string Setting(string name, string value) =>
+        string.Create(CultureInfo.InvariantCulture, $"{name,-13}{value}");
+}

--- a/SSO-Auth.Bench/Program.cs
+++ b/SSO-Auth.Bench/Program.cs
@@ -26,16 +26,25 @@ internal static class Program
     private const int DefaultWarmup = 50;
     private const int DefaultConcurrency = 8;
 
+    // Their own defaults, and small on purpose: one ten-thousand-entry import already builds ten thousand
+    // mocked accounts and writes twenty thousand map entries, so five hundred of them would measure the
+    // patience of whoever started the run rather than the endpoint.
+    private const int DefaultLinkImportIterations = 20;
+    private const int DefaultLinkImportWarmup = 3;
+
     private static async Task<int> Main(string[] args)
     {
         int iterations = DefaultIterations, warmup = DefaultWarmup, concurrency = DefaultConcurrency;
+        var linkImport = false;
+        bool iterationsGiven = false, warmupGiven = false;
         for (var i = 0; i < args.Length; i++)
         {
             switch (args[i])
             {
-                case "--iterations": iterations = Number(args, ++i); break;
-                case "--warmup": warmup = Number(args, ++i); break;
+                case "--iterations": iterations = Number(args, ++i); iterationsGiven = true; break;
+                case "--warmup": warmup = Number(args, ++i); warmupGiven = true; break;
                 case "--concurrency": concurrency = Number(args, ++i); break;
+                case "--link-import": linkImport = true; break;
                 case "--help" or "-h": Usage(); return 0;
                 default:
                     Console.Error.WriteLine("Unknown argument: " + args[i]);
@@ -48,6 +57,18 @@ internal static class Program
         {
             Console.Error.WriteLine("--iterations and --concurrency must be at least 1, --warmup at least 0.");
             return 2;
+        }
+
+        // The second scenario is a separate run rather than a section of this one (#1522). It measures a
+        // different subject - how long one bulk admin write holds the configuration lock - and its own
+        // defaults are two orders of magnitude smaller, because a ten-thousand-entry import is not a
+        // thing to do five hundred times. Behind a flag, so the invocation the perf workflow makes is
+        // byte-for-byte the run it has always made.
+        if (linkImport)
+        {
+            return await LinkImportCost.RunAsync(
+                iterationsGiven ? iterations : DefaultLinkImportIterations,
+                warmupGiven ? warmup : DefaultLinkImportWarmup).ConfigureAwait(false);
         }
 
         using var idp = new OidcTokenFixture(Authority, ClientId);
@@ -156,5 +177,6 @@ internal static class Program
         Console.WriteLine("  --iterations N   measured round-trips per scenario (default " + DefaultIterations.ToString(CultureInfo.InvariantCulture) + ")");
         Console.WriteLine("  --warmup N       discarded round-trips per caller before measuring (default " + DefaultWarmup.ToString(CultureInfo.InvariantCulture) + ")");
         Console.WriteLine("  --concurrency N  concurrent callers in the second scenario (default " + DefaultConcurrency.ToString(CultureInfo.InvariantCulture) + ")");
+        Console.WriteLine("  --link-import    measure the account-link import instead (#1522); --iterations defaults to " + DefaultLinkImportIterations.ToString(CultureInfo.InvariantCulture) + ", --warmup to " + DefaultLinkImportWarmup.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/SSO-Auth.Bench/README.md
+++ b/SSO-Auth.Bench/README.md
@@ -17,10 +17,27 @@ dotnet run --project SSO-Auth.Bench -c Release -- --iterations 2000 --warmup 200
 | `--iterations`  | 500     | measured round-trips per scenario                 |
 | `--warmup`      | 50      | round-trips each caller discards before measuring |
 | `--concurrency` | 8       | callers driving the concurrent scenario at once   |
+| `--link-import` | off     | measure the account-link import instead (#1522)   |
 
 The project is **not** in `SSO-Auth.sln`, the same way `SSO-Auth.Fuzz` is not: `dotnet build`,
 `dotnet test`, the coverage gate and the dependency scan all work from the solution and never
 restore or build this. No CI job runs it either.
+
+## The account-link import cost
+
+`--link-import` measures a different subject, and is a separate run rather than a section of the
+one above: how long ONE bulk administrative write holds the process-wide configuration lock, which
+is the lock every login waits on. It drives the real `ImportLinks` through the same harness, at
+100, 1000, 5000 and 10000 entries - the top of that range being roughly what the route's
+one-mebibyte request-size limit admits. `--iterations` defaults to 20 here and `--warmup` to 3,
+because a ten-thousand-entry import is not a thing to do five hundred times.
+
+Two bounds it prints on every run. The harness persists through a mocked serializer, so the host's
+own write to `SSO-Auth.xml` is outside the figures and every one of them is a floor; and the
+username resolution happens outside the lock in `ImportLinks`, so it is real cost but not
+lock-held time. The numbers taken with it live in
+[docs/SERVER-MIGRATION.md](../docs/SERVER-MIGRATION.md), where an operator planning a migration
+reads them.
 
 ## What the two scenarios measure
 

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -201,6 +201,53 @@ number of entries in the file you applied: that comparison is the check on this
 step, and until #1520 it could only be made in the server log, because the
 endpoint answered `204` whatever the number was.
 
+## How long the link import holds the server
+
+The import resolves every username BEFORE it takes the configuration lock, and
+then does the writes and the persist inside it. That lock is the one every login
+waits on, so on a server with many thousands of linked accounts the question is
+how long one import stops logins, and nothing said (#1522).
+
+Nothing bounds the number of entries a document may carry except the
+one-mebibyte request-size limit on the route, and a minimal entry is small, so
+about ten thousand of them fit in one body. That is the ceiling, and it is what
+the top row below measures.
+
+Measured 2026-09-05, Release `net9.0` on .NET 10.0.11 x64, forty measured
+imports per size with five discarded, one OpenID provider, every entry carrying
+an issuer stamp so both maps are written:
+
+```
+dotnet run --project SSO-Auth.Bench -c Release -- --link-import --iterations 40 --warmup 5
+
+scenario   stage            n    p50 ms    p95 ms    p99 ms    max ms
+import     100 entries     40     0.835     0.943     2.883     2.883
+import     1000 entries     40     3.852     6.683    29.502    29.502
+import     5000 entries     40    15.481    22.199    22.652    22.652
+import     10000 entries    40    43.901    76.230   100.581   100.581
+```
+
+**So a restore at the ceiling this route admits holds the lock for tens of
+milliseconds, not seconds.** The cost is close to linear in the number of
+entries. There is no entry cap on the route and this is why: a cap set where it
+would bite would refuse a large real migration, which is the only shape that
+reaches these sizes, and a cap set above the request-size limit would refuse
+nothing.
+
+**Two bounds on those numbers, and both make them a floor rather than a total.**
+The harness persists through a mocked serializer, so the host's own write to
+`SSO-Auth.xml` is not in them - which on a table this size is tens of
+milliseconds again (#1532 measures the serialization alone at 33.6 ms for five
+thousand links). And it runs on whatever box you run it on; the figures above
+are one developer machine, not a claim about yours.
+
+**A trap met while measuring this, because the next person will meet it too.**
+The first run of this harness read 1871 ms at p50 for ten thousand entries -
+forty times the number above - and the cost was the harness. Configuring the
+mocked user manager with one return per username makes it match every call
+against a list that grows with the size, so the instrument was quadratic and the
+endpoint was not. One configured call answering every username removed it.
+
 ## Rolling back
 
 A refused import leaves nothing to undo. Both resolve the whole document before


### PR DESCRIPTION
# What & why

Closes #1522.

Nothing bounds how many entries a link import may carry except the one-mebibyte
request-size limit on the route, and a minimal entry is small, so about ten
thousand fit in one body. Each distinct username costs one `GetUserByName`,
correctly taken before the configuration lock; the writes and the persist then
run inside it, and that is the lock every login waits on. The realistic shape is
not an attack - the route is admin-only, and the limiter returns no verdict for
the loopback or private-network source an administrator running a migration sits
on - it is a large real migration stopping logins for a length nobody had
measured.

#1522 offers two answers and asks for one of them. This takes the second, and the
measurement then settles the first as well.

**Measured 2026-09-05, Release `net9.0` on .NET 10.0.11 x64**, forty measured
imports per size with five discarded, one OpenID provider, every entry carrying
an issuer stamp so both maps are written:

```
dotnet run --project SSO-Auth.Bench -c Release -- --link-import --iterations 40 --warmup 5

scenario   stage            n    p50 ms    p95 ms    p99 ms    max ms
import     100 entries     40     0.835     0.943     2.883     2.883
import     1000 entries    40     3.852     6.683    29.502    29.502
import     5000 entries    40    15.481    22.199    22.652    22.652
import     10000 entries   40    43.901    76.230   100.581   100.581
```

A restore at the ceiling the route admits holds the lock for tens of milliseconds
rather than seconds, and the cost is close to linear. **So no entry cap is added,
and the page says why:** a cap set where it would bite would refuse the large real
migration that is the only shape reaching these sizes, and a cap set above the
request-size limit would refuse nothing.

**Means check:** the measurement goes in `SSO-Auth.Bench`, the harness that
already exists for exactly this - driving the real endpoint in process against
the test project's harness rather than a copy of it - behind a flag, so the run
the perf workflow makes is unchanged. A throwaway script would have produced the
same numbers and left nobody able to re-run them.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

The shipped plugin is not touched: the diff is the benchmark harness, its README
and a migration-runbook section. No `SSO-Auth/` file changes.

- [x] Fail-closed preserved - nothing in the login path, the crypto, the config
      persistence or the release pipeline is reached by this change.
- [x] No secrets logged. The harness constructs synthetic usernames and no
      credential material.
- [ ] A security review was performed - **not run, and this line stays negative.**
      Nothing that ships changes. What the change asserts is a number, and the
      number carries the command that produced it.
- [x] Log inputs sanitized inline: not applicable, nothing new logs.

**Second reader:** none tonight. In place of one, the numbers are reproducible
from the tree by the command quoted beside them, and the one thing a reader
should distrust about them is stated below rather than left to be found.

## Quality checklist

- [x] No duplicated logic. The harness drives the real `ImportLinks` through the
      existing `SsoControllerHarness` rather than re-implementing the import.
- [x] The change adds no more code than the problem requires: one scenario file,
      one flag, and the two pages that carry its output.
- [x] Comments explain why - including the one that exists only because the first
      measurement was wrong.
- [x] Architecture-conformance tests pass; the full suite is green on both target
      frameworks and is untouched by this change.
- [x] Docs impact: `docs/SERVER-MIGRATION.md` gains the section, which is the
      "where an operator planning a migration reads it" half of the Done-when, and
      `SSO-Auth.Bench/README.md` documents the flag. The wiki's `Server-Migration`
      page carries no timing claim, so nothing there is drifted by this.

## Verification

- [x] `dotnet build SSO-Auth.Bench -c Release --warnaserror`: 0 warnings, 0 errors.
- [x] `dotnet build SSO-Auth.Tests --warnaserror` on `net9.0` and `net10.0`:
      0 warnings, 0 errors. Full suite green on both, 3685 tests, 4 skipped (the
      pre-existing LAN-bind tests, #1227).
- [x] Prettier clean for both changed Markdown files, checked against LF copies -
      the working tree is CRLF, so the local check flags every file in the
      repository.
- [x] The perf workflow's invocation is unchanged: it passes `--iterations`,
      `--warmup` and `--concurrency` and no `--link-import`, so it takes the
      login-latency path exactly as before.

## Notes

**The instrument was wrong first, and that is in the change rather than only
here.** The first run read 1871 ms at p50 for ten thousand entries - forty times
the number above. The cost was the harness: configuring the mocked user manager
with one return per username makes it match every call against a list that grows
with the size, so the measuring instrument was quadratic while the endpoint was
not. One configured call answering every username removed it. The trap is written
at the line that avoids it and in the runbook section, because the next person
measuring anything through this harness will meet it.

**Two bounds on every figure, printed on each run and repeated in the page.** The
harness persists through a mocked serializer, so the host's own write to
`SSO-Auth.xml` is outside the numbers and each one is a floor - on a table this
size that write is tens of milliseconds again, which #1532 measures separately.
And the username resolution happens outside the lock in `ImportLinks`, so it is
real cost but not lock-held time.

**One developer machine.** The figures characterise the box they ran on, not
anybody else's, which is the same posture the login benchmark takes and the
reason neither carries a threshold.
