### PR TITLE
Compare the write undo against the write, and answer the atomicity question

### DIFF
--- a/SSO-Auth.Bench/ConfigWriteCost.cs
+++ b/SSO-Auth.Bench/ConfigWriteCost.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Jellyfin.Plugin.SSO_Auth.Tests;
+
+namespace Jellyfin.Plugin.SSO_Auth.Bench;
+
+/// <summary>
+/// What the undo behind a configuration write costs, against the write it is paid on (#1532). Since #1521
+/// every write takes a persisted-form snapshot of the whole configuration before the mutation, so a persist
+/// that throws can be rolled back out of the running server. It is paid inside the process-wide
+/// configuration lock, on top of the serialization the write itself does, and it is paid by writes on the
+/// LOGIN path - the canonical link a first login writes, the hourly last-login stamp, the single-logout
+/// session capture - not only by an administrator saving a form.
+/// </summary>
+/// <remarks>
+/// Two stages per size, on one fixture, in one run:
+/// <list type="bullet">
+/// <item><c>snapshot</c> - <c>PluginConfiguration.ToPersistedForm()</c>, which is exactly what
+/// <c>ProviderConfigStore.Snapshot</c> calls and the whole of the undo's cost.</item>
+/// <item><c>write</c> - the production path, <c>SSOPlugin.MutateConfiguration</c>, snapshot included.</item>
+/// </list>
+/// THE NO-SNAPSHOT BASELINE IS THE DIFFERENCE, AND THAT IS A READING OF THE SOURCE RATHER THAN AN
+/// ESTIMATE. <c>ProviderConfigStore.Mutate</c> calls <c>Snapshot</c> once, at the top, and nothing else in
+/// that method depends on the result except the rollback on the failure path. So removing the undo removes
+/// exactly the first row from the second, and no third measurement would say more than that subtraction
+/// does. There is deliberately no switch in production that turns the undo off for a benchmark to read.
+/// <para>
+/// The persist behind the write row is the real one - the plugin's own, through a mocked serializer - so
+/// the host's write to <c>SSO-Auth.xml</c> is outside every figure and each of them is a floor.
+/// </para>
+/// </remarks>
+internal static class ConfigWriteCost
+{
+    // Link counts spanning a small installation to a large one. The top of the range is where the
+    // persisted-form string is far past the large-object-heap threshold, so it is one LOH allocation per
+    // write - which is the shape of the concern rather than the milliseconds alone.
+    private static readonly int[] Sizes = { 0, 100, 1000, 5000 };
+
+    private const string Provider = "bench-idp";
+    private const string Issuer = "https://bench-idp.example.com";
+
+    internal static int Run(int iterations, int warmup)
+    {
+        Console.WriteLine("SSO-Auth configuration-write cost");
+        Console.WriteLine(Setting("runtime", Environment.Version.ToString() + "  " + System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture));
+        Console.WriteLine(Setting("iterations", iterations.ToString(CultureInfo.InvariantCulture) + " measured, " + warmup.ToString(CultureInfo.InvariantCulture) + " warmup discarded"));
+        Console.WriteLine();
+        Console.WriteLine("The host's own write to SSO-Auth.xml is NOT in these numbers - the harness persists");
+        Console.WriteLine("through a mocked serializer - so every figure is a floor. The no-snapshot baseline is");
+        Console.WriteLine("write minus snapshot: Mutate calls Snapshot once and nothing else reads it.");
+        Console.WriteLine();
+        Console.WriteLine(LatencySamples.Header());
+
+        foreach (var size in Sizes)
+        {
+            var label = size.ToString(CultureInfo.InvariantCulture) + " links";
+            Console.WriteLine(Measure(size, warmup, iterations, snapshotOnly: true).Row("snapshot", label));
+            Console.WriteLine(Measure(size, warmup, iterations, snapshotOnly: false).Row("write", label));
+        }
+
+        return 0;
+    }
+
+    private static LatencySamples Measure(int size, int warmup, int iterations, bool snapshotOnly)
+    {
+        var samples = new LatencySamples();
+
+        // One harness for the whole stage. The plugin it builds is the process-wide singleton, so a fresh
+        // one per iteration would be measuring construction; the mutation below is idempotent, so
+        // repeating it against one configuration measures the write rather than a growing table.
+        var harness = new SsoControllerHarness(configuration => Seed(configuration, size));
+        var live = harness.Configuration;
+
+        for (var i = 0; i < warmup + iterations; i++)
+        {
+            var started = Stopwatch.GetTimestamp();
+            if (snapshotOnly)
+            {
+                _ = live.ToPersistedForm();
+            }
+            else
+            {
+                SSOPlugin.Instance.MutateConfiguration(Touch);
+            }
+
+            var elapsed = Stopwatch.GetTimestamp() - started;
+            if (i >= warmup)
+            {
+                samples.Add(elapsed);
+            }
+        }
+
+        return samples;
+    }
+
+    // The smallest real write there is: one boolean nothing in the loop reads back. Anything larger would
+    // put the mutation's own cost into a measurement about the write around it.
+    private static void Touch(PluginConfiguration configuration) =>
+        configuration.EnableSingleLogout = !configuration.EnableSingleLogout;
+
+    // One OpenID provider carrying `size` links, each with an issuer stamp (#186) and a last-login stamp
+    // (#1120) - the shape a server that has been running a while actually has, and the shape whose
+    // serialization the undo pays for.
+    private static void Seed(PluginConfiguration configuration, int size)
+    {
+        var provider = new OidConfig { Enabled = true, OidEndpoint = Issuer, OidClientId = "bench" };
+        for (var i = 0; i < size; i++)
+        {
+            var canonical = "sub-" + i.ToString(CultureInfo.InvariantCulture);
+            provider.CanonicalLinks[canonical] = UserId(i);
+            provider.CanonicalLinkIssuers[canonical] = Issuer;
+            provider.CanonicalLinkLastLogins[canonical] = DateTime.UtcNow;
+        }
+
+        configuration.OidConfigs[Provider] = provider;
+    }
+
+    private static Guid UserId(int index) =>
+        new Guid(0x7a19e700, 0, 0, 0, 0, 0, 0, 0, (byte)(index >> 16), (byte)(index >> 8), (byte)index);
+
+    private static string Setting(string name, string value) =>
+        string.Create(CultureInfo.InvariantCulture, $"{name,-13}{value}");
+}

--- a/SSO-Auth.Bench/LinkImportCost.cs
+++ b/SSO-Auth.Bench/LinkImportCost.cs
@@ -107,11 +107,7 @@ internal static class LinkImportCost
         {
             links.Add(new LinkExportEntry
             {
-                // The literal rather than LinkExport.OpenIdProtocol: that class is internal to the
-                // plugin and this project is not one of its two friends. The protocol name is part of
-                // the document format an operator posts, so it is stable in the same way the field
-                // names around it are.
-                Protocol = "OpenID",
+                Protocol = LinkExport.OpenIdProtocol,
                 Provider = Provider,
                 CanonicalName = "sub-" + i.ToString(CultureInfo.InvariantCulture),
                 Username = Username(i),
@@ -123,7 +119,7 @@ internal static class LinkImportCost
             });
         }
 
-        return new LinkExportDocument { FormatVersion = 1, Links = links };
+        return new LinkExportDocument { FormatVersion = LinkExport.FormatVersion, Links = links };
     }
 
     private const string UsernamePrefix = "bench-user-";

--- a/SSO-Auth.Bench/Program.cs
+++ b/SSO-Auth.Bench/Program.cs
@@ -32,10 +32,16 @@ internal static class Program
     private const int DefaultLinkImportIterations = 20;
     private const int DefaultLinkImportWarmup = 3;
 
+    // The configuration write is cheap enough to repeat, so this one keeps a sample count that says
+    // something about a tail: the number a login-path write cares about is the slow one, not the median.
+    private const int DefaultConfigWriteIterations = 200;
+    private const int DefaultConfigWriteWarmup = 20;
+
     private static async Task<int> Main(string[] args)
     {
         int iterations = DefaultIterations, warmup = DefaultWarmup, concurrency = DefaultConcurrency;
         var linkImport = false;
+        var configWrite = false;
         bool iterationsGiven = false, warmupGiven = false;
         for (var i = 0; i < args.Length; i++)
         {
@@ -45,6 +51,7 @@ internal static class Program
                 case "--warmup": warmup = Number(args, ++i); warmupGiven = true; break;
                 case "--concurrency": concurrency = Number(args, ++i); break;
                 case "--link-import": linkImport = true; break;
+                case "--config-write": configWrite = true; break;
                 case "--help" or "-h": Usage(); return 0;
                 default:
                     Console.Error.WriteLine("Unknown argument: " + args[i]);
@@ -64,6 +71,13 @@ internal static class Program
         // defaults are two orders of magnitude smaller, because a ten-thousand-entry import is not a
         // thing to do five hundred times. Behind a flag, so the invocation the perf workflow makes is
         // byte-for-byte the run it has always made.
+        if (configWrite)
+        {
+            return ConfigWriteCost.Run(
+                iterationsGiven ? iterations : DefaultConfigWriteIterations,
+                warmupGiven ? warmup : DefaultConfigWriteWarmup);
+        }
+
         if (linkImport)
         {
             return await LinkImportCost.RunAsync(
@@ -178,5 +192,6 @@ internal static class Program
         Console.WriteLine("  --warmup N       discarded round-trips per caller before measuring (default " + DefaultWarmup.ToString(CultureInfo.InvariantCulture) + ")");
         Console.WriteLine("  --concurrency N  concurrent callers in the second scenario (default " + DefaultConcurrency.ToString(CultureInfo.InvariantCulture) + ")");
         Console.WriteLine("  --link-import    measure the account-link import instead (#1522); --iterations defaults to " + DefaultLinkImportIterations.ToString(CultureInfo.InvariantCulture) + ", --warmup to " + DefaultLinkImportWarmup.ToString(CultureInfo.InvariantCulture));
+        Console.WriteLine("  --config-write   measure the configuration write and its undo instead (#1532); --iterations defaults to " + DefaultConfigWriteIterations.ToString(CultureInfo.InvariantCulture) + ", --warmup to " + DefaultConfigWriteWarmup.ToString(CultureInfo.InvariantCulture));
     }
 }

--- a/SSO-Auth.Bench/README.md
+++ b/SSO-Auth.Bench/README.md
@@ -12,12 +12,13 @@ dotnet run --project SSO-Auth.Bench -c Release
 dotnet run --project SSO-Auth.Bench -c Release -- --iterations 2000 --warmup 200 --concurrency 16
 ```
 
-| option          | default | meaning                                           |
-| --------------- | ------- | ------------------------------------------------- |
-| `--iterations`  | 500     | measured round-trips per scenario                 |
-| `--warmup`      | 50      | round-trips each caller discards before measuring |
-| `--concurrency` | 8       | callers driving the concurrent scenario at once   |
-| `--link-import` | off     | measure the account-link import instead (#1522)   |
+| option           | default | meaning                                              |
+| ---------------- | ------- | ---------------------------------------------------- |
+| `--iterations`   | 500     | measured round-trips per scenario                    |
+| `--warmup`       | 50      | round-trips each caller discards before measuring    |
+| `--concurrency`  | 8       | callers driving the concurrent scenario at once      |
+| `--link-import`  | off     | measure the account-link import instead (#1522)      |
+| `--config-write` | off     | measure the configuration write and its undo (#1532) |
 
 The project is **not** in `SSO-Auth.sln`, the same way `SSO-Auth.Fuzz` is not: `dotnet build`,
 `dotnet test`, the coverage gate and the dependency scan all work from the solution and never
@@ -38,6 +39,18 @@ username resolution happens outside the lock in `ImportLinks`, so it is real cos
 lock-held time. The numbers taken with it live in
 [docs/SERVER-MIGRATION.md](../docs/SERVER-MIGRATION.md), where an operator planning a migration
 reads them.
+
+## The configuration-write cost
+
+`--config-write` measures the undo behind a configuration write against the write it is paid on
+(#1532). Every write has taken a persisted-form snapshot of the whole configuration since #1521, so
+a persist that throws can be rolled back out of the running server, and that snapshot is paid inside
+the process-wide lock by writes on the LOGIN path as well as by an administrator saving a form. Two
+rows per size: the snapshot alone, and the production `MutateConfiguration` with it. The no-snapshot
+baseline is the difference, which is a reading of `ProviderConfigStore.Mutate` rather than an
+estimate - it calls `Snapshot` once and nothing else reads the result - and there is deliberately no
+switch in production that turns the undo off for a benchmark. The numbers and the decision they took
+live at that method.
 
 ## What the two scenarios measure
 

--- a/SSO-Auth/AssemblyInfo.cs
+++ b/SSO-Auth/AssemblyInfo.cs
@@ -10,6 +10,13 @@ using System.Runtime.CompilerServices;
 // project does. It is a separate, non-shipping project kept out of the normal build/test path.
 [assembly: InternalsVisibleTo("SSO-Auth.Fuzz")]
 
+// The in-process benchmark harness (SSO-Auth.Bench, #1117) reads two internals directly, and both are
+// there because the number it prints is about them. PluginConfiguration.ToPersistedForm is the whole cost
+// of the undo behind a configuration write (#1521, measured by #1532), and LinkExport.FormatVersion names
+// the document version its import fixture posts. Non-shipping and outside the normal build/test path, the
+// same standing the fuzz harness has above.
+[assembly: InternalsVisibleTo("SSO-Auth.Bench")]
+
 // The VSTest twin of the test project (SSO-Auth.Tests.Stryker, #899) compiles the SAME test sources
 // for the Stryker mutation run only - Stryker's runner speaks VSTest and cannot drive the MTP-v2
 // test project. Non-shipping, outside the normal build/test path; delete with the twin when Stryker

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -133,7 +133,30 @@ internal sealed class ProviderConfigStore
             // an issuer stamp and a last-login stamp per subject: 0.127 ms at no links, 1.576 ms at 100,
             // 6.092 ms at 1000, 33.555 ms at 5000 - against 0.480 / 5.152 / 17.481 / 88.919 ms for a
             // detached copy. It is paid inside this process-wide lock, on top of the serialization the
-            // write itself does, and #1532 holds whether a large installation needs a cheaper undo.
+            // write itself does.
+            //
+            // #1532 ASKED WHAT THAT COSTS AGAINST THE WRITE IT IS PAID ON, AND THE ANSWER IS: NEARLY ALL
+            // OF IT. `dotnet run --project SSO-Auth.Bench -c Release -- --config-write --iterations 300
+            // --warmup 50`, 2026-09-05, Release net9.0 on .NET 10.0.11 x64, p50 ms:
+            //
+            //   links      0      100     1000     5000
+            //   snapshot   0.072  1.275   3.056   33.175
+            //   write      0.129  1.381   3.475   33.521
+            //
+            // The no-snapshot baseline is the difference, and that is a reading of this method rather
+            // than an estimate: Snapshot is called once, here, and nothing below reads the result except
+            // the rollback on the failure path. What the two rows say is that the host's own write is
+            // mocked out of the harness, so the undo is nearly the whole of what this plugin controls.
+            //
+            // THE CURRENT UNDO STANDS, and that is the decision #1532 asked the number to take rather
+            // than a deferral. Thirty-three milliseconds inside this lock on a five-thousand-link server
+            // is real and is not a login anybody notices; the p95 rows in that run are four times the
+            // p50, which is the large-object-heap allocation the string makes, and it is the shape to
+            // watch rather than the median. A cheaper undo exists in principle - record the mutation
+            // rather than the configuration, and replay it backwards - and it costs the property that
+            // makes this one worth having: it would have to be correct for every caller of Mutate,
+            // while a whole-configuration snapshot is correct for a caller nobody has written yet. It
+            // becomes worth building when a deployment reports contention on this lock, and not before.
             var snapshot = Snapshot(live);
 
             try

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -191,6 +191,31 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // SaveConfiguration is the write half alone: it creates the configuration directory and
         // serializes to the same file, and it neither assigns Configuration nor raises
         // ConfigurationChanged. So a throw here reaches the caller with nothing made live.
+        //
+        // THIS WRITE IS NOT ATOMIC AND DOES NOT GO THROUGH A TEMPORARY FILE, WHICH IS A DECISION RATHER
+        // THAN AN OVERSIGHT (#1532). It serializes straight over SSO-Auth.xml with no temporary copy and
+        // no rename, so the failure the line above is about - a disk that fills mid-write - leaves a
+        // truncated file. Three reasons it is left that way, in the order they bind:
+        //
+        // A rename would not save the file it is meant to save. BasePlugin<T>.LoadConfiguration catches
+        // every exception, builds a default configuration AND WRITES IT BACK over the file, so a
+        // truncated SSO-Auth.xml becomes an empty one on the next start with every provider, link and
+        // at-rest secret envelope gone and the evidence overwritten. The destructive half is on the LOAD
+        // side and is the host's; a write-side rename leaves it exactly as it is, and shipping one would
+        // buy the appearance of durability without the fact. That is #1543.
+        //
+        // Owning the write means owning what 'the serializer produced a file' means. Replacing this call
+        // with SerializeToFile-then-rename needs a definition of the temporary file having been written,
+        // and the plugin cannot tell a serializer that wrote nothing from one that wrote in place - the
+        // test harness mocks IXmlSerializer precisely so no file appears, so the rename would throw
+        // through every persisting test in the suite and the repair would be to make the mock write,
+        // which changes what those tests mean.
+        //
+        // And the running server is already covered, which is what #1521 bought: a write that throws is
+        // rolled back out of the live configuration, so the process goes back to the stored state rather
+        // than carrying a change the file does not have. What is not covered is the FILE, and the
+        // operator-facing consequence is stated where an operator reads it, in docs/SERVER-MIGRATION.md:
+        // copy SSO-Auth.xml before a migration step and check it after a failed one, before restarting.
         SaveConfiguration(incoming);
 
         // Then the live object, in place rather than by reference: every reader in this plugin holds the


### PR DESCRIPTION
# What & why

Closes #1532.

Two questions, one from each half of the issue, and both are answered here rather
than deferred.

**What the undo costs, against the write it is paid on.** Since #1521 every
configuration write takes a persisted-form snapshot of the whole configuration
before the mutation, so a persist that throws can be rolled back out of the
running server. It is paid inside the process-wide lock by writes on the LOGIN
path - the canonical link a first login writes, the hourly last-login stamp, the
single-logout capture - not only by an administrator saving a form, and the issue
recorded the snapshot's own cost without anything to compare it to.

Measured 2026-09-05, Release `net9.0` on .NET 10.0.11 x64:

```
dotnet run --project SSO-Auth.Bench -c Release -- --config-write --iterations 300 --warmup 50

scenario   stage            n    p50 ms    p95 ms    p99 ms    max ms
snapshot   0 links        300     0.072     0.139     0.268     2.081
write      0 links        300     0.129     0.161     0.193     1.792
snapshot   100 links      300     1.275     2.009     2.979     3.897
write      100 links      300     1.381     2.020     3.449     3.638
snapshot   1000 links     300     3.056    14.283    19.510    20.898
write      1000 links     300     3.475    13.174    20.194    21.159
snapshot   5000 links     300    33.175    37.895    39.466    44.313
write      5000 links     300    33.521    37.015    39.963    41.463
```

The no-snapshot baseline is the difference, and that is a reading of
`ProviderConfigStore.Mutate` rather than an estimate: it calls `Snapshot` once, at
the top, and nothing below reads the result except the rollback on the failure
path. There is deliberately no switch in production that turns the undo off so a
benchmark can read it.

**THE CURRENT UNDO STANDS**, which is the decision the issue asked the number to
take rather than a deferral. With the host's own file write mocked out of the
harness the undo is nearly the whole of what this plugin controls; 33 ms inside
the lock on a five-thousand-link server is real and is not a login anybody
notices, and a cheaper undo - record the mutation and replay it backwards - costs
the property that makes this one worth having, which is correctness for a caller
of `Mutate` nobody has written yet. It becomes worth building when a deployment
reports contention on this lock. The p95 rows are four times the p50, which is the
large-object-heap allocation the string makes, and that is the shape to watch
rather than the median.

**Whether the write goes through a temporary file.** It does not, and the reason
is now written where `PersistBase` is read. See the Notes: the first of the three
reasons is a finding rather than a cost, and it is filed as #1543.

**Means check:** the measurement goes in `SSO-Auth.Bench`, beside the two
scenarios already there, driving the production `MutateConfiguration` rather than
a re-implementation of it. The two answers go in comments at the two methods they
are about, because a decision about a line is read at that line and nowhere else.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

No behaviour changes. The diff is the benchmark harness, two comment blocks, and
one `InternalsVisibleTo` line.

- [x] Fail-closed preserved. Nothing is added, removed or reordered on the login
      path, the crypto, the config persistence or the release pipeline; the undo
      this measures is unchanged.
- [x] No secrets logged. The harness builds synthetic providers and no credential
      material, and no log call is added or moved.
- [ ] A security review was performed - **not run, and this line stays negative.**
      What ships is one assembly attribute widening the internals to a non-shipping
      harness, beside the two that were already there, and prose. The findings this
      change records were produced by reading, and the one with teeth is filed as
      its own issue rather than fixed in passing.
- [x] Log inputs sanitized inline: unchanged, nothing new logs.

**Second reader:** none tonight. In place of one, the table above is reproducible
from the tree by the command printed beside it, and the two claims that are NOT
measurements - the no-snapshot baseline being a subtraction, and the load-side
behaviour of the base class - are marked as readings rather than runs.

## Quality checklist

- [x] No duplicated logic. The write row drives `SSOPlugin.MutateConfiguration`
      itself; nothing about `Mutate` is re-implemented in the harness.
- [x] The change adds no more code than the problem requires: one scenario file,
      one flag, and the prose the two answers consist of.
- [x] Comments explain why, and both new blocks say what was decided, on what
      number, and what would reopen it.
- [x] Architecture-conformance tests pass. The full suite is green on both target
      frameworks and is untouched by this change.
- [x] Docs impact: `SSO-Auth.Bench/README.md` documents the flag.
      `docs/SERVER-MIGRATION.md` already tells an operator to copy `SSO-Auth.xml`
      before a migration step and check it after a failed one, which is the
      operator-facing half of the atomicity answer and needs no edit.

No CHANGELOG entry: nothing an installation can observe changes.

## Verification

- [x] `dotnet build SSO-Auth.Bench -c Release --warnaserror`: 0 warnings, 0 errors.
- [x] `dotnet build SSO-Auth.Tests --warnaserror` on `net9.0` and `net10.0`: 0
      warnings, 0 errors. Full suite green on both - `net9.0` 3685, `net10.0` 3686,
      0 failed, 4 skipped (the pre-existing LAN-bind tests, #1227).
- [x] Prettier clean for `SSO-Auth.Bench/README.md`, checked against an LF copy.
- [x] The perf workflow's invocation is unchanged: it passes `--iterations`,
      `--warmup` and `--concurrency` and neither new flag, so it takes the
      login-latency path exactly as before.

## Notes

**Why a temporary file and a rename is not what this change ships**, in the order
the reasons bind, all three written at `PersistBase`:

1. **It would not save the file it is meant to save**, and this is a finding
   rather than a cost. `BasePlugin<T>.LoadConfiguration` catches every exception,
   builds a default configuration and **writes it back over the file**, so a
   truncated `SSO-Auth.xml` becomes an empty one on the next start with every
   provider, link and at-rest secret envelope gone - and the truncated file, the
   only thing a person could have repaired, overwritten with it. The destructive
   act is on the LOAD side and is the host's; a write-side rename leaves it exactly
   as it is. Filed as **#1543**, where the scope decision it needs (may this plugin
   refuse to start?) is named rather than taken.
2. **Replacing the host's `SaveConfiguration` means owning what "the serializer
   produced a file" means**, and the plugin cannot tell a serializer that wrote
   nothing from one that wrote in place. The test harness mocks `IXmlSerializer`
   precisely so that no file appears, so a rename would throw through every
   persisting test in the suite, and the repair would be to make the mock write -
   which changes what those tests mean.
3. **The running server is already covered** by #1521, and the file is not, which
   is what the migration runbook already tells an operator to work around.

**A second internals door.** `SSO-Auth.Bench` joins the friend list beside the
fuzz harness. The two members it reads are named in the attribute's comment, both
because the number the harness prints is about them.

**One developer machine**, like every other figure this harness produces, and the
same reason neither scenario carries a threshold. The 1000-link rows are visibly
bimodal between the p50 and the p95; a first run of the same command read 6.3 ms
at the p50 for the snapshot there, against 3.1 ms here, so treat that size as the
noisiest row rather than as a step in the curve.
