### PR TITLE
Give one provider a bulk unlink, gated so it cannot strand the last administrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **A way back from a link import that restored the wrong document (#1519).**
+  `DELETE /sso/{mode}/Links/{provider}/{expectedLinkCount}` removes every
+  canonical link one provider holds. It exists because the link import merges -
+  it adds and overwrites and never removes - so re-importing the correct file
+  after the wrong one does not undo it: the correct document is refused whole,
+  and one leftover entry blocks the restore of every other link. Emptying the
+  provider and importing again clears that, and it is the smallest true way
+  back: a replace mode on the import would be a second destructive path with
+  the same blast radius as the mistake it answers. It touches links and nothing
+  else - no account, no permission and no password - and it creates, adopts and
+  re-points nothing. It is administrator-only, and the confirmation is the
+  server's rather than a browser dialog's: the caller sends the number of links
+  it was shown, and a call written against a stale page is refused instead of
+  emptying a different number than the operator saw. It refuses before removing
+  anything when the result would leave an administrator account with no way to
+  sign in, and names those accounts so the way out is explicit; a link on
+  another provider counts as a way in, and so does a password the account can
+  actually use, which while SSO-only login is on means the break-glass admin
+  alone. Accounts left holding no link at all are signed out; accounts that
+  still hold one elsewhere keep their sessions. The act and every refusal are
+  audited.
+
 - **A starting policy can seed the home screen (#1101).** The provisioning
   template gains a **Home screen sections** list: the sections of the web
   client's home screen, one per line, top slot first, in the exact names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,15 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   emptying a different number than the operator saw. It refuses before removing
   anything when the result would leave an administrator account with no way to
   sign in, and names those accounts so the way out is explicit. A way in is a
-  link on another **enabled** provider - a link left on a disabled one signs
-  nobody in - or a password the account can actually use, which while SSO-only
-  login is on means the break-glass admin alone. It refuses only where it would
-  TAKE the last one, so emptying an already-disabled provider is never blocked.
-  Accounts left holding no link at all are signed out; accounts that still hold
-  one elsewhere keep their sessions. The act and every refusal are audited, and
-  so is the one case the check cannot cover - an account that loses its password
-  door while the run is in flight is named in the log the moment it happens.
+  link on another **enabled** provider and nothing else: a link left on a disabled
+  one signs nobody in, and a stored password proves nothing, because this plugin
+  mints an unusable one onto the accounts it provisions and records nowhere which
+  those were. It refuses only where it would TAKE the last way in, so emptying an
+  already-disabled provider is never blocked. Accounts left holding no link at all
+  are signed out; accounts that still hold one elsewhere keep their sessions. The
+  act and every refusal are audited, and so is the case the check cannot cover: if
+  something changes while the run is in flight, an administrator left without a
+  way in is named in the log the moment it happens.
 
 - **A starting policy can seed the home screen (#1101).** The provisioning
   template gains a **Home screen sections** list: the sections of the web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,15 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   it was shown, and a call written against a stale page is refused instead of
   emptying a different number than the operator saw. It refuses before removing
   anything when the result would leave an administrator account with no way to
-  sign in, and names those accounts so the way out is explicit; a link on
-  another provider counts as a way in, and so does a password the account can
-  actually use, which while SSO-only login is on means the break-glass admin
-  alone. Accounts left holding no link at all are signed out; accounts that
-  still hold one elsewhere keep their sessions. The act and every refusal are
-  audited.
+  sign in, and names those accounts so the way out is explicit. A way in is a
+  link on another **enabled** provider - a link left on a disabled one signs
+  nobody in - or a password the account can actually use, which while SSO-only
+  login is on means the break-glass admin alone. It refuses only where it would
+  TAKE the last one, so emptying an already-disabled provider is never blocked.
+  Accounts left holding no link at all are signed out; accounts that still hold
+  one elsewhere keep their sessions. The act and every refusal are audited, and
+  so is the one case the check cannot cover - an account that loses its password
+  door while the run is in flight is named in the log the moment it happens.
 
 - **A starting policy can seed the home screen (#1101).** The provisioning
   template gains a **Home screen sections** list: the sections of the web

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
@@ -296,7 +296,7 @@ public partial class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 17;
+        const int expectedTypedCallSites = 18;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -60,6 +60,11 @@ public partial class ArchitectureConformanceTests
         // The pre-provision link write (#1133): a config-XML persist under the global lock, and its 404 is
         // an existence answer about a user id, so it is throttled for both reasons the two neighbours are.
         "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}",
+        // The per-provider bulk unlink (#1519): the same config-XML persist under the global lock as the
+        // link writes above, in bulk - and here every REFUSAL pays that persist too, because the count
+        // comparison and the removal are one transaction, so an unthrottled caller could drive the disk
+        // write with nothing but wrong counts.
+        "{mode}/Links/{provider}/{expectedLinkCount}",
     };
 
     // Routes deliberately NOT rate-limited, each with the reason it is safe: an elevation-gated admin
@@ -235,6 +240,7 @@ public partial class ArchitectureConformanceTests
         "SAML/metadata/{provider}", // SP metadata built for a stored provider
         "{mode}/Link/{provider}/{jellyfinUserId}", "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}", // link write against a stored, enabled provider
         "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}", // pre-provision write against a stored, enabled provider (#1133)
+        "{mode}/Links/{provider}/{expectedLinkCount}", // bulk unlink of a STORED provider, 400 on a miss (#1519)
 
         // Not an SSO provider name at all: Unregister's body parameter happens to be called `provider` and
         // carries a JELLYFIN AuthenticationProviderId, written to the user record so the account falls back

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -61,6 +61,10 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The pre-provision link write (#1133): it grants an identity-provider subject the ability to sign
         // in as an account other than the caller's, with no identity-provider response behind it.
         "PreprovisionCanonicalLink",
+        // The per-provider bulk unlink (#1519): it removes canonical links on accounts other than the
+        // caller's, every one of them at once, and it is the only route here that can take a whole server
+        // off SSO in one call. There is no single subject a per-user authorization check could name.
+        "PurgeProviderLinks",
         // The mappable permission vocabulary (#1484): read-only and installation-independent, and
         // elevation-gated because the config page is the only caller it exists for - an anonymous route
         // would be a new unauthenticated surface bought for nothing.

--- a/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the per-provider bulk unlink (#1519), the way back from a link import that restored
+/// the wrong document. The action can take every account on a server off SSO in one call, so what is pinned
+/// here is the gate rather than the happy path: elevation, an unknown provider, the caller-supplied count
+/// checked server-side, and the mass-lockout refusal (T-D1) with each of the three things that count as a
+/// way in for an administrator - a link on another provider, a usable password, and - the one a reader gets
+/// wrong - a password that is NOT usable because SSO-only login has taken that door away from every account
+/// but the break-glass admin.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerPurgeProviderLinksTests
+{
+    private static readonly Guid AliceId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+    private static readonly Guid BobId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
+    private static readonly Guid RootId = Guid.Parse("cccccccc-0000-0000-0000-000000000003");
+
+    [Fact]
+    public void PurgeProviderLinks_RequiresElevation()
+    {
+        // It acts on accounts the caller does not own, so no per-user authorization check can stand in for
+        // the elevation gate - there is no single subject to check against (STRIDE S, #1519).
+        var authorize = typeof(SSOController).GetMethod(nameof(SSOController.PurgeProviderLinks))!.GetCustomAttribute<AuthorizeAttribute>();
+
+        Assert.NotNull(authorize);
+        Assert.Equal(Policies.RequiresElevation, authorize!.Policy);
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_UnknownMode_IsRefused()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.PurgeProviderLinks("ldap", "keycloak", 0);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_UnknownProvider_IsRefused_AndTouchesNothing()
+    {
+        // A name that resolves to no configured provider must refuse rather than fall through to an empty
+        // match that reports success on the wrong table (STRIDE T).
+        var harness = SeedProvider(links: 2);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "not-configured", 2);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(2, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_CountTheCallerDidNotExpect_IsRefused_AndTouchesNothing()
+    {
+        // The confirmation is a server-side precondition, not a browser dialog: a call written against a
+        // stale page refuses instead of removing a different number of links than the operator was shown.
+        var harness = SeedProvider(links: 3);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        var conflict = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(409, conflict.StatusCode);
+        Assert.Contains("holds 3 link(s)", conflict.Value?.ToString(), StringComparison.Ordinal);
+        Assert.Equal(3, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_MatchingCount_RemovesEveryLink_AndAnswersWhatItDid()
+    {
+        var harness = SeedProvider(links: 3);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 3);
+
+        var document = Assert.IsType<ProviderLinkPurgeDocument>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(3, document.Removed);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_TakesTheIssuerDeadlineAndLastLoginStampsWithTheLinks()
+    {
+        // The stamps are keyed on the links; leaving one behind would judge a re-link of the same subject
+        // against a stale issuer binding (#186), expire it on the next sweep tick (#1145), or report a
+        // "last SSO login" that belongs to the previous holder of the key (#1120).
+        var harness = SeedProvider(links: 1);
+        SSOPlugin.Instance.MutateConfiguration(c =>
+        {
+            var config = c.OidConfigs["keycloak"];
+            config.CanonicalLinkIssuers["sub-0"] = "https://idp.example";
+            config.CanonicalLinkDeadlines["sub-0"] = DateTime.UtcNow.AddDays(1);
+            config.CanonicalLinkLastLogins["sub-0"] = DateTime.UtcNow;
+        });
+
+        await harness.Controller.PurgeProviderLinks("oid", "keycloak", 1);
+
+        SSOPlugin.Instance.ReadConfiguration(c =>
+        {
+            var config = c.OidConfigs["keycloak"];
+            Assert.Empty(config.CanonicalLinks);
+            Assert.Empty(config.CanonicalLinkIssuers);
+            Assert.Empty(config.CanonicalLinkDeadlines);
+            Assert.Empty(config.CanonicalLinkLastLogins);
+            return 0;
+        });
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_SignsOutOnlyTheAccountsLeftWithNoLinkAnywhere()
+    {
+        // The same scope the single unlink revokes at (#468): an account that keeps a link on another
+        // provider still has a working SSO identity, so revoking it would be an unscoped mass-logout with
+        // no security gain.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = AliceId, ["sub-bob"] = BobId },
+            };
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-bob"] = BobId },
+            };
+        });
+        SeedUser(harness, "alice", AliceId);
+        SeedUser(harness, "bob", BobId);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        var document = Assert.IsType<ProviderLinkPurgeDocument>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(2, document.Removed);
+        Assert.Equal(1, document.SignedOut);
+        await harness.SessionManager.Received(1).RevokeUserTokens(AliceId, null);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(BobId, null);
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_ThatWouldTakeAnAdministratorsLastWayIn_IsRefused_AndTouchesNothing()
+    {
+        // T-D1 on this surface. The administrator signs in through this provider alone and holds no usable
+        // password, so emptying the table would lock the server's own administration out - and the run
+        // REFUSES rather than quietly keeping that one link, which would leave the provider not empty while
+        // the answer said it was.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        var conflict = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(409, conflict.StatusCode);
+        Assert.Contains("root", conflict.Value?.ToString(), StringComparison.Ordinal);
+        Assert.Equal(2, LinkCount(harness));
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_WithAnAdministratorWhoCanStillUseAPassword_Proceeds()
+    {
+        // The falsifier for the refusal above: one field changes - the administrator has a usable password
+        // door - and the same call goes through. Without it the guard could be refusing for any reason.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_WithAnAdministratorLinkedToAnotherProvider_Proceeds()
+    {
+        // The second way in: a link on another provider. The administrator loses the keycloak link and can
+        // still sign in through adfs, so this run takes nobody's last door.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+        SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-root"] = RootId },
+        });
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_UnderSsoOnlyLogin_DoesNotCountANonExemptAdministratorsPassword()
+    {
+        // The reading a hand-written guard gets wrong. The administrator routes to the built-in password
+        // provider and carries a stored password, so the account-side reading says "has a password door" -
+        // but SSO-only login is on and this account is not the designated break-glass admin, so that door is
+        // shut for it. Counting it would strand exactly the administrator the mode was configured to keep
+        // out of the password path.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
+        SSOPlugin.Instance.MutateConfiguration(c =>
+        {
+            c.DisablePasswordLogin = true;
+            c.BreakGlassAdminUsername = "somebody-else";
+        });
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.Equal(409, Assert.IsType<ObjectResult>(result).StatusCode);
+        Assert.Equal(2, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_UnderSsoOnlyLogin_CountsTheBreakGlassAdministratorsPassword()
+    {
+        // The other half of the same rule, so the test above cannot pass merely because the mode flag
+        // refuses everything: the break-glass admin is the one account whose password door the mode leaves
+        // standing, and the purge goes through.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
+        SSOPlugin.Instance.MutateConfiguration(c =>
+        {
+            c.DisablePasswordLogin = true;
+            c.BreakGlassAdminUsername = "root";
+        });
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_WithADisabledAdministrator_Proceeds()
+    {
+        // A disabled account already has no way in, so this run takes nothing from it. Refusing here would
+        // make a disabled administrator a permanent block on an action that exists to unstick a server.
+        var harness = SeedProvider(links: 1);
+        var root = SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+        root.SetPermission(PermissionKind.IsDisabled, true);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_OnADisabledProvider_StillRemoves()
+    {
+        // Removal REVOKES a grant, so it must keep working on a disabled provider - disable-then-clean-up is
+        // the workflow this action exists for (#380).
+        var harness = SeedProvider(links: 2);
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["keycloak"].Enabled = false);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_AuditsBothTheActAndTheRefusal()
+    {
+        // A bulk removal must not reach an operator as N indistinguishable per-user lines with no statement
+        // of the act, and a blocked mass-lockout must leave a trail of its own (T-R1).
+        var harness = SeedProvider(links: 2);
+
+        await harness.Controller.PurgeProviderLinks("oid", "keycloak", 1);
+        await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        var log = string.Join("\n", harness.ControllerLog.Records.ConvertAll(r => r.Message));
+        Assert.Contains("Bulk unlink REFUSED", log, StringComparison.Ordinal);
+        Assert.Contains("CountMismatch", log, StringComparison.Ordinal);
+        Assert.Contains("Every canonical link on", log, StringComparison.Ordinal);
+    }
+
+    // A provider carrying `links` canonical links, each on its own account, none of them an administrator.
+    private static SsoControllerHarness SeedProvider(int links)
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            var config = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid>() };
+            for (var i = 0; i < links; i++)
+            {
+                config.CanonicalLinks["sub-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture)] = Guid.NewGuid();
+            }
+
+            c.OidConfigs["keycloak"] = config;
+        });
+
+        return harness;
+    }
+
+    // An administrator whose only link is the given one on keycloak, with or without a usable password door.
+    private static User SeedAdminLinkedTo(SsoControllerHarness harness, string name, Guid id, string canonicalName, bool withPassword)
+    {
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks[canonicalName] = id);
+
+        var user = SeedUser(harness, name, id);
+        user.SetPermission(PermissionKind.IsAdministrator, true);
+        if (withPassword)
+        {
+            user.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
+            user.Password = "hash-" + name;
+        }
+
+        return user;
+    }
+
+    private static User SeedUser(SsoControllerHarness harness, string name, Guid id)
+    {
+        var user = TestUsers.Named(name, id);
+        harness.UserManager.GetUserById(id).Returns(user);
+        harness.UserManager.GetUserByName(name).Returns(user);
+        return user;
+    }
+
+    private static int LinkCount(SsoControllerHarness harness)
+        => SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.Count);
+}

--- a/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
@@ -85,6 +85,42 @@ public class SSOControllerPurgeProviderLinksTests
     }
 
     [Fact]
+    public async Task PurgeProviderLinks_RefusedOnACount_WritesNothingToDisk()
+    {
+        // A count that does not match is this route's NORMAL outcome - a page that went stale - and every
+        // return out of a configuration mutation persists the file even when it changed nothing. This
+        // plugin's write is not atomic (#1532), so a routine refusal that rewrites SSO-Auth.xml is a
+        // routine chance to truncate it. The survey answers this one without entering a mutation.
+        var harness = SeedProvider(links: 3);
+        harness.Xml.ClearReceivedCalls();
+
+        await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+        await harness.Controller.PurgeProviderLinks("oid", "not-configured", 2);
+
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_StrandingRefusal_NamesAtMostTenAdministrators()
+    {
+        // The refusal names the way out, and on a server where many accounts hold administrator that would
+        // otherwise be a roster-sized body driven by one request. Capped like the link import's own refusal.
+        var harness = SeedProvider(links: 0);
+        for (var i = 0; i < 12; i++)
+        {
+            var name = "admin" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            SeedAdminLinkedTo(harness, name, Guid.NewGuid(), "sub-" + name, withPassword: false);
+        }
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 12);
+
+        var conflict = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(409, conflict.StatusCode);
+        Assert.Contains("and 2 more", conflict.Value?.ToString(), StringComparison.Ordinal);
+        Assert.Equal(12, LinkCount(harness));
+    }
+
+    [Fact]
     public async Task PurgeProviderLinks_MatchingCount_RemovesEveryLink_AndAnswersWhatItDid()
     {
         var harness = SeedProvider(links: 3);
@@ -134,10 +170,12 @@ public class SSOControllerPurgeProviderLinksTests
         {
             c.OidConfigs["keycloak"] = new OidConfig
             {
+                Enabled = true,
                 CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = AliceId, ["sub-bob"] = BobId },
             };
             c.SamlConfigs["adfs"] = new SamlConfig
             {
+                Enabled = true,
                 CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-bob"] = BobId },
             };
         });
@@ -195,6 +233,7 @@ public class SSOControllerPurgeProviderLinksTests
         SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
         SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"] = new SamlConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-root"] = RootId },
         });
 
@@ -239,6 +278,45 @@ public class SSOControllerPurgeProviderLinksTests
             c.DisablePasswordLogin = true;
             c.BreakGlassAdminUsername = "root";
         });
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_WithAnAdministratorLinkedOnlyToADisabledProvider_IsRefused()
+    {
+        // The falsifier for the test above, and the reason the guard reads Enabled at all. The
+        // administrator holds a second link - but on a provider somebody disabled, and the login path
+        // resolves through TryGetLinks(requireEnabled: true), so that link signs nobody in. Counting it as
+        // a way in would strand the administrator on exactly the disable-then-clean-up workflow this route
+        // exists for (#380), which is how this guard fail-opened before it shipped.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+        SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-root"] = RootId },
+        });
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.Equal(409, Assert.IsType<ObjectResult>(result).StatusCode);
+        Assert.Equal(2, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_OnADisabledProvider_DoesNotRefuseForWhatItTakesNothingFrom()
+    {
+        // The other direction of the same reading, and the one a guard written only against Enabled would
+        // get wrong the opposite way. The target provider is already disabled, so its links are not a way
+        // in BEFORE the run either - the administrator is no worse off afterwards, and refusing here would
+        // make a disabled provider impossible to clean up, which is the workflow the route is for.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["keycloak"].Enabled = false);
 
         var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
 
@@ -296,7 +374,9 @@ public class SSOControllerPurgeProviderLinksTests
     {
         var harness = new SsoControllerHarness(c =>
         {
-            var config = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid>() };
+            // Enabled, because that is what makes its links a way in: the login path resolves through
+            // TryGetLinks(requireEnabled: true), so a link on a disabled provider signs nobody in.
+            var config = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid>() };
             for (var i = 0; i < links; i++)
             {
                 config.CanonicalLinks["sub-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture)] = Guid.NewGuid();

--- a/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerPurgeProviderLinksTests.cs
@@ -211,17 +211,25 @@ public class SSOControllerPurgeProviderLinksTests
     }
 
     [Fact]
-    public async Task PurgeProviderLinks_WithAnAdministratorWhoCanStillUseAPassword_Proceeds()
+    public async Task PurgeProviderLinks_WithAnAdministratorHoldingAStoredPassword_IsStillRefused()
     {
-        // The falsifier for the refusal above: one field changes - the administrator has a usable password
-        // door - and the same call goes through. Without it the guard could be refusing for any reason.
+        // A STORED PASSWORD IS NOT A WAY IN HERE, and this is the reading the whole guard turns on. This
+        // plugin mints an unguessable password onto every account it provisions and onto every passwordless
+        // linked account it finds at boot (#1440), records nowhere which accounts those were, and the hash
+        // it writes is the same field and the same shape as a real one. So a non-empty User.Password is a
+        // secret somebody holds or a seal nobody can open, and nothing in the tree separates them. Counting
+        // it would clear this guard for every SSO-provisioned administrator on a server whose provider
+        // routes accounts to the built-in password provider - silently, which is the lockout it exists to
+        // refuse. The cost is this refusal, and the ways out are in its message.
         var harness = SeedProvider(links: 1);
         SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
 
         var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
 
-        Assert.IsType<OkObjectResult>(result);
-        Assert.Equal(0, LinkCount(harness));
+        var conflict = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(409, conflict.StatusCode);
+        Assert.Contains("stored password does not count", conflict.Value?.ToString(), StringComparison.Ordinal);
+        Assert.Equal(2, LinkCount(harness));
     }
 
     [Fact]
@@ -235,48 +243,6 @@ public class SSOControllerPurgeProviderLinksTests
         {
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-root"] = RootId },
-        });
-
-        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.Equal(0, LinkCount(harness));
-    }
-
-    [Fact]
-    public async Task PurgeProviderLinks_UnderSsoOnlyLogin_DoesNotCountANonExemptAdministratorsPassword()
-    {
-        // The reading a hand-written guard gets wrong. The administrator routes to the built-in password
-        // provider and carries a stored password, so the account-side reading says "has a password door" -
-        // but SSO-only login is on and this account is not the designated break-glass admin, so that door is
-        // shut for it. Counting it would strand exactly the administrator the mode was configured to keep
-        // out of the password path.
-        var harness = SeedProvider(links: 1);
-        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
-        SSOPlugin.Instance.MutateConfiguration(c =>
-        {
-            c.DisablePasswordLogin = true;
-            c.BreakGlassAdminUsername = "somebody-else";
-        });
-
-        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
-
-        Assert.Equal(409, Assert.IsType<ObjectResult>(result).StatusCode);
-        Assert.Equal(2, LinkCount(harness));
-    }
-
-    [Fact]
-    public async Task PurgeProviderLinks_UnderSsoOnlyLogin_CountsTheBreakGlassAdministratorsPassword()
-    {
-        // The other half of the same rule, so the test above cannot pass merely because the mode flag
-        // refuses everything: the break-glass admin is the one account whose password door the mode leaves
-        // standing, and the purge goes through.
-        var harness = SeedProvider(links: 1);
-        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: true);
-        SSOPlugin.Instance.MutateConfiguration(c =>
-        {
-            c.DisablePasswordLogin = true;
-            c.BreakGlassAdminUsername = "root";
         });
 
         var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
@@ -351,6 +317,25 @@ public class SSOControllerPurgeProviderLinksTests
 
         Assert.IsType<OkObjectResult>(result);
         Assert.Equal(0, LinkCount(harness));
+    }
+
+    [Fact]
+    public async Task PurgeProviderLinks_OnADisabledProvider_DoesNotReportALockoutItDidNotCause()
+    {
+        // The after-the-fact check exists to catch a race, and its line says so - "they were judged to have
+        // one, so something changed in between". On a provider that was already switched off nothing
+        // changed and nothing was taken: the administrator had no way in before the run either. Printing
+        // the line here would cry wolf on the exact workflow the route is for, in the one line whose value
+        // is that it means a real race happened.
+        var harness = SeedProvider(links: 1);
+        SeedAdminLinkedTo(harness, "root", RootId, "sub-root", withPassword: false);
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["keycloak"].Enabled = false);
+
+        var result = await harness.Controller.PurgeProviderLinks("oid", "keycloak", 2);
+
+        Assert.IsType<OkObjectResult>(result);
+        var log = string.Join("\n", harness.ControllerLog.Records.ConvertAll(r => r.Message));
+        Assert.DoesNotContain("have no way to sign in", log, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Linking/AdministratorsWithNoWayInTests.cs
+++ b/SSO-Auth.Tests/Linking/AdministratorsWithNoWayInTests.cs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The safety net under the per-provider bulk unlink (#1519). The gate refuses a run that would leave an
+/// administrator with no way to sign in, and it judges accounts resolved before the removal took the
+/// configuration lock; an account can lose a way in inside that window without any link moving, and no
+/// link-table comparison can see it. So the same question is asked once more afterwards, and what it names
+/// reaches the operator as an Error line rather than as a locked-out administrator at their next sign-in.
+/// <para>
+/// A unit, because the branch it reports on is by construction unreachable through the endpoint on a
+/// server nothing else is writing to: the gate has already refused every account this could name. What
+/// makes it fire is a concurrent change, which is exactly what a test cannot stage through one HTTP call.
+/// </para>
+/// </summary>
+public class AdministratorsWithNoWayInTests
+{
+    private static readonly Guid RootId = Guid.Parse("dddddddd-0000-0000-0000-000000000001");
+    private static readonly Guid AliceId = Guid.Parse("dddddddd-0000-0000-0000-000000000002");
+
+    [Fact]
+    public void AnAdministratorHoldingNoLinkAtAll_IsNamed()
+    {
+        var service = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var named = service.AdministratorsWithNoWayIn(new[] { Admin("root", RootId) });
+
+        Assert.Equal(new[] { "root" }, named);
+    }
+
+    [Fact]
+    public void AnAdministratorStillLinkedToAnEnabledProvider_IsNot()
+    {
+        // The falsifier: one thing changes - a live link somewhere - and the same account is silent.
+        var service = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-root"] = RootId },
+        });
+
+        Assert.Empty(service.AdministratorsWithNoWayIn(new[] { Admin("root", RootId) }));
+    }
+
+    [Fact]
+    public void AnAdministratorWhoseOnlyLinkIsOnADisabledProvider_IsNamed()
+    {
+        // The reading the whole guard turns on, in its after-the-fact form: a login resolves a link only on
+        // an enabled provider, so a link left on one somebody switched off is not a way in.
+        var service = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-root"] = RootId },
+        });
+
+        Assert.Equal(new[] { "root" }, service.AdministratorsWithNoWayIn(new[] { Admin("root", RootId) }));
+    }
+
+    [Fact]
+    public void ANonAdministratorAndADisabledAdministrator_AreNotNamed()
+    {
+        // This line exists for the accounts that keep a server administrable. An ordinary account without a
+        // link is the normal outcome of the run, and a disabled administrator had no way in before it.
+        var service = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var alice = new AccountDoors(AliceId, "alice", IsAdministrator: false, IsDisabled: false, RoutesToPasswordProvider: true, HasStoredPassword: true);
+        var disabled = new AccountDoors(RootId, "root", IsAdministrator: true, IsDisabled: true, RoutesToPasswordProvider: false, HasStoredPassword: false);
+
+        Assert.Empty(service.AdministratorsWithNoWayIn(new[] { alice, disabled }));
+    }
+
+    [Fact]
+    public void AStoredPasswordDoesNotKeepAnAdministratorOutOfTheLine()
+    {
+        // The same reading the gate takes: this plugin mints an unguessable password onto the accounts it
+        // provisions (#1440) and records nowhere which those were, so a non-empty stored password proves
+        // nothing about whether anybody can sign in with it.
+        var service = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var withPassword = new AccountDoors(RootId, "root", IsAdministrator: true, IsDisabled: false, RoutesToPasswordProvider: true, HasStoredPassword: true);
+
+        Assert.Equal(new[] { "root" }, service.AdministratorsWithNoWayIn(new[] { withPassword }));
+    }
+
+    private static AccountDoors Admin(string name, Guid id)
+        => new(id, name, IsAdministrator: true, IsDisabled: false, RoutesToPasswordProvider: false, HasStoredPassword: false);
+
+    private static CanonicalLinkService Build(Action<PluginConfiguration> configure)
+    {
+        var configuration = new PluginConfiguration();
+        configure(configuration);
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+
+        return new CanonicalLinkService(
+            Substitute.For<IUserManager>(),
+            new FakeCryptoProvider(),
+            store,
+            new CapturingLogger(),
+            new IntervalGate(TimeSpan.FromMinutes(1)));
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -525,6 +525,64 @@ internal static class SsoAudit
             jellyfinUserId);
     }
 
+    /// <summary>
+    /// Records an administrator removing every canonical link one provider holds (#1519). One line for the
+    /// act, at Warning, because a bulk removal of a thousand links must not reach an operator as a thousand
+    /// indistinguishable per-user lines with no statement of what was done - the per-account detail is
+    /// written at Information beneath it by the caller, for the accounts whose last link this took.
+    /// </summary>
+    /// <remarks>
+    /// The actor is named because this is an action taken on other people's accounts, and the counts are
+    /// what tell an operator whether the run matched the provider they meant. No canonical subject and no
+    /// account name is a field here (T-I1): the removal is identified by the provider it emptied.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="actor">The elevated administrator who ran the unlink.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider whose link table was emptied.</param>
+    /// <param name="removedLinks">How many links were removed.</param>
+    /// <param name="revokedAccounts">How many accounts lost their last SSO link and had their live tokens revoked.</param>
+    internal static void ProviderLinksPurged(ILogger logger, string actor, string protocol, string provider, int removedLinks, int revokedAccounts)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Every canonical link on {Protocol} '{Provider}' removed by {Actor}: {RemovedLinks} link(s) gone, {RevokedAccounts} account(s) left with no SSO link and signed out. No Jellyfin account, permission or password was changed.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty),
+            removedLinks,
+            revokedAccounts);
+    }
+
+    /// <summary>
+    /// Records a per-provider bulk unlink being REFUSED (#1519), so a blocked mass-lockout leaves a trail
+    /// (T-R1) exactly as a blocked SSO-only activation does. The reason is a fixed verdict CODE, never
+    /// caller input and never the account names the refusal itself carries (T-I1).
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="actor">The elevated administrator whose unlink was refused.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider named in the request.</param>
+    /// <param name="reasonCode">The refusal verdict name (a fixed enum member, not user input).</param>
+    internal static void ProviderLinksPurgeRefused(ILogger logger, string actor, string protocol, string provider, string reasonCode)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Bulk unlink REFUSED for {Actor} on {Protocol} '{Provider}' ({ReasonCode}). No link was removed.",
+            actor?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            reasonCode);
+    }
+
     /// <summary>Records SSO-only login being turned on (#165), with the guaranteed break-glass survivor.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="actor">The elevated administrator who enabled the mode.</param>

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -541,22 +541,50 @@ internal static class SsoAudit
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider whose link table was emptied.</param>
     /// <param name="removedLinks">How many links were removed.</param>
-    /// <param name="revokedAccounts">How many accounts lost their last SSO link and had their live tokens revoked.</param>
-    internal static void ProviderLinksPurged(ILogger logger, string actor, string protocol, string provider, int removedLinks, int revokedAccounts)
+    /// <param name="unlinkedAccounts">How many accounts were left holding no SSO link at all.</param>
+    /// <param name="signedOut">How many of those the token revocation actually reached.</param>
+    internal static void ProviderLinksPurged(ILogger logger, string actor, string protocol, string provider, int removedLinks, int unlinkedAccounts, int signedOut)
     {
         if (!logger.IsEnabled(LogLevel.Warning))
         {
             return;
         }
 
+        // The two counts are separate on purpose. Collapsing them would report the accounts left without
+        // an SSO link as the accounts signed out, and a revoke that threw would then be invisible: the
+        // line would understate what happened by exactly the accounts still holding a live session.
         logger.LogWarning(
-            "[SSO Audit] Every canonical link on {Protocol} '{Provider}' removed by {Actor}: {RemovedLinks} link(s) gone, {RevokedAccounts} account(s) left with no SSO link and signed out. No Jellyfin account, permission or password was changed.",
+            "[SSO Audit] Every canonical link on {Protocol} '{Provider}' removed by {Actor}: {RemovedLinks} link(s) gone, {UnlinkedAccounts} account(s) left with no SSO link, {SignedOut} of them signed out. No Jellyfin account, permission or password was changed.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty),
             actor?.ReplaceLineEndings(string.Empty),
             removedLinks,
-            revokedAccounts);
+            unlinkedAccounts,
+            signedOut);
     }
+
+    /// <summary>
+    /// Records that a bulk unlink left an administrator account with no way to sign in after all (#1519).
+    /// The gate refuses that outcome, so this line means the gate was right when it ran and the world
+    /// moved underneath it: an account can lose its password door between being judged and the removal
+    /// committing, without any link moving, which no link-table comparison can see.
+    /// </summary>
+    /// <remarks>
+    /// Error, and it names the accounts, because it is the one line that turns a silent lockout into a
+    /// repair somebody can make: give one of them a usable password, or re-link it. The caller is an
+    /// elevated administrator and the log is the operator's own, so naming them discloses nothing the
+    /// account roster does not.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider whose links were removed.</param>
+    /// <param name="administrators">The rendered list of administrator accounts now without a way in.</param>
+    internal static void ProviderLinksPurgeStrandedAdministrator(ILogger logger, string protocol, string provider, string administrators)
+        => logger.LogError(
+            "[SSO Audit] After emptying {Protocol} '{Provider}', these administrator account(s) have no way to sign in: {Administrators}. They were judged to have one when the run was checked, so something changed in between. Give one of them a usable password or re-link it.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            administrators?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records a per-provider bulk unlink being REFUSED (#1519), so a blocked mass-lockout leaves a trail

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -2282,6 +2282,138 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Removes every canonical link one provider holds. Requires administrator privileges.
+    /// </summary>
+    /// <remarks>
+    /// THE WAY BACK FROM A LINK IMPORT THAT RESTORED THE WRONG DOCUMENT (#1519). The import merges - it adds
+    /// and overwrites and never removes - so re-importing the right file after the wrong one does not undo
+    /// it: the correct document is refused whole by the repoint guard, and one leftover entry blocks every
+    /// other link in it. An unlink of everything one provider holds is the smallest true way back. It is not
+    /// a replace mode on the import, which would be a second destructive path with the same blast radius as
+    /// the mistake it answers, and it undoes nothing else: no Jellyfin account, no permission and no
+    /// password is touched, so an operator who runs this by mistake has removed links and nothing else.
+    /// <para>
+    /// It is also the first primitive here that can take every account on a server off SSO in one call, so
+    /// the confirmation is the SERVER's rather than a dialog's. The caller sends the count it was shown, and
+    /// four preconditions decide the run beside the elevation this route already requires: the provider must
+    /// be known, the count must equal what the table holds when the removal takes the lock, the table must
+    /// not have moved while the accounts were being judged, and the run must not leave an administrator
+    /// account with no way to sign in. A browser dialog protects nobody who calls the API.
+    /// </para>
+    /// <para>
+    /// The accounts whose LAST canonical link this removes are signed out, and only those - exactly the
+    /// scope the single unlink revokes at (#468). An account that keeps a link on another provider still has
+    /// a working SSO identity, so revoking it would be an unscoped mass-logout with no security gain.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The mode of the function; SAML or OID.</param>
+    /// <param name="provider">The provider whose links are all removed.</param>
+    /// <param name="expectedLinkCount">The number of links the caller was shown and expects to remove; the run refuses when the provider holds a different number.</param>
+    /// <returns>What was removed, or the refusal that stopped it.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpDelete("{mode}/Links/{provider}/{expectedLinkCount}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public async Task<ActionResult> PurgeProviderLinks([FromRoute] string mode, [FromRoute] string provider, [FromRoute] int expectedLinkCount)
+    {
+        // Throttle after the elevation guard (#382): [Authorize] refuses a non-elevated caller before this
+        // body runs, so there is no rate-limit oracle. Past it, this shares the "link" bucket with the
+        // single link writes and the import, because it is the same config-XML persist under the global
+        // lock - and here every refusal pays that persist too, so an unthrottled caller could drive the
+        // disk write with nothing but wrong counts.
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
+        {
+            return throttled;
+        }
+
+        if (RefuseUnknownMode(mode, out var parsed) is { } unknownMode)
+        {
+            return unknownMode;
+        }
+
+        var protocol = parsed == ProviderMode.Oid ? OpenIdProtocol : SamlProtocol;
+
+        // Two steps on purpose, and the split is the availability decision rather than an optimization. The
+        // survey names, under the config lock, the accounts that would be left holding no link at all; those
+        // accounts are then resolved through the user manager with the lock RELEASED, because a provider can
+        // carry thousands of links and a user-manager call per link inside the lock would block every login
+        // for as long as it took. The purge re-derives that set under the lock it removes under and refuses
+        // when it names an account the survey did not, so the window this buys cannot produce a wrong
+        // lockout verdict - it produces a refusal the caller retries.
+        var survey = _canonicalLinks.SurveyProviderLinks(parsed, provider);
+        var doors = _ssoOnly.DescribeAccountDoors(survey.UsersLosingTheirLastLink);
+        var outcome = _canonicalLinks.TryPurgeProviderLinks(parsed, provider, expectedLinkCount, doors);
+
+        if (outcome.Result != ProviderLinkPurgeResult.Purged)
+        {
+            // A blocked mass-lockout leaves a trail (T-R1), exactly as a blocked SSO-only activation does.
+            // The reason is the verdict's own enum name - a fixed constant, never request input - so the
+            // audit line cannot be written by the caller.
+            SsoAudit.ProviderLinksPurgeRefused(_logger, await ResolveActorAsync().ConfigureAwait(false), protocol, provider, outcome.Result.ToString());
+        }
+
+        switch (outcome.Result)
+        {
+            case ProviderLinkPurgeResult.UnknownProvider:
+                return BadRequest(NoMatchingProviderMessage);
+
+            case ProviderLinkPurgeResult.CountMismatch:
+                return StatusCode(
+                    StatusCodes.Status409Conflict,
+                    FormattableString.Invariant($"This provider holds {outcome.ActualLinkCount} link(s), not the {expectedLinkCount} this request expects. Reload the page and run it again against the current number."));
+
+            case ProviderLinkPurgeResult.LinkTableChanged:
+                return StatusCode(
+                    StatusCodes.Status409Conflict,
+                    "The link table changed while this request was checking which accounts would be left without a way to sign in. Nothing was removed; run it again.");
+
+            case ProviderLinkPurgeResult.WouldStrandAdministrator:
+                // The names are the way out, which is why they are in the refusal: an operator who is only
+                // told "an administrator would be stranded" has to guess which account to give a password
+                // to. The caller is an elevated administrator, who can already list every account on this
+                // server, so this discloses nothing the roster does not - and it is a REFUSAL, so it names
+                // accounts nothing was done to.
+                var stranded = string.Join(", ", outcome.StrandedAdministrators).ReplaceLineEndings(string.Empty);
+                return StatusCode(
+                    StatusCodes.Status409Conflict,
+                    "This would take the last way in from these administrator accounts: " + stranded + ". Give each of them a usable password, or unlink it deliberately one link at a time, then run this again. Nothing was removed.");
+
+            case ProviderLinkPurgeResult.Purged:
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unhandled provider-link purge result: {outcome.Result}");
+        }
+
+        // AFTER the removal is persisted, so a revoke that throws leaves the unlink already complete rather
+        // than half-done - the ordering DeleteCanonicalLink takes for the same reason. Scoped strictly to
+        // the accounts this run left with no canonical link anywhere; null revokes all of that account's
+        // tokens, which is the terminal "can no longer SSO in at all" state (#468). One account's revoke
+        // fault must not abort the rest: the links are already gone for every one of them, so stopping here
+        // would leave the remaining accounts holding live tokens with nothing recording why.
+        var signedOut = 0;
+        foreach (var userId in outcome.RevokedUserIds)
+        {
+            try
+            {
+                await _sessionManager.RevokeUserTokens(userId, null).ConfigureAwait(false);
+                signedOut++;
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Removed the last SSO link for user {UserId} in a bulk unlink and revoked their active tokens.", userId);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Revoking tokens after a bulk unlink failed for one account; its links are removed and the remaining accounts are still signed out.");
+            }
+        }
+
+        SsoAudit.ProviderLinksPurged(_logger, await ResolveActorAsync().ConfigureAwait(false), protocol, provider, outcome.RemovedLinks, signedOut);
+
+        return Ok(new ProviderLinkPurgeDocument { Removed = outcome.RemovedLinks, SignedOut = signedOut });
+    }
+
+    /// <summary>
     /// Gets all the saml links for a user.
     /// </summary>
     /// <param name="jellyfinUserId">The user ID within jellyfin for which to return the links.</param>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -2351,8 +2351,9 @@ public class SSOController : ControllerBase
         // plugin's write is not atomic (#1532): a wrong count is the NORMAL outcome here and must not spend
         // a rewrite of SSO-Auth.xml. The authoritative checks stay inside the purge below.
         var survey = _canonicalLinks.SurveyProviderLinks(parsed, provider);
+        var doors = survey.ProviderExists ? _ssoOnly.DescribeAccountDoors(survey.LinkedUsers) : Array.Empty<AccountDoors>();
         var outcome = Screen(survey, expectedLinkCount)
-            ?? _canonicalLinks.TryPurgeProviderLinks(parsed, provider, expectedLinkCount, _ssoOnly.DescribeAccountDoors(survey.LinkedUsers));
+            ?? _canonicalLinks.TryPurgeProviderLinks(parsed, provider, expectedLinkCount, doors);
 
         if (outcome.Result != ProviderLinkPurgeResult.Purged)
         {
@@ -2390,7 +2391,7 @@ public class SSOController : ControllerBase
                     + (overflow > 0 ? FormattableString.Invariant($" and {overflow} more") : string.Empty);
                 return StatusCode(
                     StatusCodes.Status409Conflict,
-                    "This would take the last way in from these administrator accounts: " + stranded + ". Give each of them a password on Jellyfin's own password provider - the account has to be routed to that provider as well as carry a password - or link it to another enabled provider, or unlink it deliberately one link at a time. Then run this again. Nothing was removed.");
+                    "This would take the last way in from these administrator accounts: " + stranded + ". A stored password does not count as a way in here, because this plugin mints an unusable one onto the accounts it provisions and cannot tell the two apart. Link each of them to another enabled provider, or unlink it deliberately through the single-link route, then run this again. Nothing was removed.");
 
             case ProviderLinkPurgeResult.Purged:
                 break;
@@ -2431,10 +2432,27 @@ public class SSOController : ControllerBase
         // it off the password provider - and no link-table comparison can see that. So the same question is
         // asked once more against what is true now. It cannot undo the removal; it turns a silent lockout
         // into a line an operator can act on, which is the difference between a bad night and a rebuild.
-        var doorless = _canonicalLinks.AdministratorsWithNoWayIn(_ssoOnly.DescribeAccountDoors(outcome.RevokedUserIds));
+        // EVERY account the guard judged, not the subset this run signed out. The two sets are not the
+        // same: an account keeping a link on a DISABLED provider is not signed out - the revoke scope is
+        // the any-link reading (#468) - and is exactly the account this net exists for, because a disabled
+        // provider is where a way in stops being one. Feeding it the revoked subset would leave the case
+        // the guard was rewritten for as the one case the net cannot see.
+        // And only where the run actually TOOK something. On a provider that was already switched off,
+        // its links were not a way in before the run either, so an administrator with none afterwards had
+        // none before - reporting that as a lockout this run caused would be a false alarm, printed on
+        // exactly the disable-then-clean-up workflow the route exists for, in a line whose whole value is
+        // that it means a real race happened.
+        var doorless = outcome.TargetWasEnabled
+            ? _canonicalLinks.AdministratorsWithNoWayIn(doors)
+            : Array.Empty<string>();
         if (doorless.Count > 0)
         {
-            SsoAudit.ProviderLinksPurgeStrandedAdministrator(_logger, protocol, provider, string.Join(", ", doorless));
+            // Capped like the refusal body, and for the same reason: a server mapping administrator
+            // broadly from an identity-provider role can make this list as long as its roster.
+            var overflowing = doorless.Count - NamedStrandedAdministrators;
+            var named = string.Join(", ", doorless.Take(NamedStrandedAdministrators))
+                + (overflowing > 0 ? FormattableString.Invariant($" and {overflowing} more") : string.Empty);
+            SsoAudit.ProviderLinksPurgeStrandedAdministrator(_logger, protocol, provider, named);
         }
 
         return Ok(new ProviderLinkPurgeDocument { Removed = outcome.RemovedLinks, SignedOut = signedOut });
@@ -2540,6 +2558,9 @@ public class SSOController : ControllerBase
     // configuration is the ordinary way this input arrives, so an integrator needs a status they can depend
     // on. The body names the two accepted tokens and never echoes the supplied one, which would reflect
     // caller-controlled text into the response.
+    private static BadRequestObjectResult? RefuseUnknownMode(string mode, out ProviderMode parsed) =>
+        ProviderModeParser.TryParse(mode, out parsed) ? null : new BadRequestObjectResult(UnknownModeMessage);
+
     // The refusals the survey can answer on its own, so a stale page does not spend a rewrite of the
     // configuration file to be told its number is old (#1519). Null means nothing here decides it and the
     // purge runs, where both of these are checked again under the lock that removes - this is a cheaper
@@ -2555,9 +2576,6 @@ public class SSOController : ControllerBase
             ? null
             : ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.CountMismatch, survey.LinkCount);
     }
-
-    private static BadRequestObjectResult? RefuseUnknownMode(string mode, out ProviderMode parsed) =>
-        ProviderModeParser.TryParse(mode, out parsed) ? null : new BadRequestObjectResult(UnknownModeMessage);
 
     // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382, #516): null when the
     // request may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -54,6 +54,10 @@ public class SSOController : ControllerBase
     // defined once (#318).
     private const string NoMatchingProviderMessage = LoginStatusMapper.NoMatchingProviderMessage;
 
+    // How many stranded administrators the mass-lockout refusal names before it summarizes the rest, so a
+    // roster-sized body cannot be driven by one request. Ten, matching the link import's own cap.
+    private const int NamedStrandedAdministrators = 10;
+
     // The refusal body for an unrecognized {mode} route token (#1399), named here beside the other fixed
     // refusal wordings. It names the two accepted tokens and never echoes the supplied one.
     private const string UnknownModeMessage = "The mode segment must be 'oid' or 'saml'.";
@@ -2332,23 +2336,30 @@ public class SSOController : ControllerBase
 
         var protocol = parsed == ProviderMode.Oid ? OpenIdProtocol : SamlProtocol;
 
-        // Two steps on purpose, and the split is the availability decision rather than an optimization. The
-        // survey names, under the config lock, the accounts that would be left holding no link at all; those
-        // accounts are then resolved through the user manager with the lock RELEASED, because a provider can
-        // carry thousands of links and a user-manager call per link inside the lock would block every login
-        // for as long as it took. The purge re-derives that set under the lock it removes under and refuses
-        // when it names an account the survey did not, so the window this buys cannot produce a wrong
-        // lockout verdict - it produces a refusal the caller retries.
+        // Resolved BEFORE anything is changed, and once. Reading the caller's own name goes to the
+        // authorization context, which can throw; doing it after the removal would turn that throw into a
+        // 500 on a run whose links are already gone and which then has no audit line at all - the one path
+        // where the trail matters most. The SSO-only endpoints resolve it up front for the same reason.
+        var actor = await ResolveActorAsync().ConfigureAwait(false);
+
+        // Two steps on purpose, and the split answers two different problems. The survey is a READ: it names
+        // every account holding a link on this provider under the config lock, so those accounts can be
+        // resolved through the user manager with the lock RELEASED - a provider can carry thousands of links,
+        // and a user-manager call per link inside the lock would block every login for the duration. It also
+        // answers the two refusals a stale page actually produces without entering a mutation at all, because
+        // every return out of one persists the configuration file even when it changed nothing, and this
+        // plugin's write is not atomic (#1532): a wrong count is the NORMAL outcome here and must not spend
+        // a rewrite of SSO-Auth.xml. The authoritative checks stay inside the purge below.
         var survey = _canonicalLinks.SurveyProviderLinks(parsed, provider);
-        var doors = _ssoOnly.DescribeAccountDoors(survey.UsersLosingTheirLastLink);
-        var outcome = _canonicalLinks.TryPurgeProviderLinks(parsed, provider, expectedLinkCount, doors);
+        var outcome = Screen(survey, expectedLinkCount)
+            ?? _canonicalLinks.TryPurgeProviderLinks(parsed, provider, expectedLinkCount, _ssoOnly.DescribeAccountDoors(survey.LinkedUsers));
 
         if (outcome.Result != ProviderLinkPurgeResult.Purged)
         {
             // A blocked mass-lockout leaves a trail (T-R1), exactly as a blocked SSO-only activation does.
             // The reason is the verdict's own enum name - a fixed constant, never request input - so the
             // audit line cannot be written by the caller.
-            SsoAudit.ProviderLinksPurgeRefused(_logger, await ResolveActorAsync().ConfigureAwait(false), protocol, provider, outcome.Result.ToString());
+            SsoAudit.ProviderLinksPurgeRefused(_logger, actor, protocol, provider, outcome.Result.ToString());
         }
 
         switch (outcome.Result)
@@ -2372,10 +2383,14 @@ public class SSOController : ControllerBase
                 // to. The caller is an elevated administrator, who can already list every account on this
                 // server, so this discloses nothing the roster does not - and it is a REFUSAL, so it names
                 // accounts nothing was done to.
-                var stranded = string.Join(", ", outcome.StrandedAdministrators).ReplaceLineEndings(string.Empty);
+                // Capped, like the link import's own refusal: a server where many accounts hold
+                // administrator would otherwise make this body as long as the roster, on one request.
+                var overflow = outcome.StrandedAdministrators.Count - NamedStrandedAdministrators;
+                var stranded = string.Join(", ", outcome.StrandedAdministrators.Take(NamedStrandedAdministrators)).ReplaceLineEndings(string.Empty)
+                    + (overflow > 0 ? FormattableString.Invariant($" and {overflow} more") : string.Empty);
                 return StatusCode(
                     StatusCodes.Status409Conflict,
-                    "This would take the last way in from these administrator accounts: " + stranded + ". Give each of them a usable password, or unlink it deliberately one link at a time, then run this again. Nothing was removed.");
+                    "This would take the last way in from these administrator accounts: " + stranded + ". Give each of them a password on Jellyfin's own password provider - the account has to be routed to that provider as well as carry a password - or link it to another enabled provider, or unlink it deliberately one link at a time. Then run this again. Nothing was removed.");
 
             case ProviderLinkPurgeResult.Purged:
                 break;
@@ -2404,11 +2419,23 @@ public class SSOController : ControllerBase
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Revoking tokens after a bulk unlink failed for one account; its links are removed and the remaining accounts are still signed out.");
+                _logger.LogError(ex, "Revoking tokens after a bulk unlink failed for user {UserId}; its links are removed and it may hold a live session, and the remaining accounts are still signed out.", userId);
             }
         }
 
-        SsoAudit.ProviderLinksPurged(_logger, await ResolveActorAsync().ConfigureAwait(false), protocol, provider, outcome.RemovedLinks, signedOut);
+        SsoAudit.ProviderLinksPurged(_logger, actor, protocol, provider, outcome.RemovedLinks, outcome.RevokedUserIds.Count, signedOut);
+
+        // The gate refuses a run that would strand an administrator, and it judges accounts read before the
+        // removal took the lock. An account can lose its password door in that window without any link
+        // moving - an ordinary SSO login on a provider whose DefaultProvider is the SSO provider id repoints
+        // it off the password provider - and no link-table comparison can see that. So the same question is
+        // asked once more against what is true now. It cannot undo the removal; it turns a silent lockout
+        // into a line an operator can act on, which is the difference between a bad night and a rebuild.
+        var doorless = _canonicalLinks.AdministratorsWithNoWayIn(_ssoOnly.DescribeAccountDoors(outcome.RevokedUserIds));
+        if (doorless.Count > 0)
+        {
+            SsoAudit.ProviderLinksPurgeStrandedAdministrator(_logger, protocol, provider, string.Join(", ", doorless));
+        }
 
         return Ok(new ProviderLinkPurgeDocument { Removed = outcome.RemovedLinks, SignedOut = signedOut });
     }
@@ -2513,6 +2540,22 @@ public class SSOController : ControllerBase
     // configuration is the ordinary way this input arrives, so an integrator needs a status they can depend
     // on. The body names the two accepted tokens and never echoes the supplied one, which would reflect
     // caller-controlled text into the response.
+    // The refusals the survey can answer on its own, so a stale page does not spend a rewrite of the
+    // configuration file to be told its number is old (#1519). Null means nothing here decides it and the
+    // purge runs, where both of these are checked again under the lock that removes - this is a cheaper
+    // path to the same answer, never the authority for it.
+    private static ProviderLinkPurgeOutcome? Screen(ProviderLinkSurvey survey, int expectedLinkCount)
+    {
+        if (!survey.ProviderExists)
+        {
+            return ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.UnknownProvider, 0);
+        }
+
+        return survey.LinkCount == expectedLinkCount
+            ? null
+            : ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.CountMismatch, survey.LinkCount);
+    }
+
     private static BadRequestObjectResult? RefuseUnknownMode(string mode, out ProviderMode parsed) =>
         ProviderModeParser.TryParse(mode, out parsed) ? null : new BadRequestObjectResult(UnknownModeMessage);
 

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1575,6 +1575,170 @@ internal sealed class CanonicalLinkService
         });
     }
 
+    /// <summary>
+    /// Reads what one provider's link table looks like before a bulk unlink acts on it (#1519): whether the
+    /// provider is stored at all, how many links it holds, and which accounts would be left holding no
+    /// canonical link anywhere once those links are gone.
+    /// </summary>
+    /// <remarks>
+    /// A read, and deliberately not the act: the accounts it names have to be resolved through the user
+    /// manager to be judged, and that resolution must not happen under the configuration lock. A provider
+    /// can carry thousands of links, and a user-manager call per link inside the lock would block every
+    /// login for the duration - the same reason the link import resolves its usernames before it takes the
+    /// lock. What that costs is a window in which the table can move, and
+    /// <see cref="TryPurgeProviderLinks"/> closes it by re-deriving this set under the lock and refusing
+    /// when it names an account this survey did not.
+    /// <para>
+    /// A disabled provider is surveyed exactly as an enabled one is. Removal REVOKES a grant, so it must
+    /// keep working on a disabled provider - disable-then-clean-up is the workflow this action exists for
+    /// (#380). Only absence is unknown here.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The provider protocol.</param>
+    /// <param name="provider">The provider whose links would be removed.</param>
+    /// <returns>The snapshot to judge; <c>ProviderExists = false</c> when no such provider is stored.</returns>
+    internal ProviderLinkSurvey SurveyProviderLinks(ProviderMode mode, string provider)
+    {
+        return _configStore.Read(configuration =>
+            TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links)
+                ? new ProviderLinkSurvey(true, links.Count, UsersLosingTheirLastLink(configuration, links))
+                : new ProviderLinkSurvey(false, 0, Array.Empty<Guid>()));
+    }
+
+    /// <summary>
+    /// Removes every canonical link one provider holds (#1519), the way back from a link import that
+    /// restored the wrong document. Four preconditions decide it, and all four are the server's: the
+    /// provider must be stored, the caller's expected count must equal what the table actually holds, the
+    /// link table must not have moved since <paramref name="judged"/> was resolved, and the run must not
+    /// leave an administrator with no way to sign in. Elevation is the fifth and is the controller's.
+    /// </summary>
+    /// <remarks>
+    /// ONE <c>Mutate</c>, so the count comparison, the lockout guard and the removal cannot interleave with
+    /// a concurrent link write - a purge that compared a count in one transaction and removed in another
+    /// would remove a table it never counted. A refusal still persists the unchanged configuration, exactly
+    /// as <see cref="TryRemoveLink"/>'s no-result arms do and for the same reason; the bytes on disk are
+    /// identical either way.
+    /// <para>
+    /// T-D1, the mass-lockout guard: this is the first primitive here that can take every account on a
+    /// server off SSO in one call, so it REFUSES rather than excluding. Silently keeping an administrator's
+    /// link would leave the provider not empty while the answer says it is, and the next import would hit
+    /// the very refusal this action exists to clear. A link on another provider counts as a way in, and so
+    /// does a password the account can actually use - which is not a field on a Jellyfin account: it is the
+    /// reading the SSO-only break-glass guard already makes (built-in password provider plus a stored
+    /// password), narrowed here by the mode flag, because while SSO-only login is on the only account whose
+    /// password door survives is the designated break-glass admin. An account that is disabled, or that has
+    /// vanished since it was judged, is not stranded by this run: it already has no way in.
+    /// </para>
+    /// <para>
+    /// The removal takes the issuer stamps (#186), the expiry deadlines (#1145) and the last-SSO-login
+    /// stamps (#1120) with the links, for the reasons <see cref="TryRemoveLink"/> takes them one at a time:
+    /// an orphan deadline would expire a re-link of the same subject on the next sweep tick, an orphan
+    /// issuer would judge it against a stale binding, and an orphan stamp is login history retained for a
+    /// subject this server no longer knows.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The provider protocol.</param>
+    /// <param name="provider">The provider whose links are removed.</param>
+    /// <param name="expectedLinkCount">The number of links the caller was shown and expects to remove.</param>
+    /// <param name="judged">The doors of every account <see cref="SurveyProviderLinks"/> named, resolved outside this lock.</param>
+    /// <returns>What happened, what to revoke, and - on the lockout refusal - who would have been stranded.</returns>
+    internal ProviderLinkPurgeOutcome TryPurgeProviderLinks(ProviderMode mode, string provider, int expectedLinkCount, IReadOnlyList<AccountDoors> judged)
+    {
+        ArgumentNullException.ThrowIfNull(judged);
+
+        return _configStore.Mutate(configuration =>
+        {
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links))
+            {
+                return Refused(ProviderLinkPurgeResult.UnknownProvider, 0);
+            }
+
+            if (links.Count != expectedLinkCount)
+            {
+                return Refused(ProviderLinkPurgeResult.CountMismatch, links.Count);
+            }
+
+            // Re-derived here rather than carried in: the set the survey read was read in an EARLIER
+            // transaction, and this is the one that acts. An account it names that was never judged means a
+            // link moved in between, so the guard below would be deciding on a stale reading of who can
+            // still sign in - refuse and let the caller start again rather than act on it.
+            var losing = UsersLosingTheirLastLink(configuration, links);
+            var doors = judged.ToDictionary(door => door.UserId);
+            if (losing.Any(userId => !doors.ContainsKey(userId)))
+            {
+                return Refused(ProviderLinkPurgeResult.LinkTableChanged, links.Count);
+            }
+
+            var stranded = losing
+                .Select(userId => doors[userId])
+                .Where(door => door.IsAdministrator && !door.IsDisabled && !HasPasswordDoor(configuration, door))
+                .Select(door => door.Username)
+                .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (stranded.Count > 0)
+            {
+                return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.WouldStrandAdministrator, 0, links.Count, Array.Empty<Guid>(), stranded);
+            }
+
+            var removed = links.Count;
+            links.Clear();
+
+            // Every stamp keyed on a link this provider held is now an orphan, because no link is left to
+            // key one on. Cleared wholesale rather than key by key: the prune the per-link removals do is
+            // "drop what the links map no longer holds", and after the clear that is all of them.
+            if (TryGetProvider(configuration, mode, provider, out var config))
+            {
+                config.CanonicalLinkDeadlines.Clear();
+                config.CanonicalLinkLastLogins.Clear();
+                if (config is OidConfig oid)
+                {
+                    oid.CanonicalLinkIssuers.Clear();
+                }
+            }
+
+            return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.Purged, removed, removed, losing, Array.Empty<string>());
+        });
+    }
+
+    // A refusal changes nothing, so every field but the reason and the count that refused is empty. Named
+    // rather than repeated three times, so a new refusal arm cannot accidentally report links removed.
+    private static ProviderLinkPurgeOutcome Refused(ProviderLinkPurgeResult result, int actualLinkCount)
+        => new(result, 0, actualLinkCount, Array.Empty<Guid>(), Array.Empty<string>());
+
+    // Whether the account can still sign in with a password once its SSO links are gone. The provider and
+    // stored-password half is read from the account outside the lock (AccountDoors); the half that needs the
+    // configuration is applied here, because while SSO-only login is on every non-exempt account has been
+    // repointed off the password provider and only the break-glass admin's door is left standing. Fail
+    // toward the refusal: an account this cannot prove has a password door is treated as having none, so
+    // the guard errs on refusing a purge rather than on stranding an administrator.
+    private static bool HasPasswordDoor(PluginConfiguration configuration, AccountDoors door)
+        => door.RoutesToPasswordProvider
+           && door.HasStoredPassword
+           && !SsoOnlyLoginGuard.IsEnforcedNonExempt(configuration, door.Username);
+
+    // The accounts holding a link in the given map and in no OTHER provider's, read under the caller's
+    // already-held config lock. Identity is by reference to the map itself rather than by provider name, so
+    // the target provider is excluded exactly once even though the two protocols keep separate namespaces
+    // and a SAML and an OpenID provider may share a name. A provider stored with a null config object
+    // (reachable via #350's null-body add) holds no links and is skipped rather than dereferenced - the
+    // same fail-closed treatment TryGetLinks and RemoveUserEverywhere give it.
+    private static List<Guid> UsersLosingTheirLastLink(PluginConfiguration configuration, SerializableDictionary<string, Guid> targetLinks)
+    {
+        var losing = new HashSet<Guid>(targetLinks.Values);
+        foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
+        {
+            if (config?.CanonicalLinks is { } links && !ReferenceEquals(links, targetLinks))
+            {
+                foreach (var userId in links.Values)
+                {
+                    losing.Remove(userId);
+                }
+            }
+        }
+
+        return losing.ToList();
+    }
+
     // Whether any SAML or OpenID provider still holds a canonical link pointing at the user, read under the
     // caller's already-held config lock (#468). A provider stored with a null config object (reachable via
     // the null-body add, #350) holds no links and is skipped rather than dereferenced - the same fail-closed

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1629,7 +1629,7 @@ internal sealed class CanonicalLinkService
             var stillLinked = UsersWithAnEnabledLink(configuration);
             return (IReadOnlyList<string>)doors
                 .Where(door => door.IsAdministrator && !door.IsDisabled)
-                .Where(door => !HasPasswordDoor(configuration, door) && !stillLinked.Contains(door.UserId))
+                .Where(door => !stillLinked.Contains(door.UserId))
                 .Select(door => door.Username)
                 .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
                 .ToList();
@@ -1653,12 +1653,28 @@ internal sealed class CanonicalLinkService
     /// T-D1, the mass-lockout guard: this is the first primitive here that can take every account on a
     /// server off SSO in one call, so it REFUSES rather than excluding. Silently keeping an administrator's
     /// link would leave the provider not empty while the answer says it is, and the next import would hit
-    /// the very refusal this action exists to clear. A link on another provider counts as a way in, and so
-    /// does a password the account can actually use - which is not a field on a Jellyfin account: it is the
-    /// reading the SSO-only break-glass guard already makes (built-in password provider plus a stored
-    /// password), narrowed here by the mode flag, because while SSO-only login is on the only account whose
-    /// password door survives is the designated break-glass admin. An account that is disabled, or that has
-    /// vanished since it was judged, is not stranded by this run: it already has no way in.
+    /// the very refusal this action exists to clear. An account that is disabled, or that has vanished
+    /// since it was judged, is not stranded by this run: it already has no way in.
+    /// </para>
+    /// <para>
+    /// WHAT COUNTS AS A WAY IN IS A LINK ON AN ENABLED PROVIDER, AND A STORED PASSWORD DOES NOT COUNT.
+    /// The decision that asked for this guard left the reading of "a password the account can use" to be
+    /// measured rather than assumed, and the measurement says the tree cannot make it. This plugin mints
+    /// an unguessable password onto every account it provisions and onto every passwordless linked account
+    /// it finds at boot (#1440, <c>ProvisionedPassword.Mint</c>: 64 CSPRNG bytes, "never displayed, never
+    /// stored anywhere else and never recoverable"), and it records nowhere which accounts those were. So
+    /// a non-empty <c>User.Password</c> is a hash somebody may hold or a seal nobody can open, and the two
+    /// are the same bytes. On a server whose provider routes accounts to the built-in password provider -
+    /// which the configuration page names as a common setting - counting it would have cleared this guard
+    /// for every SSO-provisioned administrator on the server, silently, which is the exact lockout it
+    /// exists to refuse.
+    /// </para>
+    /// <para>
+    /// So the password term is out until something can tell the two apart, and the cost is stated rather
+    /// than hidden: an administrator who really does sign in with a password and holds a link on the
+    /// provider being emptied makes this refuse. The refusal names them and the ways out - unlink that one
+    /// account deliberately through the single-link route, or link it to another enabled provider - and
+    /// both are one call. A refusal costs a call; the other error costs the server.
     /// </para>
     /// <para>
     /// The removal takes the issuer stamps (#186), the expiry deadlines (#1145) and the last-SSO-login
@@ -1723,14 +1739,14 @@ internal sealed class CanonicalLinkService
                 ? linked
                     .Select(userId => doors[userId])
                     .Where(door => door.IsAdministrator && !door.IsDisabled)
-                    .Where(door => !HasPasswordDoor(configuration, door) && !elsewhere.OnAnEnabledProvider.Contains(door.UserId))
+                    .Where(door => !elsewhere.OnAnEnabledProvider.Contains(door.UserId))
                     .Select(door => door.Username)
                     .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
                     .ToList()
                 : new List<string>();
             if (stranded.Count > 0)
             {
-                return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.WouldStrandAdministrator, 0, links.Count, Array.Empty<Guid>(), stranded);
+                return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.WouldStrandAdministrator, 0, links.Count, Array.Empty<Guid>(), stranded, elsewhere.TargetEnabled);
             }
 
             var removed = links.Count;
@@ -1749,20 +1765,9 @@ internal sealed class CanonicalLinkService
                 }
             }
 
-            return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.Purged, removed, removed, losing, Array.Empty<string>());
+            return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.Purged, removed, removed, losing, Array.Empty<string>(), elsewhere.TargetEnabled);
         });
     }
-
-    // Whether the account can still sign in with a password once its SSO links are gone. The provider and
-    // stored-password half is read from the account outside the lock (AccountDoors); the half that needs the
-    // configuration is applied here, because while SSO-only login is on every non-exempt account has been
-    // repointed off the password provider and only the break-glass admin's door is left standing. Fail
-    // toward the refusal: an account this cannot prove has a password door is treated as having none, so
-    // the guard errs on refusing a purge rather than on stranding an administrator.
-    private static bool HasPasswordDoor(PluginConfiguration configuration, AccountDoors door)
-        => door.RoutesToPasswordProvider
-           && door.HasStoredPassword
-           && !SsoOnlyLoginGuard.IsEnforcedNonExempt(configuration, door.Username);
 
     // Everything the purge needs to know about the OTHER providers, from ONE walk under the caller's
     // already-held config lock: which accounts hold a link somewhere else at all, which hold one on a

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1601,8 +1601,39 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Read(configuration =>
             TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links)
-                ? new ProviderLinkSurvey(true, links.Count, UsersLosingTheirLastLink(configuration, links))
+                ? new ProviderLinkSurvey(true, links.Count, links.Values.Distinct().ToList())
                 : new ProviderLinkSurvey(false, 0, Array.Empty<Guid>()));
+    }
+
+    /// <summary>
+    /// Names the administrator accounts among the given doors that have no way to sign in at all, read
+    /// against the configuration as it stands now (#1519).
+    /// </summary>
+    /// <remarks>
+    /// The safety net under the purge rather than part of its gate. The gate judges accounts resolved
+    /// before the removal took the lock, and an account can lose its password door in that window without
+    /// its LINKS moving - an ordinary SSO login on a provider whose DefaultProvider is the SSO provider id
+    /// repoints the account off the password provider, which no link-table comparison can see. That window
+    /// cannot be closed from here (the user records are the host's and are not under this lock), so it is
+    /// read again afterwards instead, and an administrator left with nothing reaches the operator as an
+    /// Error line the moment it happens rather than at their next sign-in.
+    /// </remarks>
+    /// <param name="doors">The accounts to re-judge, resolved through the user manager after the removal.</param>
+    /// <returns>The usernames of administrators with neither a password door nor a link on an enabled provider.</returns>
+    internal IReadOnlyList<string> AdministratorsWithNoWayIn(IReadOnlyList<AccountDoors> doors)
+    {
+        ArgumentNullException.ThrowIfNull(doors);
+
+        return _configStore.Read(configuration =>
+        {
+            var stillLinked = UsersWithAnEnabledLink(configuration);
+            return (IReadOnlyList<string>)doors
+                .Where(door => door.IsAdministrator && !door.IsDisabled)
+                .Where(door => !HasPasswordDoor(configuration, door) && !stillLinked.Contains(door.UserId))
+                .Select(door => door.Username)
+                .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        });
     }
 
     /// <summary>
@@ -1650,31 +1681,53 @@ internal sealed class CanonicalLinkService
         {
             if (!TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links))
             {
-                return Refused(ProviderLinkPurgeResult.UnknownProvider, 0);
+                return ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.UnknownProvider, 0);
             }
 
             if (links.Count != expectedLinkCount)
             {
-                return Refused(ProviderLinkPurgeResult.CountMismatch, links.Count);
+                return ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.CountMismatch, links.Count);
             }
 
             // Re-derived here rather than carried in: the set the survey read was read in an EARLIER
             // transaction, and this is the one that acts. An account it names that was never judged means a
             // link moved in between, so the guard below would be deciding on a stale reading of who can
             // still sign in - refuse and let the caller start again rather than act on it.
-            var losing = UsersLosingTheirLastLink(configuration, links);
+            var linked = links.Values.Distinct().ToList();
             var doors = judged.ToDictionary(door => door.UserId);
-            if (losing.Any(userId => !doors.ContainsKey(userId)))
+            if (linked.Any(userId => !doors.ContainsKey(userId)))
             {
-                return Refused(ProviderLinkPurgeResult.LinkTableChanged, links.Count);
+                return ProviderLinkPurgeOutcome.Refusing(ProviderLinkPurgeResult.LinkTableChanged, links.Count);
             }
 
-            var stranded = losing
-                .Select(userId => doors[userId])
-                .Where(door => door.IsAdministrator && !door.IsDisabled && !HasPasswordDoor(configuration, door))
-                .Select(door => door.Username)
-                .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            // TWO DIFFERENT QUESTIONS OVER THE SAME ACCOUNTS, and they take opposite readings of a disabled
+            // provider. Who gets signed out is who is left holding NO canonical link anywhere, enabled or
+            // not - the reading the single unlink already revokes on (#468). Who would be STRANDED is
+            // decided against enabled providers only, because the login path resolves a link through
+            // TryGetLinks(requireEnabled: true): a link on a disabled provider is a row in a table, not a
+            // way in. Counting one as a way in is how this guard fail-opened before it shipped, on exactly
+            // the disable-then-clean-up workflow the action exists for (#380).
+            //
+            // Both are answered from ONE walk of the other providers, built before either is asked. Asking
+            // per account instead would be a scan of every other provider per linked account, inside the
+            // process-wide configuration lock that every login takes - quadratic in exactly the case this
+            // endpoint exists for, a provider carrying thousands of links.
+            var elsewhere = LinksHeldElsewhere(configuration, links);
+            var losing = linked.Where(userId => !elsewhere.Any.Contains(userId)).ToList();
+
+            // A run strands an administrator only when it TAKES their last way in. Every candidate holds a
+            // link on the target, so "had a way in before" reduces to "the target is enabled, or they had
+            // one that survives anyway" - which is why the target being disabled refuses nobody: its links
+            // were not a way in before the run either, and cleaning it up takes nothing away.
+            var stranded = elsewhere.TargetEnabled
+                ? linked
+                    .Select(userId => doors[userId])
+                    .Where(door => door.IsAdministrator && !door.IsDisabled)
+                    .Where(door => !HasPasswordDoor(configuration, door) && !elsewhere.OnAnEnabledProvider.Contains(door.UserId))
+                    .Select(door => door.Username)
+                    .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+                : new List<string>();
             if (stranded.Count > 0)
             {
                 return new ProviderLinkPurgeOutcome(ProviderLinkPurgeResult.WouldStrandAdministrator, 0, links.Count, Array.Empty<Guid>(), stranded);
@@ -1700,11 +1753,6 @@ internal sealed class CanonicalLinkService
         });
     }
 
-    // A refusal changes nothing, so every field but the reason and the count that refused is empty. Named
-    // rather than repeated three times, so a new refusal arm cannot accidentally report links removed.
-    private static ProviderLinkPurgeOutcome Refused(ProviderLinkPurgeResult result, int actualLinkCount)
-        => new(result, 0, actualLinkCount, Array.Empty<Guid>(), Array.Empty<string>());
-
     // Whether the account can still sign in with a password once its SSO links are gone. The provider and
     // stored-password half is read from the account outside the lock (AccountDoors); the half that needs the
     // configuration is applied here, because while SSO-only login is on every non-exempt account has been
@@ -1716,27 +1764,68 @@ internal sealed class CanonicalLinkService
            && door.HasStoredPassword
            && !SsoOnlyLoginGuard.IsEnforcedNonExempt(configuration, door.Username);
 
-    // The accounts holding a link in the given map and in no OTHER provider's, read under the caller's
-    // already-held config lock. Identity is by reference to the map itself rather than by provider name, so
-    // the target provider is excluded exactly once even though the two protocols keep separate namespaces
-    // and a SAML and an OpenID provider may share a name. A provider stored with a null config object
-    // (reachable via #350's null-body add) holds no links and is skipped rather than dereferenced - the
-    // same fail-closed treatment TryGetLinks and RemoveUserEverywhere give it.
-    private static List<Guid> UsersLosingTheirLastLink(PluginConfiguration configuration, SerializableDictionary<string, Guid> targetLinks)
+    // Everything the purge needs to know about the OTHER providers, from ONE walk under the caller's
+    // already-held config lock: which accounts hold a link somewhere else at all, which hold one on a
+    // provider a login could actually resolve through, and whether the target itself is enabled. The
+    // target is excluded by reference to its own links map rather than by name, so it is excluded exactly
+    // once even though a SAML and an OpenID provider may share a name. A provider stored with a null
+    // config object (reachable via #350's null-body add) holds no links and is skipped rather than
+    // dereferenced - the same fail-closed treatment TryGetLinks and RemoveUserEverywhere give it.
+    private static LinksElsewhere LinksHeldElsewhere(PluginConfiguration configuration, SerializableDictionary<string, Guid> targetLinks)
     {
-        var losing = new HashSet<Guid>(targetLinks.Values);
-        foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
+        var any = new HashSet<Guid>();
+        var enabled = new HashSet<Guid>();
+        var targetEnabled = false;
+
+        foreach (var config in AllProviders(configuration))
         {
-            if (config?.CanonicalLinks is { } links && !ReferenceEquals(links, targetLinks))
+            if (config?.CanonicalLinks is not { } links)
             {
-                foreach (var userId in links.Values)
+                continue;
+            }
+
+            if (ReferenceEquals(links, targetLinks))
+            {
+                targetEnabled |= config.Enabled;
+                continue;
+            }
+
+            foreach (var userId in links.Values)
+            {
+                any.Add(userId);
+                if (config.Enabled)
                 {
-                    losing.Remove(userId);
+                    enabled.Add(userId);
                 }
             }
         }
 
-        return losing.ToList();
+        return new LinksElsewhere(any, enabled, targetEnabled);
+    }
+
+    // Both protocols' providers as one sequence (covariant Concat over the shared base), so a walk over
+    // them is written once.
+    private static IEnumerable<ProviderConfigBase> AllProviders(PluginConfiguration configuration)
+        => configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values);
+
+    // Every account an enabled provider still points a link at - the after-the-fact form of the guard's
+    // reading, with no target to exclude because the removal has already happened. One walk for the same
+    // reason the guard takes one: this runs under the lock every login takes.
+    private static HashSet<Guid> UsersWithAnEnabledLink(PluginConfiguration configuration)
+    {
+        var linked = new HashSet<Guid>();
+        foreach (var config in AllProviders(configuration))
+        {
+            if (config is { Enabled: true, CanonicalLinks: { } links })
+            {
+                foreach (var userId in links.Values)
+                {
+                    linked.Add(userId);
+                }
+            }
+        }
+
+        return linked;
     }
 
     // Whether any SAML or OpenID provider still holds a canonical link pointing at the user, read under the

--- a/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
+++ b/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// The outcome of a per-provider bulk unlink (#1519). Closed by convention (the controller's mapper
+/// throws on an unhandled arm), so a new outcome forces a new mapping rather than a silent
+/// fall-through - which on this surface would mean answering success for a run that removed nothing.
+/// </summary>
+internal enum ProviderLinkPurgeResult
+{
+    /// <summary>Every link the provider held was removed.</summary>
+    Purged,
+
+    /// <summary>No provider of that mode/name exists; nothing was removed.</summary>
+    UnknownProvider,
+
+    /// <summary>The provider holds a different number of links than the caller expected; nothing was removed.</summary>
+    CountMismatch,
+
+    /// <summary>The run would leave an administrator account with no way to sign in; nothing was removed.</summary>
+    WouldStrandAdministrator,
+
+    /// <summary>The link table changed while the accounts were being judged; nothing was removed.</summary>
+    LinkTableChanged,
+}
+
+/// <summary>
+/// What one provider's link table looks like to the bulk unlink before it acts (#1519): how many links
+/// the provider holds, and which accounts would be left holding no canonical link at all once those links
+/// are gone. A detached snapshot taken under the configuration lock, so the caller can resolve those
+/// accounts through the user manager WITHOUT holding it - the same discipline the link import takes for
+/// the same reason, since a provider can carry thousands of links and a user-manager call per link inside
+/// the lock would block every login for the duration.
+/// </summary>
+/// <param name="ProviderExists">Whether a provider of that mode and name is stored at all.</param>
+/// <param name="LinkCount">How many links the provider holds.</param>
+/// <param name="UsersLosingTheirLastLink">
+/// The distinct accounts that hold a link on this provider and none on any other, so the purge would take
+/// their last one. Re-derived under the lock when the purge runs; this copy exists only to be judged.
+/// </param>
+internal readonly record struct ProviderLinkSurvey(bool ProviderExists, int LinkCount, IReadOnlyList<Guid> UsersLosingTheirLastLink);
+
+/// <summary>
+/// What the tree can read about one account's ways in, resolved through the user manager OUTSIDE the
+/// configuration lock and judged inside it (#1519, T-D1). "Can use a password" is not a single field on a
+/// Jellyfin account and is not asked of the host: it is the same reading the SSO-only break-glass guard
+/// already makes - the account routes to the built-in password provider AND carries a stored password -
+/// and the mode-dependent half of it (SSO-only login is on, and this account is not the break-glass
+/// admin) is applied by the purge, because only the purge holds the configuration.
+/// </summary>
+/// <param name="UserId">The account.</param>
+/// <param name="Username">The account's own username, the basis the break-glass exemption is judged on.</param>
+/// <param name="IsAdministrator">Whether the account holds the administrator permission.</param>
+/// <param name="IsDisabled">Whether the account is disabled, and so already has no way in for this run to take.</param>
+/// <param name="RoutesToPasswordProvider">Whether the account's authentication provider is Jellyfin's built-in password provider.</param>
+/// <param name="HasStoredPassword">Whether the account carries a non-empty stored password.</param>
+internal readonly record struct AccountDoors(
+    Guid UserId,
+    string Username,
+    bool IsAdministrator,
+    bool IsDisabled,
+    bool RoutesToPasswordProvider,
+    bool HasStoredPassword);
+
+/// <summary>
+/// The outcome of a per-provider bulk unlink (#1519), with everything the controller needs to answer, to
+/// audit, and to revoke. Every field except <see cref="Result"/> is meaningful only on the arm that
+/// produced it: a refusal removes nothing, so its counts describe the state that refused rather than work
+/// done.
+/// </summary>
+/// <param name="Result">What happened.</param>
+/// <param name="RemovedLinks">How many links were removed; zero on every refusal.</param>
+/// <param name="ActualLinkCount">How many links the provider actually held, so a count mismatch can say what the real number is.</param>
+/// <param name="RevokedUserIds">
+/// The accounts whose LAST canonical link this run removed, which the controller revokes the live tokens
+/// of - exactly the scope the single unlink revokes at (#468). Empty on every refusal.
+/// </param>
+/// <param name="StrandedAdministrators">
+/// The administrator accounts whose last way in the run would have taken, named so the way out is
+/// explicit. Empty on every other arm.
+/// </param>
+internal readonly record struct ProviderLinkPurgeOutcome(
+    ProviderLinkPurgeResult Result,
+    int RemovedLinks,
+    int ActualLinkCount,
+    IReadOnlyList<Guid> RevokedUserIds,
+    IReadOnlyList<string> StrandedAdministrators);

--- a/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
+++ b/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
@@ -102,12 +102,20 @@ internal readonly record struct LinksElsewhere(HashSet<Guid> Any, HashSet<Guid> 
 /// The administrator accounts whose last way in the run would have taken, named so the way out is
 /// explicit. Empty on every other arm.
 /// </param>
+/// <param name="TargetWasEnabled">
+/// Whether the emptied provider was enabled, so its links were a way in before the run and the run took
+/// something. False means it took nothing from anybody, which is why the guard refused nobody - and why
+/// the after-the-fact check must not be asked either: an account with no way in on a server whose
+/// provider is switched off had none before the run, and reporting it as a lockout this run caused would
+/// be a false alarm on the workflow the route exists for.
+/// </param>
 internal readonly record struct ProviderLinkPurgeOutcome(
     ProviderLinkPurgeResult Result,
     int RemovedLinks,
     int ActualLinkCount,
     IReadOnlyList<Guid> RevokedUserIds,
-    IReadOnlyList<string> StrandedAdministrators)
+    IReadOnlyList<string> StrandedAdministrators,
+    bool TargetWasEnabled = false)
 {
     /// <summary>
     /// A refusal: nothing was removed, nobody is revoked, and the only fields that carry anything are the
@@ -118,5 +126,5 @@ internal readonly record struct ProviderLinkPurgeOutcome(
     /// <param name="actualLinkCount">How many links the provider actually holds.</param>
     /// <returns>The refusal outcome.</returns>
     internal static ProviderLinkPurgeOutcome Refusing(ProviderLinkPurgeResult result, int actualLinkCount)
-        => new(result, 0, actualLinkCount, Array.Empty<Guid>(), Array.Empty<string>());
+        => new(result, 0, actualLinkCount, Array.Empty<Guid>(), Array.Empty<string>(), TargetWasEnabled: false);
 }

--- a/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
+++ b/SSO-Auth/Api/Linking/ProviderLinkPurge.cs
@@ -30,22 +30,6 @@ internal enum ProviderLinkPurgeResult
 }
 
 /// <summary>
-/// What one provider's link table looks like to the bulk unlink before it acts (#1519): how many links
-/// the provider holds, and which accounts would be left holding no canonical link at all once those links
-/// are gone. A detached snapshot taken under the configuration lock, so the caller can resolve those
-/// accounts through the user manager WITHOUT holding it - the same discipline the link import takes for
-/// the same reason, since a provider can carry thousands of links and a user-manager call per link inside
-/// the lock would block every login for the duration.
-/// </summary>
-/// <param name="ProviderExists">Whether a provider of that mode and name is stored at all.</param>
-/// <param name="LinkCount">How many links the provider holds.</param>
-/// <param name="UsersLosingTheirLastLink">
-/// The distinct accounts that hold a link on this provider and none on any other, so the purge would take
-/// their last one. Re-derived under the lock when the purge runs; this copy exists only to be judged.
-/// </param>
-internal readonly record struct ProviderLinkSurvey(bool ProviderExists, int LinkCount, IReadOnlyList<Guid> UsersLosingTheirLastLink);
-
-/// <summary>
 /// What the tree can read about one account's ways in, resolved through the user manager OUTSIDE the
 /// configuration lock and judged inside it (#1519, T-D1). "Can use a password" is not a single field on a
 /// Jellyfin account and is not asked of the host: it is the same reading the SSO-only break-glass guard
@@ -66,6 +50,40 @@ internal readonly record struct AccountDoors(
     bool IsDisabled,
     bool RoutesToPasswordProvider,
     bool HasStoredPassword);
+
+/// <summary>
+/// What one provider's link table looks like to the bulk unlink before it acts (#1519): whether the
+/// provider is stored at all, how many links it holds, and which accounts hold them.
+/// </summary>
+/// <remarks>
+/// A detached snapshot taken under the configuration lock and WITHOUT a write, which is both of the jobs
+/// it has. It lets the accounts be resolved through the user manager with the lock released - a provider
+/// can carry thousands of links, and a user-manager call per link inside the lock would block every login
+/// for the duration - and it lets the two refusals a stale page actually produces be answered without
+/// entering a mutation, because every return out of one persists the configuration file even when it
+/// changed nothing, and a count that does not match is this endpoint's NORMAL outcome rather than an
+/// exceptional one. The authoritative checks stay inside the mutation; this only keeps the routine
+/// refusal off the write path.
+/// </remarks>
+/// <param name="ProviderExists">Whether a provider of that mode and name is stored.</param>
+/// <param name="LinkCount">How many links it holds.</param>
+/// <param name="LinkedUsers">The distinct accounts holding those links, to be judged before the purge runs.</param>
+internal readonly record struct ProviderLinkSurvey(bool ProviderExists, int LinkCount, IReadOnlyList<Guid> LinkedUsers);
+
+/// <summary>
+/// What one walk of every provider OTHER than the one being emptied says about the accounts it holds
+/// (#1519), plus whether the target itself is enabled.
+/// </summary>
+/// <remarks>
+/// Two sets rather than one, because the purge asks two questions with opposite readings of a disabled
+/// provider: who is left holding no link at all decides who is signed out, and who is left holding no
+/// link a login could resolve decides who would be stranded. Built once, because it is built inside the
+/// process-wide configuration lock every login takes, and a provider can carry thousands of links.
+/// </remarks>
+/// <param name="Any">Accounts holding a link on some other provider, enabled or not.</param>
+/// <param name="OnAnEnabledProvider">Accounts holding a link on some other ENABLED provider, which is what a login can resolve.</param>
+/// <param name="TargetEnabled">Whether the provider being emptied is itself enabled, so its links were a way in before the run.</param>
+internal readonly record struct LinksElsewhere(HashSet<Guid> Any, HashSet<Guid> OnAnEnabledProvider, bool TargetEnabled);
 
 /// <summary>
 /// The outcome of a per-provider bulk unlink (#1519), with everything the controller needs to answer, to
@@ -89,4 +107,16 @@ internal readonly record struct ProviderLinkPurgeOutcome(
     int RemovedLinks,
     int ActualLinkCount,
     IReadOnlyList<Guid> RevokedUserIds,
-    IReadOnlyList<string> StrandedAdministrators);
+    IReadOnlyList<string> StrandedAdministrators)
+{
+    /// <summary>
+    /// A refusal: nothing was removed, nobody is revoked, and the only fields that carry anything are the
+    /// reason and the count that refused. Named rather than written out at each arm, so a new refusal
+    /// cannot accidentally report links removed.
+    /// </summary>
+    /// <param name="result">Why the run refused.</param>
+    /// <param name="actualLinkCount">How many links the provider actually holds.</param>
+    /// <returns>The refusal outcome.</returns>
+    internal static ProviderLinkPurgeOutcome Refusing(ProviderLinkPurgeResult result, int actualLinkCount)
+        => new(result, 0, actualLinkCount, Array.Empty<Guid>(), Array.Empty<string>());
+}

--- a/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
@@ -97,6 +98,49 @@ internal sealed class SsoOnlyLoginService
             IsAdministrator: user.HasPermission(PermissionKind.IsAdministrator),
             IsEnabled: !user.HasPermission(PermissionKind.IsDisabled),
             HasUsablePasswordLogin: usablePasswordLogin);
+    }
+
+    /// <summary>
+    /// Resolves the named accounts into what the tree can read about their ways in (#1519), for the
+    /// per-provider bulk unlink's mass-lockout guard. The same reading <see cref="DescribeBreakGlass"/>
+    /// makes, and it lives here rather than beside the caller so "can this account use a password" has one
+    /// home: the built-in password provider plus a non-empty stored password. The mode-dependent half - that
+    /// while SSO-only login is on only the break-glass admin's password door survives - is left to the
+    /// caller, which is the only side holding the configuration.
+    /// </summary>
+    /// <remarks>
+    /// Called OUTSIDE the configuration lock, deliberately: the accounts come from a snapshot of one
+    /// provider's link table, that table can carry thousands of entries, and a user-manager call per entry
+    /// inside the lock would block every login for the duration. An id that resolves to no account is
+    /// reported as disabled rather than dropped, so the caller's set stays exactly the set it asked about -
+    /// an account that is not there has no way in for a purge to take, which is the same answer.
+    /// </remarks>
+    /// <param name="userIds">The accounts to resolve, as the link-table snapshot named them.</param>
+    /// <returns>One entry per requested id, in the order asked.</returns>
+    internal IReadOnlyList<AccountDoors> DescribeAccountDoors(IReadOnlyList<Guid> userIds)
+    {
+        ArgumentNullException.ThrowIfNull(userIds);
+
+        var doors = new List<AccountDoors>(userIds.Count);
+        foreach (var userId in userIds)
+        {
+            var user = _userManager.GetUserById(userId);
+            if (user is null)
+            {
+                doors.Add(new AccountDoors(userId, string.Empty, IsAdministrator: false, IsDisabled: true, RoutesToPasswordProvider: false, HasStoredPassword: false));
+                continue;
+            }
+
+            doors.Add(new AccountDoors(
+                userId,
+                user.Username,
+                user.HasPermission(PermissionKind.IsAdministrator),
+                user.HasPermission(PermissionKind.IsDisabled),
+                SsoAuthenticationProviders.IsDefaultPasswordProvider(user.AuthenticationProviderId),
+                !string.IsNullOrEmpty(user.Password)));
+        }
+
+        return doors;
     }
 
     /// <summary>

--- a/SSO-Auth/Config/ProviderLinkPurgeDocument.cs
+++ b/SSO-Auth/Config/ProviderLinkPurgeDocument.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// What a per-provider bulk unlink removed (#1519), answered to the caller.
+/// </summary>
+/// <remarks>
+/// It reports COUNTS and nothing else. The action reads canonical names and account ids to do its work and
+/// writes none of them here: an endpoint that answered with the accounts it had just unlinked would be a
+/// roster export behind a delete verb, and the elevated caller already has the link roster route if that is
+/// what they want. A JSON-only transport shape, never persisted to the config XML, so it carries no
+/// XML-serialization attributes - the same shape <see cref="LinkImportResultDocument"/> takes.
+/// </remarks>
+public class ProviderLinkPurgeDocument
+{
+    /// <summary>
+    /// Gets or sets how many canonical links were removed. It equals the count the caller sent, because a
+    /// count that did not match is a refusal rather than a partial run - so this is the confirmation that
+    /// the number the operator was shown is the number that went.
+    /// </summary>
+    public int Removed { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many accounts were left holding no canonical SSO link at all and had their live
+    /// tokens revoked. Always at most <see cref="Removed"/>, and smaller whenever an account held several
+    /// of the removed links or still holds one on another provider - those accounts keep their sessions,
+    /// which is the same scope the single unlink revokes at (#468).
+    /// </summary>
+    public int SignedOut { get; set; }
+}

--- a/docs/ACCOUNT-MANAGEMENT-API.md
+++ b/docs/ACCOUNT-MANAGEMENT-API.md
@@ -465,6 +465,77 @@ while the user still holds another one does not revoke, so unlinking one
 provider does not log somebody out of a session they legitimately hold through
 another.
 
+## Remove every link one provider holds
+
+```
+DELETE /sso/{mode}/Links/{provider}/{expectedLinkCount}
+```
+
+`PurgeProviderLinks`. Elevation-gated, and the way back from an import that
+restored the wrong document: the import merges, so re-importing the right file
+does not undo the wrong one. This empties one provider's link table so the right
+document can be imported into a clean provider.
+
+`expectedLinkCount` is the number of links the caller believes the provider
+holds. It is a precondition and not a display value: the server compares it
+against what the table holds under the same lock it removes under, and refuses
+on a difference. A call written against a page that has gone stale is refused
+rather than removing a different number of links than the operator was shown, so
+a browser confirmation is not what protects this route.
+
+| Status | Meaning                                                                          |
+| ------ | -------------------------------------------------------------------------------- |
+| 200    | Every link was removed; the body carries the counts                              |
+| 400    | `mode` is neither `oid` nor `saml`, or no provider of that name is configured    |
+| 403    | The caller is not an administrator                                               |
+| 409    | The count does not match, an administrator would be stranded, or the table moved |
+| 429    | The `link` budget for this client is exhausted                                   |
+
+The success body:
+
+```json
+{ "Removed": 42, "SignedOut": 39 }
+```
+
+`Removed` is the number of links that went, and always equals the count sent -
+a count that did not match is a refusal rather than a partial run. `SignedOut`
+is how many accounts were left holding no canonical link at all and had their
+live tokens revoked; it is smaller than `Removed` whenever an account held
+several of the removed links or still holds one on another provider. That is the
+same scope the single unlink revokes at: an account with a working link
+elsewhere keeps its sessions.
+
+Nothing but links is touched. No Jellyfin account, permission or password is
+changed, and no link is created, adopted or re-pointed - so an operator who runs
+this by mistake has removed links and nothing else. There is no undo: the way
+back is the account-link backup taken before the migration, re-imported.
+
+### The refusal that keeps administration reachable
+
+The run refuses, before it removes anything, when emptying the table would leave
+an administrator account with no way to sign in. The 409 names those accounts,
+because the way out is to give one of them a usable password or to unlink it
+deliberately through the single-link route, and an operator told only that "an
+administrator would be stranded" has to guess which.
+
+A link on another provider counts as a way in, and so does a password the
+account can actually use. "Can actually use" is not a single field on a Jellyfin
+account: it means the account routes to the built-in password provider and
+carries a stored password - and, while SSO-only login is on, that the account is
+the designated break-glass admin, since the mode has taken the password door
+away from everybody else. A disabled administrator is not stranded by the run,
+because it already has no way in.
+
+The run refuses rather than silently keeping the administrator's link. Keeping
+it would leave the provider not empty while the answer said it was, and the next
+import would hit exactly the repoint refusal this route exists to clear.
+
+Both the act and every refusal are audited (`SsoAudit.ProviderLinksPurged` and
+`SsoAudit.ProviderLinksPurgeRefused`, `SSO-Auth/Api/Audit/SsoAudit.cs`). The act
+is one Warning line naming the administrator who ran it, the provider and the
+counts, with the per-account detail at Information beneath it; a refusal names a
+fixed verdict code and no account. No canonical name appears in either.
+
 ## Revoke SSO for an account entirely
 
 ```

--- a/docs/ACCOUNT-MANAGEMENT-API.md
+++ b/docs/ACCOUNT-MANAGEMENT-API.md
@@ -518,13 +518,34 @@ because the way out is to give one of them a usable password or to unlink it
 deliberately through the single-link route, and an operator told only that "an
 administrator would be stranded" has to guess which.
 
-A link on another provider counts as a way in, and so does a password the
-account can actually use. "Can actually use" is not a single field on a Jellyfin
-account: it means the account routes to the built-in password provider and
-carries a stored password - and, while SSO-only login is on, that the account is
-the designated break-glass admin, since the mode has taken the password door
-away from everybody else. A disabled administrator is not stranded by the run,
-because it already has no way in.
+A link on another **enabled** provider counts as a way in, and so does a password
+the account can actually use. Enabled matters: a login resolves a link only on an
+enabled provider, so a link left behind on one somebody disabled is a row in a
+table and not a way to sign in - counting it would strand an administrator on
+exactly the disable-then-clean-up workflow this route exists for.
+
+"Can actually use" is not a single field on a Jellyfin account either: it means
+the account routes to the built-in password provider and carries a stored
+password - and, while SSO-only login is on, that the account is the designated
+break-glass admin, since the mode has taken the password door away from everybody
+else. An account on a third-party authentication provider is read as having no
+password door, which can refuse a purge that was in fact safe; the way past that
+is the single-link DELETE.
+
+The run asks both sides of the question, so it only refuses where it would TAKE
+the last way in. Emptying a provider that is already disabled refuses nobody: its
+links were not a way in before the run either. An administrator whose account is
+disabled is not stranded for the same reason.
+
+The refusal names at most ten accounts and then says how many more there are.
+
+One case the gate cannot cover, stated rather than implied: the accounts are read
+just before the removal takes the configuration lock, and an account can lose its
+password door in that window without any link moving - an ordinary SSO login on a
+provider whose default provider is the SSO one repoints the account off the
+password provider. The run therefore asks the question again afterwards and
+writes an Error line naming any administrator that is now without a way in. It
+cannot undo the removal; it is what turns a silent lockout into a repair.
 
 The run refuses rather than silently keeping the administrator's link. Keeping
 it would leave the provider not empty while the answer said it was, and the next

--- a/docs/ACCOUNT-MANAGEMENT-API.md
+++ b/docs/ACCOUNT-MANAGEMENT-API.md
@@ -518,19 +518,28 @@ because the way out is to give one of them a usable password or to unlink it
 deliberately through the single-link route, and an operator told only that "an
 administrator would be stranded" has to guess which.
 
-A link on another **enabled** provider counts as a way in, and so does a password
-the account can actually use. Enabled matters: a login resolves a link only on an
-enabled provider, so a link left behind on one somebody disabled is a row in a
-table and not a way to sign in - counting it would strand an administrator on
-exactly the disable-then-clean-up workflow this route exists for.
+A way in is a link on another **enabled** provider, and nothing else. Enabled
+matters: a login resolves a link only on an enabled provider, so a link left
+behind on one somebody disabled is a row in a table and not a way to sign in -
+counting it would strand an administrator on exactly the disable-then-clean-up
+workflow this route exists for.
 
-"Can actually use" is not a single field on a Jellyfin account either: it means
-the account routes to the built-in password provider and carries a stored
-password - and, while SSO-only login is on, that the account is the designated
-break-glass admin, since the mode has taken the password door away from everybody
-else. An account on a third-party authentication provider is read as having no
-password door, which can refuse a purge that was in fact safe; the way past that
-is the single-link DELETE.
+**A stored password does not count, and that is deliberate.** This plugin mints
+an unguessable password onto every account it provisions, and onto every
+passwordless linked account it finds at startup, so that such an account cannot
+be signed into with an empty one. It records nowhere which accounts those were,
+and the hash it writes is the same field and the same shape as one an
+administrator set. So a non-empty stored password is a secret somebody holds or a
+seal nobody can open, and nothing in the tree separates them. Counting it would
+have cleared this guard for every SSO-provisioned administrator on a server whose
+provider routes accounts to Jellyfin's built-in password provider - which is a
+common setting - silently, which is the lockout the guard exists to refuse.
+
+The cost of that is stated rather than hidden: an administrator who really does
+sign in with a password, and who holds a link on the provider being emptied,
+makes this refuse. Link that account to another enabled provider, or unlink it
+deliberately through the single-link DELETE, and run the purge again. Both are one
+call, and a refusal costs a call where the other error costs the server.
 
 The run asks both sides of the question, so it only refuses where it would TAKE
 the last way in. Emptying a provider that is already disabled refuses nobody: its
@@ -540,12 +549,13 @@ disabled is not stranded for the same reason.
 The refusal names at most ten accounts and then says how many more there are.
 
 One case the gate cannot cover, stated rather than implied: the accounts are read
-just before the removal takes the configuration lock, and an account can lose its
-password door in that window without any link moving - an ordinary SSO login on a
-provider whose default provider is the SSO one repoints the account off the
-password provider. The run therefore asks the question again afterwards and
-writes an Error line naming any administrator that is now without a way in. It
-cannot undo the removal; it is what turns a silent lockout into a repair.
+just before the removal takes the configuration lock, and something else can
+change in that window - another administrator disabling the other provider, or
+unlinking the account there. The run therefore asks the question again after the
+removal and writes an Error line naming any administrator that is now without a
+way in. It cannot undo the removal; it is what turns a silent lockout into a
+repair. It is asked only where the run took something, so emptying an
+already-disabled provider never produces that line.
 
 The run refuses rather than silently keeping the administrator's link. Keeping
 it would leave the provider not empty while the answer said it was, and the next

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -260,9 +260,33 @@ importing the wrong file. Re-importing the correct one does not undo it. The lin
 import only adds and overwrites, never removes, so the wrong file's entries stay;
 the correct document then hits `this instance already links that identity to a
 different account; unlink it first`, and because the refusal is whole-document,
-one leftover entry blocks the restore of every other link. Unlinking is one call
-per canonical name and the refusal names at most ten entries at a time, by index.
-There is no replace mode and no bulk unlink. #1519 holds that gap.
+one leftover entry blocks the restore of every other link.
+
+What clears it is emptying the provider and importing again, not importing over
+the top:
+
+```
+DELETE /sso/oid/Links/keycloak/{the number of links the provider holds}
+```
+
+`PurgeProviderLinks`, elevation-gated, one provider at a time. It removes every
+canonical link that provider holds and nothing else - no account, no permission
+and no password is touched - and the count in the path is checked against what
+the table actually holds, so a call written against a stale page is refused
+rather than emptying a different number of links than you were shown. Accounts
+left holding no link at all are signed out; accounts that still have a link on
+another provider keep their sessions.
+
+It refuses, before removing anything, when the result would leave an
+administrator account with no way to sign in, and the refusal names those
+accounts. Give one of them a usable password, or unlink it deliberately with the
+single-link DELETE, and run it again. `docs/ACCOUNT-MANAGEMENT-API.md` carries
+the full contract, including what counts as a way in while SSO-only login is on.
+
+There is still no replace mode on the import itself, and that is deliberate: an
+import that replaced would be a second destructive path with the same blast
+radius as the mistake it answers. The purge above is the way back, and the pair
+of backup files remains the way back from the purge.
 
 Re-importing the same file onto the state it produced IS safe, and the walk shows
 it: a second run of a successful import succeeds and changes nothing, because a

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -279,12 +279,13 @@ another provider keep their sessions.
 
 It refuses, before removing anything, when the result would leave an
 administrator account with no way to sign in, and the refusal names those
-accounts. Give one of them a usable password, or unlink it deliberately with the
-single-link DELETE, and run it again. A way in means a password the account can
-actually use, or a link on another **enabled** provider - a link on a disabled
-one signs nobody in, so it does not count.
-`docs/ACCOUNT-MANAGEMENT-API.md` carries the full contract, including what counts
-while SSO-only login is on and the one window the check cannot cover.
+accounts. A way in means a link on another **enabled** provider and nothing else -
+a link on a disabled one signs nobody in, and a stored password proves nothing,
+because this plugin mints an unusable one onto the accounts it provisions and
+cannot tell the two apart. Link such an account to another enabled provider, or
+unlink it deliberately with the single-link DELETE, and run this again.
+`docs/ACCOUNT-MANAGEMENT-API.md` carries the full contract, including the one
+window the check cannot cover.
 
 There is still no replace mode on the import itself, and that is deliberate: an
 import that replaced would be a second destructive path with the same blast

--- a/docs/SERVER-MIGRATION.md
+++ b/docs/SERVER-MIGRATION.md
@@ -280,8 +280,11 @@ another provider keep their sessions.
 It refuses, before removing anything, when the result would leave an
 administrator account with no way to sign in, and the refusal names those
 accounts. Give one of them a usable password, or unlink it deliberately with the
-single-link DELETE, and run it again. `docs/ACCOUNT-MANAGEMENT-API.md` carries
-the full contract, including what counts as a way in while SSO-only login is on.
+single-link DELETE, and run it again. A way in means a password the account can
+actually use, or a link on another **enabled** provider - a link on a disabled
+one signs nobody in, so it does not count.
+`docs/ACCOUNT-MANAGEMENT-API.md` carries the full contract, including what counts
+while SSO-only login is on and the one window the check cannot cover.
 
 There is still no replace mode on the import itself, and that is deliberate: an
 import that replaced would be a second destructive path with the same blast


### PR DESCRIPTION
# What & why

Closes #1519.

A link import merges — it adds and overwrites and never removes — so re-importing
the correct file after the wrong one does not undo it: the correct document is
refused whole by the repoint guard, and one leftover entry blocks the restore of
every other link. Until now the only way out was one `DELETE` per canonical name,
against a refusal that names at most ten entries at a time by index.

This adds the remedy the decision on #1519 chose:

```
DELETE /sso/{mode}/Links/{provider}/{expectedLinkCount}
```

It removes every canonical link one provider holds and nothing else — no account,
no permission, no password — and it creates, adopts and re-points nothing. It is
the smallest true way back rather than a replace mode on the import, which would
be a second destructive path with the same blast radius as the mistake it
answers.

It is also the first primitive here that can take every account on a server off
SSO in one call, so most of this change is the gate. Five preconditions, four of
them the server's:

- **elevation**, because it acts on accounts the caller does not own and there is
  no single subject a per-user check could name;
- **a provider that resolves**, refusing rather than matching an empty table and
  reporting success on the wrong one;
- **the caller-supplied count**, compared against what the table holds under the
  same lock the removal takes, so a call written against a stale page refuses
  instead of emptying a different number than the operator was shown — a browser
  dialog protects nobody who calls the API;
- **the link table not having moved** while the accounts were being judged;
- **T-D1**: the run refuses, before removing anything, when the result would leave
  an administrator account with no way to sign in, and names those accounts so the
  way out is explicit.

## What counts as a way in, measured rather than assumed

The decision left this to the builder to measure and record. It is a link on an
**enabled** provider, and nothing else.

*Enabled*, because every login resolution passes `requireEnabled: true` and both
flow services refuse a provider that is `not { Enabled: true }`. A link left on a
provider somebody disabled is a row in a table, not a way to sign in.

*And nothing else* — in particular **not** a stored password, which is the
finding that cost this branch two rounds. `ProvisionedPassword.Mint` writes 64
CSPRNG bytes onto every account this plugin provisions and onto every passwordless
linked account the boot sweep finds (#1440), deliberately, so such an account
cannot be signed into with the empty password. Nothing records which accounts
those were, and the hash is the same field and the same shape as one an
administrator set. On a provider whose `DefaultProvider` is Jellyfin's built-in
password provider — which the settings page names as a common option, and which
the session mint writes onto every account that signs in — counting it cleared
this guard for every SSO-provisioned administrator on the server.

The cost is stated rather than hidden: an administrator who really does sign in
with a password, and who holds a link on the provider being emptied, makes this
refuse. The refusal names both ways out and each is one call.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: every unknown — an unresolved provider, a count that
      does not match, a table that moved, an account whose doors cannot be proven —
      refuses and removes nothing.
- [x] No secrets logged; the audit lines carry protocol, provider, actor and
      counts, and no canonical subject (T-I1). Log inputs are sanitized inline at
      the log call.
- [x] A security review was performed.
- [x] Review record: below.
- [x] Log inputs from the IdP are sanitized inline at the log call.

### Review record

Four lenses, refute-by-default, run twice: once on the first state and again on
the fixed one. **CONFIRMED 15 / PLAUSIBLE 2** as raised across both rounds.

**Round 1 — bypass lens: FAIL.** CONFIRMED 1 + 2 informational, PLAUSIBLE 1.

- *The T-D1 guard counted a link on a disabled provider as a way in* — FIXED.
- *`ProviderLinkSurvey` fields unread; the revoke-failure log names no account* —
  both FIXED.
- *TOCTOU on the account doors rather than the links* — see round 2.

**Round 1 — availability lens: FAIL.** CONFIRMED 5, PLAUSIBLE 1. Independently
found the same disabled-provider hole, plus: every refusal rewrote
`SSO-Auth.xml`; the actor was resolved after the state change so a throw lost the
audit line; the stranding refusal body was unbounded; the code comment claimed a
race property the code did not have. All FIXED.

**Round 1 — correctness lens: FAIL.** CONFIRMED 8, PLAUSIBLE 2. The same hole
again, plus: two tests passed for the wrong reason and pinned it; `SignedOut` and
the act audit understated a revoke that threw; the refusal's suggested remedy did
not by itself clear the refusal. All FIXED. It also caught the first fix's own
regression before it landed — a per-account scan of every other provider inside
the process-wide configuration lock — now one walk building two sets.

**Round 2 — availability lens: FAIL.** CONFIRMED 5. The sealed-password reading
above (HIGH), the safety net fed a smaller population than the gate judged, the
net's line uncapped, and a declined one: an administrator on a third-party
authentication provider reads as door-less and can make a safe purge refuse. That
is the fail-safe direction, the single-link route is the way past it, and the API
page says so — **DECLINED with that reason.**

**Round 2 — correctness lens: FAIL.** CONFIRMED 6. Confirmed every round-1 fix,
and found the safety net wrong in both directions: silent on the accounts the race
would hit, and crying wolf with a false causal claim on a disabled provider where
the run took nothing. Both FIXED, and the net now has five unit tests plus an
endpoint test for its silence.

No finding was left without a disposition. The two rounds are the two commits
after the first.

## Quality checklist

- [x] No duplicated logic; the two questions the guard asks come from one walk.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why. Module DAG respected — `Api.Session → Api.Linking` is
      an existing allowed edge; the password reading stays in `SsoOnlyLoginService`
      so "what the tree can read about an account" has one home.
- [x] Architecture-conformance tests pass. Three rosters were updated as the rules
      require: the rate-limit classification, the provider-name classification, the
      typed-call-site sentinel, and the elevation surface.
- [x] Docs included: `docs/ACCOUNT-MANAGEMENT-API.md`, `docs/SERVER-MIGRATION.md`
      and the CHANGELOG.

## Verification

- [x] `dotnet build --warnaserror` green on **both** TFMs, 0 warnings.
- [x] Full suite green on both: 3708 (net9.0) / 3709 (net10.0), 0 failed.
- [x] Prettier clean for every changed `.md`.

Guards proven by deletion, each turning exactly the tests it should red:
disabling the count comparison and the lockout refusal reddens four; reading the
any-provider set instead of the enabled one reddens the disabled-elsewhere
falsifier; forcing the target-enabled term true reddens the disabled-target one.

## Notes

**Not in scope, deliberately.** The configuration page has no button for this;
the contract is API-only today, which the docs say. The page half belongs with the
4.4 configuration rebuild rather than in front of it.

**Left open.** Making a sealed password distinguishable from a real one would let
the password term come back. That is a change on #1440's own surface — both minting
sites would have to record what they sealed — and it is not smuggled in here.

**No second reader.** This branch was reviewed by five adversarial lens runs and
by the local gate; no person has read it yet.
