### PR TITLE
Name the minted account in the login audit line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,24 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Changed
 
+- **The login audit line now names the Jellyfin account, and the
+  provider-presented name beside it where the two differ (#1551).** The
+  `[SSO Audit] Login succeeded` line carried the username the identity provider
+  presented. Jellyfin publishes its own `AuthenticationSuccess` event for the
+  same mint and names the **resolved account** in it, and the two are not always
+  the same name: an existing account link resolves an account under whatever
+  name it already carries, and `SyncUsernameFromProvider` is off by default, so
+  the audit line could name somebody the server's own event never mentioned.
+  Correlating the plugin's trail with the host's notification - which is the only
+  way to tell an SSO login from a password login at a notification destination -
+  was then not possible for exactly the accounts whose names had drifted. The
+  line now carries the name the host is about to carry, read off the very result
+  the host publishes rather than derived a second time beside it, and appends
+  `The provider presented the name '<name>'.` only where the presented name
+  differs. A login whose names agree writes the line byte-for-byte as before.
+  **A log parser matching the old line for the provider's username reads the
+  account's name instead.**
+
 - **Restoring an account-link backup now says how many links it restored
   (#1520).** `POST /sso/Config/Links/Import`, and the **Import Account Links**
   button that posts to it, answered the same empty success whatever the number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,15 +574,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   presented. Jellyfin publishes its own `AuthenticationSuccess` event for the
   same mint and names the **resolved account** in it, and the two are not always
   the same name: an existing account link resolves an account under whatever
-  name it already carries, and `SyncUsernameFromProvider` is off by default, so
-  the audit line could name somebody the server's own event never mentioned.
+  name it already carries and `SyncUsernameFromProvider` is off by default, a
+  created account was provisioned under Jellyfin's own name allowlist which drops
+  characters a provider's name may carry, and a requested rename can have been
+  declined - so the audit line could name somebody the server's own event never
+  mentioned.
   Correlating the plugin's trail with the host's notification - which is the only
   way to tell an SSO login from a password login at a notification destination -
   was then not possible for exactly the accounts whose names had drifted. The
   line now carries the name the host is about to carry, read off the very result
   the host publishes rather than derived a second time beside it, and appends
   `The provider presented the name '<name>'.` only where the presented name
-  differs. A login whose names agree writes the line byte-for-byte as before.
+  differs, decided on the names as the line prints them rather than on the raw
+  values, so a provider cannot make the line assert a difference it then shows
+  two identical names for. A login whose names agree writes the line
+  byte-for-byte as before.
   **A log parser matching the old line for the provider's username reads the
   account's name instead.**
 

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -80,6 +80,34 @@ public class SsoAuditTests
     }
 
     [Fact]
+    public void LoginSucceeded_StripsLineEndings_FromTheProviderPresentedName()
+    {
+        // The presented name is a second identity-provider-supplied value in the same template (#1551), so
+        // it is a second forging surface and carries the same inline sanitizer as the first.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice.jellyfin", isAdmin: false, presentedUsername: "ali\r\n[SSO Audit] forged");
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
+        Assert.Contains("Login succeeded: alice.jellyfin", message, StringComparison.Ordinal);
+        Assert.Contains("presented the name 'ali[SSO Audit] forged'", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoginSucceeded_APresentedNameEqualToTheAccountName_AddsNothingToTheLine()
+    {
+        // The clause exists for the drift arm only. Every other login writes what it always wrote, and this
+        // is the row that fails if the comparison is dropped and the clause becomes unconditional.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: false, presentedUsername: "alice");
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=False).", message);
+    }
+
+    [Fact]
     public void ProvisionedPendingApproval_LogsWarning_SayingNoSessionWasIssued()
     {
         var logger = new CapturingLogger();

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -95,6 +95,21 @@ public class SsoAuditTests
     }
 
     [Fact]
+    public void LoginSucceeded_APresentedNameDifferingOnlyInStrippedCharacters_AddsNothingToTheLine()
+    {
+        // The decision is taken on what the line will PRINT, not on the raw values. Compared raw, these two
+        // are different strings; printed, they are the same name - so a raw comparison emits a line asserting
+        // a difference and then showing two identical names, which an identity provider can produce at will
+        // just by appending a newline to the name it presents.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: false, presentedUsername: "alice\r\n");
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=False).", message);
+    }
+
+    [Fact]
     public void LoginSucceeded_APresentedNameEqualToTheAccountName_AddsNothingToTheLine()
     {
         // The clause exists for the drift arm only. Every other login writes what it always wrote, and this

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -456,16 +456,22 @@ public class LoginCompletionServiceTests
         };
         var auditLog = new CapturingLogger();
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
-        users.GetUserById(Existing).Returns(TestUsers.Named("alice.jellyfin", Existing));
+        // THREE DISTINCT NAMES on purpose. The account the resolver returns, the name on the result the
+        // host hands back, and the name the provider presented are all different here, so the row can only
+        // pass if the line is read off the HOST RESULT - the value the host itself publishes - rather than
+        // off the account record or off the identity. Two of the three being equal would let a second
+        // derivation pass while claiming to be the host's.
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice.account", Existing));
         users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
-            .Returns(new AuthenticationResult { User = new UserDto { Name = "alice.jellyfin" } });
+            .Returns(new AuthenticationResult { User = new UserDto { Name = "alice.host" } });
 
         await service.CompleteAsync(
             OidcIdentity("kc", "sub-1", "alice.idp"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
 
         var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
-        Assert.Contains("Login succeeded: alice.jellyfin", audit.Message, StringComparison.Ordinal);
+        Assert.Contains("Login succeeded: alice.host", audit.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("alice.account", audit.Message, StringComparison.Ordinal);
         Assert.Contains("presented the name 'alice.idp'", audit.Message, StringComparison.Ordinal);
     }
 

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -439,4 +439,57 @@ public class LoginCompletionServiceTests
         await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
+    [Fact]
+    public async Task CompleteAsync_AResolvedAccountNamedDifferently_IsNamedByTheAccount_AndThePresentedNameBeside()
+    {
+        // #1551. The operator lines this line up against the host's own AuthenticationSuccess event for the
+        // same mint, and that event names the RESOLVED ACCOUNT: AuthenticateDirect publishes the very result
+        // it returns, with User set from the account it minted for. An existing subject-keyed link resolves
+        // an account under whatever name it already carries, and SyncUsernameFromProvider is off by default,
+        // so a line carrying the provider-presented name names somebody the host's event never mentions and
+        // the correlation the issue closes on is not available.
+        var config = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice.jellyfin", Existing));
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
+            .Returns(new AuthenticationResult { User = new UserDto { Name = "alice.jellyfin" } });
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice.idp"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Contains("Login succeeded: alice.jellyfin", audit.Message, StringComparison.Ordinal);
+        Assert.Contains("presented the name 'alice.idp'", audit.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AResolvedAccountNamedTheSame_WritesTheLineUnchanged()
+    {
+        // The near-miss beside the row above: the two names agree on every login that is not the drift arm,
+        // and a fix that appended the provider's name unconditionally would add a clause to every audit line
+        // on every server. Nothing about a login that did not drift may change.
+        var config = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
+            .Returns(new AuthenticationResult { User = new UserDto { Name = "alice" } });
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'kc' (admin=False).", audit.Message);
+    }
 }

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -439,6 +439,7 @@ public class LoginCompletionServiceTests
         await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
+
     [Fact]
     public async Task CompleteAsync_AResolvedAccountNamedDifferently_IsNamedByTheAccount_AndThePresentedNameBeside()
     {

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -33,7 +33,12 @@ internal static class SsoAudit
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
     /// <param name="username">The Jellyfin account the session was issued for.</param>
-    /// <param name="isAdmin">Whether the session was granted administrator rights.</param>
+    /// <param name="isAdmin">
+    /// Whether the identity provider ASSERTED administrator rights on this login. It is the identity's claim
+    /// and not the state the mint granted: the permission write is skipped entirely when EnableAuthorization
+    /// is off, and the break-glass administrator is never demoted by it. The name beside it is the account's,
+    /// so the two halves of this line have different provenance - see #1554.
+    /// </param>
     /// <param name="presentedUsername">
     /// The username the identity provider presented on this login. Named in the line only where it differs
     /// from <paramref name="username"/>; null suppresses the comparison entirely.
@@ -51,6 +56,11 @@ internal static class SsoAudit
         // its own evidence denies, which an identity provider can produce at will. The sanitizer is still
         // spelled out inline at each logging call below rather than being passed down from here, because
         // CodeQL's cs/log-forging taint tracking does not follow it across an assignment.
+        //
+        // ORDINAL, DELIBERATELY, though the host resolves a username case-insensitively. The rename this
+        // clause reports the absence of decides on the same basis - CanonicalLinkService compares the
+        // account name against the sanitized presented name with StringComparison.Ordinal - so a case-folding
+        // comparison here would stay silent about a difference the rename path would act on.
         if (presentedUsername is not null
             && !string.Equals(
                 presentedUsername.ReplaceLineEndings(string.Empty),

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -23,9 +23,11 @@ internal static class SsoAudit
     /// Records a successful login (a session was issued). The name this line carries is the JELLYFIN
     /// ACCOUNT's, because that is the one an operator has to line this line up against: the host publishes
     /// its own <c>AuthenticationSuccess</c> event for the same mint and names the resolved account in it
-    /// (#1551). The provider-presented name can differ from it - an existing link resolves an account under
-    /// whatever name it already carries, and <c>SyncUsernameFromProvider</c> is off by default - so it is
-    /// named too, and only where it differs, so an unchanged login writes the line it always wrote.
+    /// (#1551). The provider-presented name can differ from the account's for more than one reason - an
+    /// existing link resolves an account under whatever name it already carries and
+    /// <c>SyncUsernameFromProvider</c> is off by default; a created account was provisioned under the
+    /// host's own name allowlist, which drops characters the provider's name may carry; a requested rename
+    /// can have been declined - so the presented name is carried too, and only where the two differ.
     /// </summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
@@ -43,7 +45,17 @@ internal static class SsoAudit
             return;
         }
 
-        if (presentedUsername is not null && !string.Equals(presentedUsername, username, StringComparison.Ordinal))
+        // The decision is taken on the values AS THEY WILL BE PRINTED, never on the raw ones. Both names are
+        // stripped of line endings on the way into the line, so a provider presenting "alice\r\n" against the
+        // account "alice" compares unequal raw and prints two identical names - a line asserting a difference
+        // its own evidence denies, which an identity provider can produce at will. The sanitizer is still
+        // spelled out inline at each logging call below rather than being passed down from here, because
+        // CodeQL's cs/log-forging taint tracking does not follow it across an assignment.
+        if (presentedUsername is not null
+            && !string.Equals(
+                presentedUsername.ReplaceLineEndings(string.Empty),
+                username?.ReplaceLineEndings(string.Empty),
+                StringComparison.Ordinal))
         {
             logger.LogInformation(
                 "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}'.",

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -19,16 +19,39 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Audit;
 /// </summary>
 internal static class SsoAudit
 {
-    /// <summary>Records a successful login (a session was issued).</summary>
+    /// <summary>
+    /// Records a successful login (a session was issued). The name this line carries is the JELLYFIN
+    /// ACCOUNT's, because that is the one an operator has to line this line up against: the host publishes
+    /// its own <c>AuthenticationSuccess</c> event for the same mint and names the resolved account in it
+    /// (#1551). The provider-presented name can differ from it - an existing link resolves an account under
+    /// whatever name it already carries, and <c>SyncUsernameFromProvider</c> is off by default - so it is
+    /// named too, and only where it differs, so an unchanged login writes the line it always wrote.
+    /// </summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
-    /// <param name="username">The Jellyfin username the session was issued for.</param>
+    /// <param name="username">The Jellyfin account the session was issued for.</param>
     /// <param name="isAdmin">Whether the session was granted administrator rights.</param>
-    internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool isAdmin)
+    /// <param name="presentedUsername">
+    /// The username the identity provider presented on this login. Named in the line only where it differs
+    /// from <paramref name="username"/>; null suppresses the comparison entirely.
+    /// </param>
+    internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool isAdmin, string? presentedUsername = null)
     {
         if (!logger.IsEnabled(LogLevel.Information))
         {
+            return;
+        }
+
+        if (presentedUsername is not null && !string.Equals(presentedUsername, username, StringComparison.Ordinal))
+        {
+            logger.LogInformation(
+                "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}'.",
+                username?.ReplaceLineEndings(string.Empty),
+                protocol,
+                provider?.ReplaceLineEndings(string.Empty),
+                isAdmin,
+                presentedUsername.ReplaceLineEndings(string.Empty));
             return;
         }
 

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -229,14 +229,6 @@ internal sealed class LoginCompletionService
     // indistinguishable from an unlimited account, and disabling on it would make that same transient change
     // indistinguishable from a real expiry - so the fail-closed answer is to refuse this login and leave the
     // account exactly as it was.
-    // The name the host is about to publish for this mint (#1551). AuthenticateDirect sets the result's User
-    // from the account it minted for and publishes the SAME instance as its AuthenticationSuccess event, so
-    // reading it here is reading the host's own value rather than deriving a second one beside it. The
-    // parameter is nullable and the presented name is the fallback because a host that returned no user
-    // raised no event either, and an audit line is never worth throwing a completed login away for.
-    private static string MintedUsername(AuthenticationResult? authenticationResult, VerifiedIdentity identity)
-        => authenticationResult?.User?.Name ?? identity.Username;
-
     private async Task<ActionResult?> EnforceAccountExpiryAsync(VerifiedIdentity identity, Guid userId)
     {
         if (_canonicalLinks.IsAccountAdministrator(userId))
@@ -325,4 +317,13 @@ internal sealed class LoginCompletionService
             _logger.LogError(ex, "Failed to capture the Single Logout session state after a successful login; logout propagation will be unavailable for this session.");
         }
     }
+
+    // The name the host is about to publish for this mint (#1551). AuthenticateDirect sets the result's User
+    // from the account it minted for and publishes the SAME instance as its AuthenticationSuccess event, so
+    // reading it here is reading the host's own value rather than deriving a second one beside it. The
+    // parameter is nullable and the presented name is the fallback because a host that returned no user
+    // raised no event either, and an audit line is never worth throwing a completed login away for. Empty
+    // counts as absent for the same reason: a blank name correlates with nothing.
+    private static string MintedUsername(AuthenticationResult? authenticationResult, VerifiedIdentity identity)
+        => string.IsNullOrEmpty(authenticationResult?.User?.Name) ? identity.Username : authenticationResult.User.Name;
 }

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -190,9 +190,11 @@ internal sealed class LoginCompletionService
         // event, so an operator can line the two up. AuthenticateDirect builds that event's payload from
         // THIS result - it publishes the same instance it returns - so User.Name is the host's own value
         // rather than a second derivation of it that could drift. The provider-presented name is passed
-        // beside it and is logged only where the two differ, which is the arm where an existing link
-        // resolves an account under its own name and SyncUsernameFromProvider is off. The fallback is
-        // reached only when the host returned no user, and there is then no host event to correlate with.
+        // beside it and is logged only where the two differ, which happens for more than one reason: an
+        // existing link resolves an account under its own name with SyncUsernameFromProvider off, a created
+        // account was provisioned through Jellyfin's name allowlist, or a requested rename was declined. The
+        // fallback is reached only when the host returned no usable name; the line then names what it always
+        // named, and an audit line is never worth throwing a completed login away for.
         var mintedUsername = MintedUsername(authenticationResult, identity);
         SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, mintedUsername, identity.Admin, identity.Username);
 
@@ -321,9 +323,11 @@ internal sealed class LoginCompletionService
     // The name the host is about to publish for this mint (#1551). AuthenticateDirect sets the result's User
     // from the account it minted for and publishes the SAME instance as its AuthenticationSuccess event, so
     // reading it here is reading the host's own value rather than deriving a second one beside it. The
-    // parameter is nullable and the presented name is the fallback because a host that returned no user
-    // raised no event either, and an audit line is never worth throwing a completed login away for. Empty
-    // counts as absent for the same reason: a blank name correlates with nothing.
+    // parameter is nullable and the presented name is the fallback because a name is all this line can
+    // correlate on: without one there is nothing to line the two records up by, so the pre-#1551 value is
+    // no worse than a blank, and an audit line is never worth throwing a completed login away for. Empty
+    // counts as absent for the same reason. The host publishes its event BEFORE returning, so a missing
+    // name does not mean a missing event - it means the correlation cannot be made from this end.
     private static string MintedUsername(AuthenticationResult? authenticationResult, VerifiedIdentity identity)
         => string.IsNullOrEmpty(authenticationResult?.User?.Name) ? identity.Username : authenticationResult.User.Name;
 }

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -186,7 +186,15 @@ internal sealed class LoginCompletionService
             sessionParameters,
             remoteEndPointResolver,
             () => _canonicalLinks.IsIdentityStillLinked(identity.LinkMode, identity.Provider, identity.Subject, userId)).ConfigureAwait(false);
-        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, identity.Username, identity.Admin);
+        // #1551: the line names the account the HOST is about to name in its own AuthenticationSuccess
+        // event, so an operator can line the two up. AuthenticateDirect builds that event's payload from
+        // THIS result - it publishes the same instance it returns - so User.Name is the host's own value
+        // rather than a second derivation of it that could drift. The provider-presented name is passed
+        // beside it and is logged only where the two differ, which is the arm where an existing link
+        // resolves an account under its own name and SyncUsernameFromProvider is off. The fallback is
+        // reached only when the host returned no user, and there is then no host event to correlate with.
+        var mintedUsername = MintedUsername(authenticationResult, identity);
+        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, mintedUsername, identity.Admin, identity.Username);
 
         // #1139: counted beside the audit line rather than at a new hook point, so the counter and the trail
         // cannot come apart. Here rather than in the status mapper because a success reaches the mapper too,
@@ -221,6 +229,14 @@ internal sealed class LoginCompletionService
     // indistinguishable from an unlimited account, and disabling on it would make that same transient change
     // indistinguishable from a real expiry - so the fail-closed answer is to refuse this login and leave the
     // account exactly as it was.
+    // The name the host is about to publish for this mint (#1551). AuthenticateDirect sets the result's User
+    // from the account it minted for and publishes the SAME instance as its AuthenticationSuccess event, so
+    // reading it here is reading the host's own value rather than deriving a second one beside it. The
+    // parameter is nullable and the presented name is the fallback because a host that returned no user
+    // raised no event either, and an audit line is never worth throwing a completed login away for.
+    private static string MintedUsername(AuthenticationResult? authenticationResult, VerifiedIdentity identity)
+        => authenticationResult?.User?.Name ?? identity.Username;
+
     private async Task<ActionResult?> EnforceAccountExpiryAsync(VerifiedIdentity identity, Guid userId)
     {
         if (_canonicalLinks.IsAccountAdministrator(userId))

--- a/docs/THREAT-MODEL-TRUSTED-HEADER.md
+++ b/docs/THREAT-MODEL-TRUSTED-HEADER.md
@@ -203,7 +203,11 @@ What the plugin can do: record the header path under its own protocol label in
 the audit trail rather than folding it into the two existing ones, and record the
 peer address the login was accepted from, which is the only piece of evidence
 that exists. Today the success record carries the username, the protocol, the
-provider and whether administrator rights were granted, and no address:
+provider and whether administrator rights were granted, and no address. The
+quotation below is pinned to `origin/main`, which is where it was taken; on the
+`4.4` line the username field became the RESOLVED Jellyfin account rather than
+the name the provider presented, with the presented name appended where the two
+differ (#1551). Neither change adds an address, so nothing in this section moves.
 
 ```
 $ git show origin/main:SSO-Auth/Api/Audit/SsoAudit.cs | sed -n '35,41p'


### PR DESCRIPTION
# What & why

Closes #1551.

The decision recorded on #1551 on 2026-09-09 answered "no" to the success half
of the SSO marker and set one condition on closing it: the correlation an operator
falls back to has to be possible in practice, so the plugin's audit line must carry
what a reader needs to line it up with the host's own event - the user and a
timestamp at the least.

**The timestamp half needs no code**, and this is the reading rather than a
recollection. Jellyfin's file sink stamps every line, and the plugin's own category
is not filtered out:

```
$ docker cp jf-sso:/config/config/logging.default.json .
"MinimumLevel": { "Default": "Information", "Override": { "Microsoft": "Warning", "System": "Warning" } }
"outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] [{ThreadId}] {SourceContext}: {Message}{NewLine}{Exception}"
```

**The user half was not met**, which is what this change is. The line carried
`identity.Username` - the name the identity provider presented. Jellyfin publishes
its own `AuthenticationSuccess` event for the same mint and names the RESOLVED
account in it, and the two are not always the same name. The plugin's own source
says where they part:

```
$ git grep -n 'the two names can have drifted apart' origin/4.4 -- SSO-Auth/Api/Linking/CanonicalLinkService.cs
origin/4.4:SSO-Auth/Api/Linking/CanonicalLinkService.cs:294:                // The one arm where the two names can have drifted apart: the subject resolved an account
```

An existing link resolves an account under whatever name it already carries and
`SyncUsernameFromProvider` is off by default; a created account was provisioned
through Jellyfin's own name allowlist, which drops characters a provider's name may
carry; and a requested rename can have been declined. On any of those the audit line
named somebody the server's event never mentioned, and the correlation the decision
closes on was not available for exactly the accounts whose names had drifted.

The line now names the account, read off the very result the host publishes, and
appends `The provider presented the name '<name>'.` only where the two differ. That
the host publishes the same instance it returns was read off the assembly this
machine's server runs, not assumed:

```
$ ilspycmd -t Emby.Server.Implementations.Session.SessionManager Emby.Server.Implementations.dll | sed -n '1333,1341p'
	AuthenticationResult returnResult = new AuthenticationResult
	{
		User = _userManager.GetUserDto(user, request.RemoteEndPoint),
		SessionInfo = ToSessionInfoDto(sessionInfo),
		AccessToken = token,
		ServerId = ((IApplicationHost)_appHost).SystemId
	};
	await _eventManager.PublishAsync<AuthenticationResultEventArgs>(new AuthenticationResultEventArgs(returnResult))...
	return returnResult;
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing in this change runs before the
      mint or takes part in any authentication decision; it is log text past the
      mint.
- [x] No secrets logged; secrets are redacted on config export. The presented name
      is the identical value the line already printed as `{Username}`, so no new
      value class enters the trail.
- [x] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline.
- [x] Review record, below.
- [x] Log inputs from the IdP are sanitized inline at the log call. Both foreign
      values carry `ReplaceLineEndings` spelled out in the `LogInformation`
      argument list on both arms; nothing is passed down from a helper, because
      CodeQL's taint tracking does not follow it across an assignment. That is why
      the comparison sanitizes a second time rather than handing its result on.

### Review record

Three refute-by-default lenses read the full files and their callers, then two were
re-run against the fixed state. **No second reader is available on this board; that
re-run is the same lenses against a later state, not a reading by a second person.**

| Lens         | Round 1                            | Round 2 (fixed state)                      |
| ------------ | ---------------------------------- | ------------------------------------------ |
| correctness  | NEEDS_IMPROVEMENT, 8 raised        | NEEDS_IMPROVEMENT, 3 carried               |
| bypass       | PASS, 7 raised, none exploitable   | not re-run (PASS in round 1)               |
| availability | NEEDS_IMPROVEMENT, 5 raised        | PASS, all three carried items closed       |

Counts as raised: **CONFIRMED 4 / PLAUSIBLE 16.** A finding is counted CONFIRMED
only where a reproduction was produced - the raw-versus-rendered comparison and the
same-line concatenation were both driven through the compiled method and their
output bytes quoted; the orphaned comment block and the overclaimed scope were
reproduced by reading the tree at named lines.

Dispositions, every finding of either kind:

- **FIXED - the drift decision was taken on RAW values while the line rendered
  SANITIZED ones.** A provider presenting `alice\r\n` against the account `alice`
  compared unequal, took the drift arm, and then printed two identical names: a line
  asserting a difference its own evidence denies, producible at will. The decision
  is now taken on the values as the line will print them, with a row that reddens if
  it is taken back.
- **FIXED - the new helper was wedged between the T-D1 mass-lockout comment block
  and `EnforceAccountExpiryAsync`, the method that comment documents.** Two lenses
  found it independently; nothing in the compiler or StyleCop sees it. The helper
  moved to the end of the class.
- **FIXED - the stated scope of the clause was too narrow,** in the doc comment, the
  changelog and - after the second round, which the first answer missed - at the
  call site. All three now name the provisioning allowlist and the declined rename
  beside the sync-off arm.
- **FIXED - the fallback guarded null but not empty,** so a blank host-supplied name
  printed a nameless account. It treats empty as absent now.
- **FIXED - the fallback's stated reason was wrong.** It said a host that returned
  no user raised no event either; the host publishes and then returns the same
  instance, so a missing name means the correlation cannot be made from this end.
  The behaviour is unchanged and the reason is now true.
- **FIXED - the test could not distinguish the derivation it claims.** The account
  name and the host result's name were the same string, so a read off the account
  record would have passed. Three distinct names now, and the row fails unless the
  value comes off the host result.
- **FIXED - the `isAdmin` parameter documentation claimed the opposite of what it
  carries.** It said "whether the session was granted administrator rights"; it is
  the provider's assertion.
- **DECLINED - `StringComparison.Ordinal` against a host that resolves usernames
  case-insensitively.** The rename whose absence this clause reports decides on the
  same basis - `CanonicalLinkService` compares the account name against the
  sanitized presented name with `Ordinal` - so folding case here would go quiet
  about a difference the rename path would act on. The reason sits at the
  comparison.
- **DECLINED, its own issue - `admin=` reports the provider's claim, not the rights
  the mint granted.** #1554. Pre-existing; this change makes the mismatch sharper by
  putting a host-derived name beside a provider-derived flag, which is the argument
  for the issue rather than for widening this one.
- **DECLINED, its own issue - a foreign name can concatenate a second plausible
  record onto one physical line.** #1555, with the real output bytes. Pre-existing,
  and this change moves attacker text out of the FIRST field, which makes a
  start-anchored parser sound where it was not; it does not end the shape, and the
  shape reaches every audit entry carrying a foreign value rather than this one.
- **DECLINED - two message templates for one event on a structured sink.** The
  changelog states it and warns the log-parser case explicitly. Splitting the event
  in two was the alternative and is worse for the same operator.
- **DISCLOSED, NOT FIXED - the fallback re-creates the old behaviour silently.** If
  the host returned a result with no usable name, the line names the presented name
  in the account position, the clause is suppressed, and no test would redden. The
  decompilation above shows the 10.11 host always sets `User`; the net10 target
  builds against 12.0.0-rc2, which that reading does not cover. The fallback stays
  because removing it puts a `NullReferenceException` after the session is minted -
  17 existing rows demonstrated exactly that shape during this work, and a user
  holding a session and an error page is the worse outcome.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The one deliberate duplication is the sanitizer, for the CodeQL reason
      stated at the comparison.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318). No
      new dependency and no constructor change: the value is read from a result the
      method already holds, so the ten construction sites of
      `LoginCompletionService` are untouched.
- [x] Architecture-conformance tests pass, and this change establishes no new
      structural property.
- [x] Docs impact considered. `CHANGELOG.md` carries the entry including the
      log-parser warning, and `docs/THREAT-MODEL-TRUSTED-HEADER.md` now says which
      line its pinned quotation is and is not about. The wiki names no audit-line
      format, so nothing there goes stale.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks, 0
      warnings, on `SSO-Auth.Tests.csproj`.
- [x] `dotnet test` is green. `net9.0` 3784 passed / 0 failed / 4 skipped;
      `net10.0` 3785 passed / 0 failed / 4 skipped.
- [x] Prettier is clean for the two `.md` files this change touches.

Guards proven by deleting them, each reddening a distinct row:

| Deletion                                        | What goes red                                                                                                     |
| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| the helper returns `identity.Username`          | `CompleteAsync_AResolvedAccountNamedDifferently_IsNamedByTheAccount_AndThePresentedNameBeside`                      |
| the clause is emitted unconditionally           | `CompleteAsync_AResolvedAccountNamedTheSame_WritesTheLineUnchanged` and `LoginSucceeded_APresentedNameEqualToTheAccountName_AddsNothingToTheLine` |
| the comparison goes back to the raw values      | `LoginSucceeded_APresentedNameDifferingOnlyInStrippedCharacters_AddsNothingToTheLine`                               |
| the sanitizer is dropped from the presented name | `LoginSucceeded_StripsLineEndings_FromTheProviderPresentedName`                                                    |

## Notes

Out of scope, each carried as its own issue: #1554 (the `admin=` field's
provenance) and #1555 (same-line concatenation in every audit entry carrying a
foreign value).

`ReplaceLineEndings` strips the line-ending characters and not every invisible one -
`U+000B`, a trailing space or `U+200B` still take the drift arm. That is correct
rather than a gap: there the printed value equals the raw value, so the line is
truthful. The line-ending case was special precisely because this code erased the
difference before printing it.
