### PR TITLE
Stop a foreign value forging a second record inside an audit line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -814,26 +814,42 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 ### Security
 
 - **An identity-provider-supplied value can no longer forge a second audit
-  record inside one line (#1555).** Every foreign value in the SSO audit trail
-  was already stripped of line endings, so none of them could SPLIT an entry -
-  and nothing bounded a value inside the sentence it landed in, so a presented
-  username could close the sentence and write a whole second, plausible record
-  on the same physical line. An unanchored search of the trail, or a SIEM rule
-  matching the substring, then reports a login that never happened, under any
-  name the attacker chooses; the value is attacker-supplied wherever the
-  identity provider lets a person edit their own `preferred_username`, which is
-  most of them. Every foreign value now also has the opening square bracket
-  removed at the logging call, which is enough because the `[SSO Audit] ` prefix
-  a trail is filtered on can begin no other way. The repair is on the emitter
-  rather than on the login line, so it covers every entry carrying a foreign
-  value.
+  record inside an audit line (#1555).** Every foreign value the SSO audit
+  trail prints was already stripped of line endings, so none of them could
+  SPLIT an entry - and nothing bounded a value inside the sentence it landed
+  in, so a presented username could close the sentence and write a whole
+  second, plausible record on the same physical line. An unanchored search of
+  the log, or a SIEM rule matching the substring, then reports a login that
+  never happened, under any name the attacker chooses; the value is
+  attacker-supplied wherever the identity provider lets a person edit their own
+  `preferred_username`, which is most of them. Every foreign value the emitter
+  prints now also has its opening square bracket replaced by a round one at the
+  logging call, which is enough because the `[SSO Audit] ` prefix a trail is
+  filtered on can begin no other way. The repair is on the emitter rather than
+  on the login line, so it covers every audit entry that carries a foreign
+  value, and a conformance rule fails the build if a future entry arrives
+  without it.
+
+  **What this does NOT cover, stated plainly.** The property is the audit
+  emitter's, not the log file's. Ordinary plugin log lines elsewhere - the
+  OpenID callback error, the username-sanitization notice, the rejected avatar
+  URL, the SAML denial - still carry identity-provider text under the
+  line-ending strip alone, so the marker is still plantable through them and an
+  unanchored search over the whole log is still not sound. That is tracked as
+  #1557 and is not fixed here. Anchoring a search at the start of a line is,
+  and was already made sound for the first field by #1551.
 
   **If you parse this trail, read this.** A name legitimately containing an
-  opening square bracket now prints without it, exactly as a name containing a
-  line ending already printed without that. Structured sinks are unchanged in
-  shape - the fields were separate template parameters before and still are -
-  and the value they receive is the stripped one, the same value the rendered
-  line shows.
+  opening square bracket now prints a round one instead, as a name containing a
+  line ending already printed without it. The substitution is deliberately not
+  a deletion: deleting would make two different names print alike, and the
+  login line's presented-name clause - which fires only when the two names
+  differ - would then go silent for a difference the provider chose. Structured
+  sinks are unchanged in shape: the fields were separate template parameters
+  before and still are, and the value they receive is the substituted one, the
+  same value the rendered line shows. Filesystem paths this server composed for
+  itself are not foreign values and are printed exactly, because the
+  unreadable-configuration lines exist to name a file an operator has to find.
 
 - **An account the plugin creates is now stored with the password and the login
   routing it is given (#1440).** Both were written onto the account object the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -813,6 +813,28 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **An identity-provider-supplied value can no longer forge a second audit
+  record inside one line (#1555).** Every foreign value in the SSO audit trail
+  was already stripped of line endings, so none of them could SPLIT an entry -
+  and nothing bounded a value inside the sentence it landed in, so a presented
+  username could close the sentence and write a whole second, plausible record
+  on the same physical line. An unanchored search of the trail, or a SIEM rule
+  matching the substring, then reports a login that never happened, under any
+  name the attacker chooses; the value is attacker-supplied wherever the
+  identity provider lets a person edit their own `preferred_username`, which is
+  most of them. Every foreign value now also has the opening square bracket
+  removed at the logging call, which is enough because the `[SSO Audit] ` prefix
+  a trail is filtered on can begin no other way. The repair is on the emitter
+  rather than on the login line, so it covers every entry carrying a foreign
+  value.
+
+  **If you parse this trail, read this.** A name legitimately containing an
+  opening square bracket now prints without it, exactly as a name containing a
+  line ending already printed without that. Structured sinks are unchanged in
+  shape - the fields were separate template parameters before and still are -
+  and the value they receive is the stripped one, the same value the rendered
+  line shows.
+
 - **An account the plugin creates is now stored with the password and the login
   routing it is given (#1440).** Both were written onto the account object the
   server handed back at creation and neither reached the database: the session

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rule for the audit emitter's two inline sanitizers (#1555): every foreign value the audit
+/// trail prints carries BOTH of them, spelled out at the logging call, and the handful of values that
+/// deliberately carry only one are named here rather than being noticed as an absence.
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    // The values a line prints EXACTLY on purpose, because the plugin composed them for itself and the exact
+    // text is the actionable content of the entry. The unreadable-configuration lines tell an operator which
+    // file to move out of the way, and the declarative-write lines tell them which mounted document to edit;
+    // a data directory whose name carries a bracket would otherwise be named as a path that does not exist,
+    // in the one line written for a total lockout. No untrusted party can write any of them, so the bracket
+    // substitution buys nothing here and costs the whole point of the line.
+    private static readonly string[] AuditValuesPrintedExactly =
+    {
+        "configurationFilePath",
+        "preservedCopyPath",
+        "markerPath",
+        "source",
+    };
+
+    private const string LineEndingSanitizer = "ReplaceLineEndings(string.Empty)";
+    private const string RecordMarkerSanitizer = "Replace('[', '(')";
+
+    [Fact]
+    public void EveryForeignValueTheAuditTrailPrints_CarriesBothInlineSanitizers()
+    {
+        // The property this locks in is #1555's, and the reason it is a conformance rule rather than a row
+        // per emitter is the count: the trail has ~30 entries and around 68 sanitized arguments, of which a
+        // test driving a forging payload can realistically cover two or three. Everything else could lose
+        // the substitution - or arrive without it, in an entry added next month - with the whole suite
+        // green, which is precisely the state the issue found the file in for the line-ending strip's
+        // younger sibling.
+        //
+        // It reads the SOURCE rather than reflecting over the assembly on purpose. The rule is about the
+        // expression being written inline at the logging call, because the sanitizer that CodeQL's
+        // cs/log-forging taint tracking can see is the one in the argument list; a compiled method body
+        // cannot answer that question, and a helper doing the same work would satisfy reflection while
+        // breaking the property the repo keeps this shape for.
+        var path = Path.Combine(RepoTree.Root, "SSO-Auth", "Api", "Audit", "SsoAudit.cs");
+        var offenders = new List<string>();
+
+        var lineNumber = 0;
+        foreach (var line in File.ReadLines(path))
+        {
+            lineNumber++;
+            if (!line.Contains(LineEndingSanitizer, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var exempt = AuditValuesPrintedExactly.Any(value =>
+                line.Contains(value + "?." + LineEndingSanitizer, StringComparison.Ordinal)
+                || line.Contains(value + "." + LineEndingSanitizer, StringComparison.Ordinal));
+
+            var substituted = line.Contains(LineEndingSanitizer + "." + RecordMarkerSanitizer, StringComparison.Ordinal);
+
+            if (exempt == substituted)
+            {
+                offenders.Add(
+                    "SsoAudit.cs:" + lineNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    + (exempt
+                        ? " prints a value this rule names as printed exactly, and substitutes its bracket anyway"
+                        : " sanitizes a foreign value's line endings without substituting its record-marker bracket")
+                    + ": " + line.Trim());
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every foreign value SsoAudit prints carries the line-ending strip AND the record-marker "
+            + "substitution, inline at the logging call (#1555); the values printed exactly are named in "
+            + "AuditValuesPrintedExactly and carry only the first. These lines break that: "
+            + string.Join(" | ", offenders));
+    }
+
+    [Fact]
+    public void TheAuditEmitter_IsTheOnlyPlaceThatWritesTheRecordMarker()
+    {
+        // The substitution is only worth anything while ONE file can write the marker: a second writer with
+        // a foreign value in its template would reopen the hole from a direction this rule cannot see. The
+        // marker is plantable today through ordinary plugin log lines that are not audit entries at all -
+        // that is #1557 and is deliberately not this rule's subject - but a second EMITTER of the marker
+        // itself is, because it would be claiming to be the audit trail.
+        var sources = Directory
+            .EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(file => File.ReadAllText(file).Contains("\"[SSO Audit] ", StringComparison.Ordinal))
+            .Select(file => Path.GetRelativePath(RepoTree.Root, file).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(
+            new[] { "SSO-Auth/Api/Audit/SsoAudit.cs", "SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs" },
+            sources);
+    }
+}

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -13,8 +13,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// Tests for <see cref="SsoAudit"/> - the structured security audit-log entries (#928 U1). Every
 /// method is pinned on three properties: the level it fires at, the "[SSO Audit]" prefix plus its
-/// key fields, and the inline line-ending strip on EVERY caller-supplied string so an identity-
-/// provider- or admin-supplied value can never forge or split an entry. The sensitive-data posture
+/// key fields, and the two inline sanitizers on EVERY foreign caller-supplied string so an identity-
+/// provider- or admin-supplied value can neither SPLIT an entry (the line-ending strip) nor forge a
+/// second one inside the line it lands in (the bracket substitution, #1555). A filesystem path this
+/// server composed for itself is not a foreign value and deliberately carries only the first, because
+/// the exact text is the actionable content of the line it appears in. The sensitive-data posture
 /// is structural - the signatures accept no secret, token, NameID or SessionIndex - and the fixed-
 /// code discipline (reason codes are enum names/constants, never request-derived text) is asserted
 /// where a code parameter exists.
@@ -96,8 +99,8 @@ public class SsoAuditTests
         // expectation: the fixture's own name carries the audit prefix, the line-ending strip left it
         // whole, and an unanchored search over the trail then matched a record nothing emitted. The
         // line-ending property this row exists for is unchanged - the two halves of the name are joined
-        // and no newline reaches the message - and the bracket is gone with it.
-        Assert.Contains("presented the name 'aliSSO Audit] forged'", message, StringComparison.Ordinal);
+        // and no newline reaches the message - and the marker cannot open a second record beside it.
+        Assert.Contains("presented the name 'ali(SSO Audit] forged'", message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -455,7 +458,10 @@ public class SsoAuditTests
     {
         var logger = new CapturingLogger();
 
-        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "eve", isAdmin: false, presentedUsername: SecondRecordPayload);
+        // Both foreign values of this entry carry the payload, so the row reddens whichever of the two
+        // loses its substitution. The account name cannot carry one in practice - Jellyfin's own
+        // allowlist admits no bracket - which is exactly why the provider name is the second here.
+        SsoAudit.LoginSucceeded(logger, "OpenID", SecondRecordPayload, "eve", isAdmin: false, presentedUsername: SecondRecordPayload);
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.Equal(1, CountMarkers(message));
@@ -472,9 +478,11 @@ public class SsoAuditTests
         var logger = new CapturingLogger();
 
         // The shape reaches every entry carrying a foreign value, not the login line alone, which is why
-        // the repair sits on the emitter. A second entry with two foreign names holds that scope down: it
-        // fails if the escape is added at one call site and not at the others.
-        SsoAudit.AccountRenamed(logger, "OpenID", "corp", SecondRecordPayload, SecondRecordPayload);
+        // the repair sits on the emitter rather than on one entry. EVERY foreign argument of this entry
+        // carries the payload - the provider name as well as both account names - so the row reddens if
+        // the substitution is dropped from any one of the three. What it does NOT hold down is the other
+        // emitters, and that is what the conformance rule over this file is for.
+        SsoAudit.AccountRenamed(logger, "OpenID", SecondRecordPayload, SecondRecordPayload, SecondRecordPayload);
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.Equal(1, CountMarkers(message));

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -91,7 +91,13 @@ public class SsoAuditTests
         var message = Assert.Single(logger.Entries).Message;
         Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
         Assert.Contains("Login succeeded: alice.jellyfin", message, StringComparison.Ordinal);
-        Assert.Contains("presented the name 'ali[SSO Audit] forged'", message, StringComparison.Ordinal);
+
+        // THIS ROW ASSERTED THE FORGED MARKER SURVIVED UNTIL #1555, and that was the defect stated as an
+        // expectation: the fixture's own name carries the audit prefix, the line-ending strip left it
+        // whole, and an unanchored search over the trail then matched a record nothing emitted. The
+        // line-ending property this row exists for is unchanged - the two halves of the name are joined
+        // and no newline reaches the message - and the bracket is gone with it.
+        Assert.Contains("presented the name 'aliSSO Audit] forged'", message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -434,6 +440,56 @@ public class SsoAuditTests
 
         Assert.Equal(5, log.Entries.Count);
         Assert.All(log.Entries, e => Assert.StartsWith("[SSO Audit]", e.Message, StringComparison.Ordinal));
+    }
+
+    // The payload of #1555, verbatim: a presented name whose text closes the sentence it lands in and
+    // then opens a whole second, plausible record on the SAME physical line. Stripping line endings does
+    // not touch it - it forges no new line - so an unanchored search or a SIEM substring rule reports a
+    // login by "root" that never happened. The bracket escape is what makes the marker unforgeable, and
+    // these two rows redden the moment it is taken back off the emitter.
+    private const string SecondRecordPayload =
+        "x'. [SSO Audit] Login succeeded: root via OpenID provider 'corp' (admin=True). The provider presented the name 'root";
+
+    [Fact]
+    public void LoginSucceeded_APresentedNameForgingASecondRecord_LeavesOneAuditMarkerOnTheLine()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "eve", isAdmin: false, presentedUsername: SecondRecordPayload);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(1, CountMarkers(message));
+        Assert.StartsWith("[SSO Audit]", message, StringComparison.Ordinal);
+
+        // The forged record is what a reader is meant not to be able to find, so the assertion is on the
+        // text a search would look for rather than on the escape that prevents it.
+        Assert.DoesNotContain("[SSO Audit] Login succeeded: root", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AccountRenamed_AForeignNameForgingASecondRecord_LeavesOneAuditMarkerOnTheLine()
+    {
+        var logger = new CapturingLogger();
+
+        // The shape reaches every entry carrying a foreign value, not the login line alone, which is why
+        // the repair sits on the emitter. A second entry with two foreign names holds that scope down: it
+        // fails if the escape is added at one call site and not at the others.
+        SsoAudit.AccountRenamed(logger, "OpenID", "corp", SecondRecordPayload, SecondRecordPayload);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(1, CountMarkers(message));
+        Assert.DoesNotContain("[SSO Audit] Login succeeded: root", message, StringComparison.Ordinal);
+    }
+
+    private static int CountMarkers(string message)
+    {
+        var markers = 0;
+        for (var at = message.IndexOf("[SSO Audit] ", StringComparison.Ordinal); at >= 0; at = message.IndexOf("[SSO Audit] ", at + 1, StringComparison.Ordinal))
+        {
+            markers++;
+        }
+
+        return markers;
     }
 
     private sealed class LevelFilteredLogger : ILogger

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -12,19 +12,34 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Audit;
 /// successful logins, adoption of a pre-existing account, and provider configuration changes. Every
 /// entry shares the "[SSO Audit]" prefix so operators can filter the trail, and only non-sensitive
 /// fields are logged (never secrets or certificates). Identity-provider- and admin-supplied values
-/// are stripped of line endings AND of the opening square bracket, inline before logging, so they
-/// can neither split an entry nor forge a second one inside the line they land on. The two halves
-/// answer two different attacks and the second is #1555: stripping the line endings stops a foreign
-/// value from producing a second PHYSICAL line, and nothing stopped it from producing a second
-/// plausible RECORD on the same line, which an unanchored search or a SIEM substring rule reports
-/// as a login that never happened. One character carries that repair, because the prefix every
-/// entry is filtered on can only begin with an opening square bracket, so a value that holds none
-/// cannot reproduce that prefix wherever in the sentence it sits.
-/// IT IS A STRIP AND NOT AN ESCAPE, for the reason the first attempt failed on: a backslash written
-/// in front of the bracket leaves the marker intact as a SUBSTRING, so every unanchored search this
-/// is about still matches it. Removing the character is what the file already does to a line ending
-/// and it is what makes the property hold; the cost is that a name legitimately carrying an opening
-/// bracket is printed without it, which is the same trade the line-ending strip already takes.
+/// are stripped of line endings AND have their opening square bracket replaced by a round one,
+/// inline before logging, so they can neither split an entry nor forge a second one inside the line
+/// they land on. The two halves answer two different attacks and the second is #1555: stripping the
+/// line endings stops a foreign value from producing a second PHYSICAL line, and nothing stopped it
+/// from producing a second plausible RECORD on the same line, which an unanchored search or a SIEM
+/// substring rule reports as a login that never happened. One character carries that repair, because
+/// the prefix every entry is filtered on can only begin with an opening square bracket, so a value
+/// that holds none can reproduce that prefix nowhere in the sentence it sits in.
+/// NOT AN ESCAPE AND NOT A DELETION, and both were tried before this. A backslash written in front
+/// of the bracket leaves the marker whole as a SUBSTRING, so every unanchored search this is about
+/// still matches it. Deleting the character closes that, and it makes two DIFFERENT values print
+/// the same - which matters at one place in this file, the comparison in
+/// <see cref="LoginSucceeded"/>, where a presented name differing from the account name only in a
+/// bracket would then be silently reported as no difference at all, an audit disclosure an identity
+/// provider could switch off by choosing the character. Substituting keeps every value distinct
+/// from every other, so no comparison here can be made to go quiet; the cost is that a value
+/// legitimately carrying an opening bracket prints a round one instead.
+/// WHAT IS DELIBERATELY NOT SUBSTITUTED is a filesystem path this server composed for itself - the
+/// configuration file, the copy beside it, the marker, and the mounted declarative source. Those are
+/// host-owned and reachable by no untrusted party, and the EXACT text is the actionable content of
+/// the line: the unreadable-configuration lines tell an operator which file to move out of the way,
+/// and a data directory whose name carries a bracket would be named as a path that does not exist,
+/// in the one line written for a total lockout. They keep the line-ending strip and nothing more.
+/// WHAT THIS DOES NOT REACH IS EVERY OTHER LOG LINE THE PLUGIN WRITES. The property is this
+/// emitter's, not the log file's: ordinary plugin lines elsewhere carry identity-provider values
+/// under the line-ending strip alone, so the marker text is still plantable through them and an
+/// unanchored search over the whole file is still not sound. That is #1557, and no sentence here or
+/// in the changelog may be read as claiming otherwise.
 /// Each call is guarded by <see cref="ILogger.IsEnabled(LogLevel)"/> so the inline sanitizers are
 /// not evaluated when the level is disabled (net10 CA1873, #566); both stay spelled out at the
 /// logging call, never handed down from a helper, so CodeQL's log-forging taint tracking still
@@ -68,7 +83,15 @@ internal static class SsoAudit
         // account "alice" compares unequal raw and prints two identical names - a line asserting a difference
         // its own evidence denies, which an identity provider can produce at will. The sanitizer is still
         // spelled out inline at each logging call below rather than being passed down from here, because
-        // CodeQL's cs/log-forging taint tracking does not follow it across an assignment.
+        // CodeQL's cs/log-forging taint tracking does not follow them across an assignment.
+        //
+        // AND THIS IS WHY THE BRACKET IS SUBSTITUTED RATHER THAN DELETED (#1555). Comparing printed values
+        // means any two values the sanitizers render alike are reported as no difference at all. Deleting
+        // the bracket does exactly that to a presented name that differs from the account name only in one,
+        // and that pair is not contrived: the bracket is one of the characters the host allowlist drops when
+        // it provisions an account, which is the second of the three reasons this clause exists. A provider
+        // could then switch the disclosure off by choosing the character. Substituting keeps every value
+        // distinct from every other, so nothing an identity provider sends can make this comparison quiet.
         //
         // ORDINAL, DELIBERATELY, though the host resolves a username case-insensitively. The rename this
         // clause reports the absence of decides on the same basis - CanonicalLinkService compares the
@@ -76,25 +99,25 @@ internal static class SsoAudit
         // comparison here would stay silent about a difference the rename path would act on.
         if (presentedUsername is not null
             && !string.Equals(
-                presentedUsername.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-                username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+                presentedUsername.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 StringComparison.Ordinal))
         {
             logger.LogInformation(
                 "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}'.",
-                username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+                username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 protocol,
-                provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 isAdmin,
-                presentedUsername.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+                presentedUsername.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return;
         }
 
         logger.LogInformation(
             "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}).",
-            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             isAdmin);
     }
 
@@ -117,9 +140,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Provisioning rolled back for {Protocol} provider '{Provider}': the account '{Username}' was created and then deleted again because the login could not be completed. Nothing was left behind, and the failure that stopped it is logged separately. The user can sign in once that failure is fixed.",
-            protocol?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            protocol?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            username?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -139,8 +162,8 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] Provisioning could not be rolled back ({Reason}): the account '{Username}' was created for a login that then failed, and deleting it again did not work. It holds no SSO link and no usable password, and it will refuse that identity a fresh account under the same name - delete it manually.",
-            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            username?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -160,9 +183,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] New account provisioned pending approval: '{Username}' via {Protocol} provider '{Provider}' was created disabled (ProvisionNewUsersDisabled); no session issued. Enable it in the Jellyfin dashboard to approve.",
-            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>Records an SSO identity being linked to a pre-existing account (the opt-in adoption path).</summary>
@@ -179,9 +202,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO identity linked to existing account '{DisplayName}' via {Protocol} provider '{Provider}' (AllowExistingAccountLink).",
-            displayName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            displayName?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -189,7 +212,8 @@ internal static class SsoAudit
     /// the name an administrator sees in the Jellyfin dashboard and nothing else, so the trail has to say
     /// which name became which - without it, an account an operator is looking for has silently become a
     /// different row in the user list with no record of why. Both names are identity-provider-influenced,
-    /// so both are stripped of line endings inline at the call, like every other name this file logs.
+    /// so both carry the two inline sanitizers at the call, like every other foreign name this file logs:
+    /// the line-ending strip and the bracket substitution that keeps the record marker unforgeable (#1555).
     /// </summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
@@ -205,10 +229,10 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Linked account renamed from '{PreviousName}' to '{NewName}' to follow {Protocol} provider '{Provider}' (SyncUsernameFromProvider).",
-            previousName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            newName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            previousName?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            newName?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -230,7 +254,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by login-time deprovisioning: an SSO login via {Protocol} provider '{Provider}' was denied by the role allow-list and the account was disabled (DisableAccountOnRoleDenied). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -254,7 +278,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by account expiry: an SSO login via {Protocol} provider '{Provider}' carried an expiry instant at or before now, so the account was disabled and its tokens were revoked (AccountExpiryClaim). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -278,7 +302,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by account expiry: the background expiry sweep found a stored deadline at or before now for a {Protocol} provider '{Provider}' link with no intervening login, so the account was disabled and its tokens were revoked (AccountExpiryClaim). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -321,7 +345,7 @@ internal static class SsoAudit
         logger.LogInformation(
             "[SSO Audit] Provider configured: {Protocol} '{Provider}'.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>Records a provider being removed.</summary>
@@ -338,7 +362,7 @@ internal static class SsoAudit
         logger.LogInformation(
             "[SSO Audit] Provider removed: {Protocol} '{Provider}'.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -358,7 +382,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] A ConfigurationChanged subscriber failed after a completed configuration save ({Reason}). The save itself is stored and live; whatever that subscriber keeps in step with the configuration may not be.",
-            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -379,7 +403,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Configuration write proceeding without a rollback: the current configuration could not be serialized for one ({Reason}). If this write fails, the running server keeps the change while the file does not, until the next restart.",
-            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -399,7 +423,7 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] Configuration write failed and could not be rolled back ({Reason}): the running server is carrying a change that is not in the file. Restart the server to put it back on the stored configuration.",
-            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -421,7 +445,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Configuration save ignored for {Protocol} provider '{Provider}': it is managed by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -441,7 +465,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Configuration save ignored for provisioning profile '{Profile}': it is defined by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
-            profile?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            profile?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -465,10 +489,10 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] {Door} refused for {Protocol} provider '{Provider}': it is managed by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
-            door?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            door?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            source?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            source?.ReplaceLineEndings(string.Empty));
     }
 
     /// <summary>
@@ -490,9 +514,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] {Door} refused for provisioning profile '{Profile}': it is defined by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
-            door?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            profile?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            source?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            door?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            profile?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            source?.ReplaceLineEndings(string.Empty));
     }
 
     /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
@@ -507,7 +531,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID provider '{Provider}' does not advertise PKCE (S256) in its discovery document (code_challenge_methods_supported). PKCE is still sent, but a server that ignores it leaves cross-session authorization-code injection undetectable (RFC 9700 §2.1.1). Set RequirePkce to fail closed once the provider supports it.",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>Records an administrator importing a configuration document (#161).</summary>
@@ -546,9 +570,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Account-link backup restored by {Actor}: {TotalLinks} link(s) rebound to this instance's accounts, with no identity-provider response redeemed. Per provider: {PerProvider}.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             totalLinks,
-            perProvider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            perProvider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -577,9 +601,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Canonical link pre-provisioned by {Actor}: {Protocol} '{Provider}' -> Jellyfin user {UserId}, with no identity-provider response redeemed.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             jellyfinUserId);
     }
 
@@ -614,8 +638,8 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Every canonical link on {Protocol} '{Provider}' removed by {Actor}: {RemovedLinks} link(s) gone, {UnlinkedAccounts} account(s) left with no SSO link, {SignedOut} of them signed out. No Jellyfin account, permission or password was changed.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             removedLinks,
             unlinkedAccounts,
             signedOut);
@@ -641,8 +665,8 @@ internal static class SsoAudit
         => logger.LogError(
             "[SSO Audit] After emptying {Protocol} '{Provider}', these administrator account(s) have no way to sign in: {Administrators}. They were judged to have one when the run was checked, so something changed in between. Give one of them a usable password or re-link it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            administrators?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            administrators?.ReplaceLineEndings(string.Empty).Replace('[', '('));
 
     /// <summary>
     /// Records a per-provider bulk unlink being REFUSED (#1519), so a blocked mass-lockout leaves a trail
@@ -663,9 +687,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Bulk unlink REFUSED for {Actor} on {Protocol} '{Provider}' ({ReasonCode}). No link was removed.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -683,8 +707,8 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login ENABLED by {Actor}: break-glass admin '{BreakGlassAdmin}' keeps password login; {RepointedCount} account(s) repointed to SSO-only.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             repointedCount);
     }
 
@@ -701,7 +725,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login DISABLED by {Actor}: native password routing restored for {RestoredCount} account(s); no password hash was reset.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             restoredCount);
     }
 
@@ -722,7 +746,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login activation REFUSED for {Actor}: no surviving admin login path ({ReasonCode}). No change was made.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -739,8 +763,8 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Break-glass admin designated by {Actor}: '{BreakGlassAdmin}' is now the account SSO-only login never repoints.",
-            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>
@@ -761,7 +785,7 @@ internal static class SsoAudit
 
         logger.LogInformation(
             "[SSO Audit] SAML logout requested: a validated LogoutRequest for provider '{Provider}' revoked tokens for {UsersRevoked} user(s).",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             usersRevoked);
     }
 
@@ -784,7 +808,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SAML logout request REJECTED for provider '{Provider}' ({ReasonCode}). No session was terminated.",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -808,7 +832,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID back-channel logout REJECTED for provider '{Provider}' ({ReasonCode}). No session was terminated.",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -833,7 +857,7 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] OpenID back-channel logout could NOT be performed for provider '{Provider}' ({ReasonCode}). The identity provider ordered a termination and no session was terminated, so a signed-out session may still be running.",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -861,7 +885,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID provider '{Provider}': the configured role claim could not be read ({ReasonCode}), so this login was granted NO roles from it. Under a configured role allow-list that denies the login; check the role-claim path against what the provider actually emits.",
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reasonCode);
     }
 
@@ -884,7 +908,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. Each switches off a default-on protection on the login path (such as transport, issuer/audience, or endpoint binding); keep them only if the provider genuinely requires it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             string.Join(", ", options));
     }
 
@@ -914,14 +938,14 @@ internal static class SsoAudit
         {
             logger.LogError(
                 "[SSO Audit] {ConfigurationFile} could not be read, and NO copy of it was kept. Default settings are being served, the server is about to overwrite the file with them, and every SSO sign-in is refused with 503 until a configuration holding at least one provider is saved or imported, or the stored file is restored and the server started again - a save that carries no provider does not end it, and a server serving defaults usually has none to save. This plugin does not touch Jellyfin password sign-in - but an account it provisioned has none, and on a server that was in SSO-only mode the accounts it repointed have none either, so the only certain way in is the break-glass administrator. If nobody can sign in at all, move the unreadable configuration file out of the way and delete the marker file beside it - the one whose name is the configuration file plus .unreadable, with no timestamp on the end - then restart: SSO then answers as it did before this check existed. Keep any timestamped copies lying beside the configuration file rather than deleting them: they are from an earlier fault, or from an earlier boot of this one whose record was lost, and one of them may hold more than this server now has.",
-                configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+                configurationFilePath?.ReplaceLineEndings(string.Empty));
             return;
         }
 
         logger.LogError(
             "[SSO Audit] {ConfigurationFile} could not be read. It was copied to {PreservedCopy} before the server overwrites it. Default settings are being served - no provider, no account link, no stored secret - and every SSO sign-in is refused with 503 until a configuration holding at least one provider is saved or imported, or the stored file is restored and the server started again. A save that carries no provider does not end it, and a server serving defaults usually has none to save. This plugin does not touch Jellyfin password sign-in - but an account it provisioned has none, and on a server that was in SSO-only mode the accounts it repointed have none either, so the only certain way in is the break-glass administrator. If nobody can sign in at all, move the unreadable configuration file out of the way and delete the marker file beside it - the one whose name is the configuration file plus .unreadable, with no timestamp on the end - then restart: SSO then answers as it did before this check existed. Do not delete it, nor any other timestamped copy beside the configuration file: the one named above is what was kept this time, and any others are from earlier boots or earlier faults and may hold more than it does.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            configurationFilePath?.ReplaceLineEndings(string.Empty),
+            preservedCopyPath?.ReplaceLineEndings(string.Empty));
     }
 
     /// <summary>
@@ -942,7 +966,7 @@ internal static class SsoAudit
             // know; two Error lines contradicting each other during an outage is worse than one saying
             // less.
             "[SSO Audit] The unreadable configuration could not be copied to {PreservedCopy}. The line after this one says what copy, if any, remains.",
-            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            preservedCopyPath?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records that the readability check could not read the stored configuration at all - the file was
@@ -957,7 +981,7 @@ internal static class SsoAudit
         => logger.LogWarning(
             error,
             "[SSO Audit] {ConfigurationFile} could not be opened for the startup readability check, so it was not judged. If the server can read it, nothing is wrong; if it cannot, it will serve default settings without this warning saying so.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            configurationFilePath?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records that a previous start found the configuration unreadable and nobody has supplied one since
@@ -970,8 +994,8 @@ internal static class SsoAudit
     internal static void UnreadableConfigurationStillUnrepaired(ILogger logger, string configurationFilePath, string? preservedCopyPath)
         => logger.LogError(
             "[SSO Audit] {ConfigurationFile} was unreadable at an earlier start and no configuration has been supplied since, so this server is still serving default settings and still refusing every SSO sign-in. The copy kept for this incident: {PreservedCopy}. Save or import a configuration holding at least one provider to clear this; if no administrator can sign in at all, move the unreadable configuration file out of the way, delete the marker file beside it - the configuration file plus .unreadable, with no timestamp - and restart. Do not delete the copy named above, nor any other timestamped copy beside the configuration file: the one named is this incident's, and an earlier one may hold more than it does.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
-            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal) ?? "none recorded, or the recorded one is no longer beside the configuration");
+            configurationFilePath?.ReplaceLineEndings(string.Empty),
+            preservedCopyPath?.ReplaceLineEndings(string.Empty) ?? "none recorded, or the recorded one is no longer beside the configuration");
 
     /// <summary>
     /// Records that the configuration came back on disk while the marker still stood (#1543) - somebody
@@ -983,7 +1007,7 @@ internal static class SsoAudit
     internal static void UnreadableConfigurationRepairedOnDisk(ILogger logger, string configurationFilePath)
         => logger.LogWarning(
             "[SSO Audit] {ConfigurationFile} holds a configuration again, so this server stops serving defaults and accepts SSO sign-in. The preserved copy of the unreadable file is left where it is.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            configurationFilePath?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records that the marker keeping the state across a restart could not be written (#1543). It costs
@@ -997,7 +1021,7 @@ internal static class SsoAudit
         => logger.LogError(
             error,
             "[SSO Audit] The marker {MarkerPath} could not be written. This server is serving default settings and refusing SSO now, but a restart will forget that and answer as though no provider were configured.",
-            markerPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            markerPath?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records that the marker could not be removed after an administrator supplied a configuration
@@ -1010,7 +1034,7 @@ internal static class SsoAudit
         => logger.LogError(
             error,
             "[SSO Audit] The marker {MarkerPath} could not be removed. SSO is accepted again now, but a restart would refuse it once more; delete that file by hand.",
-            markerPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
+            markerPath?.ReplaceLineEndings(string.Empty));
 
     /// <summary>
     /// Records a configuration arriving while defaults were being served, which is what ends the refusal

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -12,10 +12,23 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Audit;
 /// successful logins, adoption of a pre-existing account, and provider configuration changes. Every
 /// entry shares the "[SSO Audit]" prefix so operators can filter the trail, and only non-sensitive
 /// fields are logged (never secrets or certificates). Identity-provider- and admin-supplied values
-/// are stripped of line endings inline before logging so they cannot forge or split an entry.
-/// Each call is guarded by <see cref="ILogger.IsEnabled(LogLevel)"/> so the inline line-ending
-/// sanitizer is not evaluated when the level is disabled (net10 CA1873, #566); the sanitizer stays
-/// at the logging call so CodeQL's log-forging taint tracking still sees it inline.
+/// are stripped of line endings AND of the opening square bracket, inline before logging, so they
+/// can neither split an entry nor forge a second one inside the line they land on. The two halves
+/// answer two different attacks and the second is #1555: stripping the line endings stops a foreign
+/// value from producing a second PHYSICAL line, and nothing stopped it from producing a second
+/// plausible RECORD on the same line, which an unanchored search or a SIEM substring rule reports
+/// as a login that never happened. One character carries that repair, because the prefix every
+/// entry is filtered on can only begin with an opening square bracket, so a value that holds none
+/// cannot reproduce that prefix wherever in the sentence it sits.
+/// IT IS A STRIP AND NOT AN ESCAPE, for the reason the first attempt failed on: a backslash written
+/// in front of the bracket leaves the marker intact as a SUBSTRING, so every unanchored search this
+/// is about still matches it. Removing the character is what the file already does to a line ending
+/// and it is what makes the property hold; the cost is that a name legitimately carrying an opening
+/// bracket is printed without it, which is the same trade the line-ending strip already takes.
+/// Each call is guarded by <see cref="ILogger.IsEnabled(LogLevel)"/> so the inline sanitizers are
+/// not evaluated when the level is disabled (net10 CA1873, #566); both stay spelled out at the
+/// logging call, never handed down from a helper, so CodeQL's log-forging taint tracking still
+/// sees them inline.
 /// </summary>
 internal static class SsoAudit
 {
@@ -63,25 +76,25 @@ internal static class SsoAudit
         // comparison here would stay silent about a difference the rename path would act on.
         if (presentedUsername is not null
             && !string.Equals(
-                presentedUsername.ReplaceLineEndings(string.Empty),
-                username?.ReplaceLineEndings(string.Empty),
+                presentedUsername.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+                username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
                 StringComparison.Ordinal))
         {
             logger.LogInformation(
                 "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}'.",
-                username?.ReplaceLineEndings(string.Empty),
+                username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
                 protocol,
-                provider?.ReplaceLineEndings(string.Empty),
+                provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
                 isAdmin,
-                presentedUsername.ReplaceLineEndings(string.Empty));
+                presentedUsername.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
             return;
         }
 
         logger.LogInformation(
             "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}).",
-            username?.ReplaceLineEndings(string.Empty),
+            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             isAdmin);
     }
 
@@ -104,9 +117,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Provisioning rolled back for {Protocol} provider '{Provider}': the account '{Username}' was created and then deleted again because the login could not be completed. Nothing was left behind, and the failure that stopped it is logged separately. The user can sign in once that failure is fixed.",
-            protocol?.ReplaceLineEndings(string.Empty),
-            provider?.ReplaceLineEndings(string.Empty),
-            username?.ReplaceLineEndings(string.Empty));
+            protocol?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -126,8 +139,8 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] Provisioning could not be rolled back ({Reason}): the account '{Username}' was created for a login that then failed, and deleting it again did not work. It holds no SSO link and no usable password, and it will refuse that identity a fresh account under the same name - delete it manually.",
-            error?.Message?.ReplaceLineEndings(string.Empty),
-            username?.ReplaceLineEndings(string.Empty));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -147,9 +160,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] New account provisioned pending approval: '{Username}' via {Protocol} provider '{Provider}' was created disabled (ProvisionNewUsersDisabled); no session issued. Enable it in the Jellyfin dashboard to approve.",
-            username?.ReplaceLineEndings(string.Empty),
+            username?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>Records an SSO identity being linked to a pre-existing account (the opt-in adoption path).</summary>
@@ -166,9 +179,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO identity linked to existing account '{DisplayName}' via {Protocol} provider '{Provider}' (AllowExistingAccountLink).",
-            displayName?.ReplaceLineEndings(string.Empty),
+            displayName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -192,10 +205,10 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Linked account renamed from '{PreviousName}' to '{NewName}' to follow {Protocol} provider '{Provider}' (SyncUsernameFromProvider).",
-            previousName?.ReplaceLineEndings(string.Empty),
-            newName?.ReplaceLineEndings(string.Empty),
+            previousName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            newName?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -217,7 +230,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by login-time deprovisioning: an SSO login via {Protocol} provider '{Provider}' was denied by the role allow-list and the account was disabled (DisableAccountOnRoleDenied). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -241,7 +254,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by account expiry: an SSO login via {Protocol} provider '{Provider}' carried an expiry instant at or before now, so the account was disabled and its tokens were revoked (AccountExpiryClaim). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -265,7 +278,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Account disabled by account expiry: the background expiry sweep found a stored deadline at or before now for a {Protocol} provider '{Provider}' link with no intervening login, so the account was disabled and its tokens were revoked (AccountExpiryClaim). Administrators are never disabled by this path.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -308,7 +321,7 @@ internal static class SsoAudit
         logger.LogInformation(
             "[SSO Audit] Provider configured: {Protocol} '{Provider}'.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>Records a provider being removed.</summary>
@@ -325,7 +338,7 @@ internal static class SsoAudit
         logger.LogInformation(
             "[SSO Audit] Provider removed: {Protocol} '{Provider}'.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -345,7 +358,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] A ConfigurationChanged subscriber failed after a completed configuration save ({Reason}). The save itself is stored and live; whatever that subscriber keeps in step with the configuration may not be.",
-            error?.Message?.ReplaceLineEndings(string.Empty));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -366,7 +379,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Configuration write proceeding without a rollback: the current configuration could not be serialized for one ({Reason}). If this write fails, the running server keeps the change while the file does not, until the next restart.",
-            error?.Message?.ReplaceLineEndings(string.Empty));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -386,7 +399,7 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] Configuration write failed and could not be rolled back ({Reason}): the running server is carrying a change that is not in the file. Restart the server to put it back on the stored configuration.",
-            error?.Message?.ReplaceLineEndings(string.Empty));
+            error?.Message?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -408,7 +421,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Configuration save ignored for {Protocol} provider '{Provider}': it is managed by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -428,7 +441,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Configuration save ignored for provisioning profile '{Profile}': it is defined by a declarative source, so the stored value was kept. Edit the source and restart the server to change it.",
-            profile?.ReplaceLineEndings(string.Empty));
+            profile?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -452,10 +465,10 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] {Door} refused for {Protocol} provider '{Provider}': it is managed by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
-            door?.ReplaceLineEndings(string.Empty),
+            door?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
-            source?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            source?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -477,9 +490,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] {Door} refused for provisioning profile '{Profile}': it is defined by the declarative source {Source}, so nothing was written. Edit that source and restart the server to change it.",
-            door?.ReplaceLineEndings(string.Empty),
-            profile?.ReplaceLineEndings(string.Empty),
-            source?.ReplaceLineEndings(string.Empty));
+            door?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            profile?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            source?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
@@ -494,7 +507,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID provider '{Provider}' does not advertise PKCE (S256) in its discovery document (code_challenge_methods_supported). PKCE is still sent, but a server that ignores it leaves cross-session authorization-code injection undetectable (RFC 9700 §2.1.1). Set RequirePkce to fail closed once the provider supports it.",
-            provider?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>Records an administrator importing a configuration document (#161).</summary>
@@ -533,9 +546,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Account-link backup restored by {Actor}: {TotalLinks} link(s) rebound to this instance's accounts, with no identity-provider response redeemed. Per provider: {PerProvider}.",
-            actor?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             totalLinks,
-            perProvider?.ReplaceLineEndings(string.Empty));
+            perProvider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -564,9 +577,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Canonical link pre-provisioned by {Actor}: {Protocol} '{Provider}' -> Jellyfin user {UserId}, with no identity-provider response redeemed.",
-            actor?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             jellyfinUserId);
     }
 
@@ -601,8 +614,8 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] Every canonical link on {Protocol} '{Provider}' removed by {Actor}: {RemovedLinks} link(s) gone, {UnlinkedAccounts} account(s) left with no SSO link, {SignedOut} of them signed out. No Jellyfin account, permission or password was changed.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
-            actor?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             removedLinks,
             unlinkedAccounts,
             signedOut);
@@ -628,8 +641,8 @@ internal static class SsoAudit
         => logger.LogError(
             "[SSO Audit] After emptying {Protocol} '{Provider}', these administrator account(s) have no way to sign in: {Administrators}. They were judged to have one when the run was checked, so something changed in between. Give one of them a usable password or re-link it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
-            administrators?.ReplaceLineEndings(string.Empty));
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            administrators?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records a per-provider bulk unlink being REFUSED (#1519), so a blocked mass-lockout leaves a trail
@@ -650,9 +663,9 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Bulk unlink REFUSED for {Actor} on {Protocol} '{Provider}' ({ReasonCode}). No link was removed.",
-            actor?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -670,8 +683,8 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login ENABLED by {Actor}: break-glass admin '{BreakGlassAdmin}' keeps password login; {RepointedCount} account(s) repointed to SSO-only.",
-            actor?.ReplaceLineEndings(string.Empty),
-            breakGlassAdmin?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             repointedCount);
     }
 
@@ -688,7 +701,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login DISABLED by {Actor}: native password routing restored for {RestoredCount} account(s); no password hash was reset.",
-            actor?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             restoredCount);
     }
 
@@ -709,7 +722,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SSO-only login activation REFUSED for {Actor}: no surviving admin login path ({ReasonCode}). No change was made.",
-            actor?.ReplaceLineEndings(string.Empty),
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -726,8 +739,8 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] Break-glass admin designated by {Actor}: '{BreakGlassAdmin}' is now the account SSO-only login never repoints.",
-            actor?.ReplaceLineEndings(string.Empty),
-            breakGlassAdmin?.ReplaceLineEndings(string.Empty));
+            actor?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            breakGlassAdmin?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -748,7 +761,7 @@ internal static class SsoAudit
 
         logger.LogInformation(
             "[SSO Audit] SAML logout requested: a validated LogoutRequest for provider '{Provider}' revoked tokens for {UsersRevoked} user(s).",
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             usersRevoked);
     }
 
@@ -771,7 +784,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] SAML logout request REJECTED for provider '{Provider}' ({ReasonCode}). No session was terminated.",
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -795,7 +808,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID back-channel logout REJECTED for provider '{Provider}' ({ReasonCode}). No session was terminated.",
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -820,7 +833,7 @@ internal static class SsoAudit
 
         logger.LogError(
             "[SSO Audit] OpenID back-channel logout could NOT be performed for provider '{Provider}' ({ReasonCode}). The identity provider ordered a termination and no session was terminated, so a signed-out session may still be running.",
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -848,7 +861,7 @@ internal static class SsoAudit
 
         logger.LogWarning(
             "[SSO Audit] OpenID provider '{Provider}': the configured role claim could not be read ({ReasonCode}), so this login was granted NO roles from it. Under a configured role allow-list that denies the login; check the role-claim path against what the provider actually emits.",
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             reasonCode);
     }
 
@@ -871,7 +884,7 @@ internal static class SsoAudit
         logger.LogWarning(
             "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. Each switches off a default-on protection on the login path (such as transport, issuer/audience, or endpoint binding); keep them only if the provider genuinely requires it.",
             protocol,
-            provider?.ReplaceLineEndings(string.Empty),
+            provider?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
             string.Join(", ", options));
     }
 
@@ -901,14 +914,14 @@ internal static class SsoAudit
         {
             logger.LogError(
                 "[SSO Audit] {ConfigurationFile} could not be read, and NO copy of it was kept. Default settings are being served, the server is about to overwrite the file with them, and every SSO sign-in is refused with 503 until a configuration holding at least one provider is saved or imported, or the stored file is restored and the server started again - a save that carries no provider does not end it, and a server serving defaults usually has none to save. This plugin does not touch Jellyfin password sign-in - but an account it provisioned has none, and on a server that was in SSO-only mode the accounts it repointed have none either, so the only certain way in is the break-glass administrator. If nobody can sign in at all, move the unreadable configuration file out of the way and delete the marker file beside it - the one whose name is the configuration file plus .unreadable, with no timestamp on the end - then restart: SSO then answers as it did before this check existed. Keep any timestamped copies lying beside the configuration file rather than deleting them: they are from an earlier fault, or from an earlier boot of this one whose record was lost, and one of them may hold more than this server now has.",
-                configurationFilePath?.ReplaceLineEndings(string.Empty));
+                configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
             return;
         }
 
         logger.LogError(
             "[SSO Audit] {ConfigurationFile} could not be read. It was copied to {PreservedCopy} before the server overwrites it. Default settings are being served - no provider, no account link, no stored secret - and every SSO sign-in is refused with 503 until a configuration holding at least one provider is saved or imported, or the stored file is restored and the server started again. A save that carries no provider does not end it, and a server serving defaults usually has none to save. This plugin does not touch Jellyfin password sign-in - but an account it provisioned has none, and on a server that was in SSO-only mode the accounts it repointed have none either, so the only certain way in is the break-glass administrator. If nobody can sign in at all, move the unreadable configuration file out of the way and delete the marker file beside it - the one whose name is the configuration file plus .unreadable, with no timestamp on the end - then restart: SSO then answers as it did before this check existed. Do not delete it, nor any other timestamped copy beside the configuration file: the one named above is what was kept this time, and any others are from earlier boots or earlier faults and may hold more than it does.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty),
-            preservedCopyPath?.ReplaceLineEndings(string.Empty));
+            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -929,7 +942,7 @@ internal static class SsoAudit
             // know; two Error lines contradicting each other during an outage is worse than one saying
             // less.
             "[SSO Audit] The unreadable configuration could not be copied to {PreservedCopy}. The line after this one says what copy, if any, remains.",
-            preservedCopyPath?.ReplaceLineEndings(string.Empty));
+            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records that the readability check could not read the stored configuration at all - the file was
@@ -944,7 +957,7 @@ internal static class SsoAudit
         => logger.LogWarning(
             error,
             "[SSO Audit] {ConfigurationFile} could not be opened for the startup readability check, so it was not judged. If the server can read it, nothing is wrong; if it cannot, it will serve default settings without this warning saying so.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty));
+            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records that a previous start found the configuration unreadable and nobody has supplied one since
@@ -957,8 +970,8 @@ internal static class SsoAudit
     internal static void UnreadableConfigurationStillUnrepaired(ILogger logger, string configurationFilePath, string? preservedCopyPath)
         => logger.LogError(
             "[SSO Audit] {ConfigurationFile} was unreadable at an earlier start and no configuration has been supplied since, so this server is still serving default settings and still refusing every SSO sign-in. The copy kept for this incident: {PreservedCopy}. Save or import a configuration holding at least one provider to clear this; if no administrator can sign in at all, move the unreadable configuration file out of the way, delete the marker file beside it - the configuration file plus .unreadable, with no timestamp - and restart. Do not delete the copy named above, nor any other timestamped copy beside the configuration file: the one named is this incident's, and an earlier one may hold more than it does.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty),
-            preservedCopyPath?.ReplaceLineEndings(string.Empty) ?? "none recorded, or the recorded one is no longer beside the configuration");
+            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal),
+            preservedCopyPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal) ?? "none recorded, or the recorded one is no longer beside the configuration");
 
     /// <summary>
     /// Records that the configuration came back on disk while the marker still stood (#1543) - somebody
@@ -970,7 +983,7 @@ internal static class SsoAudit
     internal static void UnreadableConfigurationRepairedOnDisk(ILogger logger, string configurationFilePath)
         => logger.LogWarning(
             "[SSO Audit] {ConfigurationFile} holds a configuration again, so this server stops serving defaults and accepts SSO sign-in. The preserved copy of the unreadable file is left where it is.",
-            configurationFilePath?.ReplaceLineEndings(string.Empty));
+            configurationFilePath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records that the marker keeping the state across a restart could not be written (#1543). It costs
@@ -984,7 +997,7 @@ internal static class SsoAudit
         => logger.LogError(
             error,
             "[SSO Audit] The marker {MarkerPath} could not be written. This server is serving default settings and refusing SSO now, but a restart will forget that and answer as though no provider were configured.",
-            markerPath?.ReplaceLineEndings(string.Empty));
+            markerPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records that the marker could not be removed after an administrator supplied a configuration
@@ -997,7 +1010,7 @@ internal static class SsoAudit
         => logger.LogError(
             error,
             "[SSO Audit] The marker {MarkerPath} could not be removed. SSO is accepted again now, but a restart would refuse it once more; delete that file by hand.",
-            markerPath?.ReplaceLineEndings(string.Empty));
+            markerPath?.ReplaceLineEndings(string.Empty).Replace("[", string.Empty, StringComparison.Ordinal));
 
     /// <summary>
     /// Records a configuration arriving while defaults were being served, which is what ends the refusal

--- a/docs/THREAT-MODEL-TRUSTED-HEADER.md
+++ b/docs/THREAT-MODEL-TRUSTED-HEADER.md
@@ -207,7 +207,10 @@ provider and whether administrator rights were granted, and no address. The
 quotation below is pinned to `origin/main`, which is where it was taken; on the
 `4.4` line the username field became the RESOLVED Jellyfin account rather than
 the name the provider presented, with the presented name appended where the two
-differ (#1551). Neither change adds an address, so nothing in this section moves.
+differ (#1551), and every foreign value in the trail lost its opening square
+bracket as well as its line endings, so that a value cannot forge a second
+record inside the line it lands in (#1555). None of those changes adds an
+address, so nothing in this section moves.
 
 ```
 $ git show origin/main:SSO-Auth/Api/Audit/SsoAudit.cs | sed -n '35,41p'

--- a/docs/THREAT-MODEL-TRUSTED-HEADER.md
+++ b/docs/THREAT-MODEL-TRUSTED-HEADER.md
@@ -207,10 +207,12 @@ provider and whether administrator rights were granted, and no address. The
 quotation below is pinned to `origin/main`, which is where it was taken; on the
 `4.4` line the username field became the RESOLVED Jellyfin account rather than
 the name the provider presented, with the presented name appended where the two
-differ (#1551), and every foreign value in the trail lost its opening square
-bracket as well as its line endings, so that a value cannot forge a second
-record inside the line it lands in (#1555). None of those changes adds an
-address, so nothing in this section moves.
+differ (#1551), and every foreign value the audit emitter prints has its
+opening square bracket substituted as well as its line endings stripped, so an
+audit line cannot be made to carry a second forged record (#1555 - which is the
+emitter alone; the same text is still plantable through ordinary plugin log
+lines, #1557). None of those changes adds an address, so nothing in this section
+moves.
 
 ```
 $ git show origin/main:SSO-Auth/Api/Audit/SsoAudit.cs | sed -n '35,41p'


### PR DESCRIPTION
# What & why

Closes #1555.

Every foreign value the SSO audit trail prints was already stripped of line
endings, so none of them could SPLIT an entry. Nothing bounded a value INSIDE the
sentence it landed in, so a presented username could close the sentence and write
a whole second, plausible record on the same physical line. An unanchored search
of the log, or any SIEM rule matching the substring, then reports a login by
"root" that never happened. The value is attacker-supplied wherever the identity
provider lets a person edit their own `preferred_username`.

Every foreign value the emitter prints now has its opening square bracket
replaced by a round one, inline at the same logging call, at all 56 foreign-value
sites rather than on the login line alone. One character carries the repair,
because the `[SSO Audit] ` prefix a trail is filtered on can begin no other way.

**Why a substitution and not a deletion or an escape**, and both were tried
first, each caught by a test rather than by reasoning:

- A backslash in front of the bracket leaves the marker whole as a SUBSTRING, so
  every unanchored search this is about still matched it. The new rows failed on
  the first build.
- Deleting the bracket closes that, and makes two DIFFERENT values print alike.
  One place in this file compares printed values - the clause naming the
  presented username only where it differs from the account - so a presented
  name differing from the account name only in a bracket compared equal and the
  disclosure vanished. The bracket is one of the characters Jellyfin own
  allowlist drops when it provisions an account, which is the second of the
  three reasons that clause exists, so an identity provider could switch the
  disclosure off by choosing the character.

**Twelve values are deliberately printed exactly**: the configuration file, the
preserved copy, the marker and the mounted declarative source. They are composed
by this server, reachable by no untrusted party, and the exact text is the
actionable content of the line - the unreadable-configuration entries exist to
name a file an operator has to move out of the way. A data directory whose name
carries a bracket was being named as a path that does not exist, in the one line
written for a total lockout.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: nothing here runs before the mint or takes part in
      any authentication decision; it is log text past the decision. The one
      comparison it touches selects a message template and nothing else.
- [x] No secrets logged. No message template moved and no new value class enters
      the trail; only the rendering of values already printed changes.
- [x] A security review was performed. Record below.
- [x] Review record, below.
- [x] Log inputs from the IdP are sanitized inline at the log call. Both
      sanitizers stay spelled out in the argument list at every call, never
      handed down from a helper, because CodeQL log-forging taint tracking does
      not follow them across an assignment. That inline shape is now enforced by
      a conformance rule that reads the source rather than reflecting over the
      assembly, since a compiled body cannot answer it.

### Review record

Three refute-by-default lenses read the full files and their callers.
**No second reader is available on this board; what stands in place of one is
three independent lenses over the same state, not a reading by a second person.**

| Lens        | Verdict           | Raised             |
| ----------- | ----------------- | ------------------ |
| correctness | NEEDS_IMPROVEMENT | 5, one high        |
| bypass      | NEEDS_IMPROVEMENT | 5, no bypass found |
| integration | NEEDS_IMPROVEMENT | 5, one high        |

Counts as raised: **CONFIRMED 6 / PLAUSIBLE 9.** A finding is CONFIRMED only
where a reproduction was produced: the suppression of the presented-name clause
and an unauthenticated forgery through a non-audit log line were both driven
through the compiled code; the mangled paths and the false test contract were
reproduced by reading the tree at named lines.

Dispositions, every finding of either kind:

- **FIXED - deleting the bracket let an identity provider suppress the
  presented-name clause.** Raised independently by two lenses with a
  reproduction. The substitution keeps every value distinct, so no comparison in
  this file can be made to go quiet.
- **FIXED - the strip was applied to host-owned filesystem paths.** Twelve
  sites, including the total-lockout recovery lines whose whole content is a
  path an operator has to find.
- **FIXED - the changelog and the threat model claimed a whole-log property.**
  All three lenses raised it. Both texts now scope the claim to the audit
  emitter and name what is left.
- **FIXED - no conformance rule locked the property in.** Two rows cover two of
  about thirty entries; the rest could have lost the substitution with the suite
  green. A rule now reads every sanitizer site in the emitter and fails both
  ways, and a second pins that the record marker is written from the file that
  owns it.
- **FIXED - a test scope sentence was false.** The `AccountRenamed` row passed a
  clean provider name, so removing the substitution from that method provider
  argument left it green. Both payload rows now carry the payload in every
  foreign argument.
- **FIXED - two doc passages inside the touched files went stale.**
- **DEFERRED, its own issue - the marker is still plantable through ordinary
  plugin log lines outside this emitter.** #1557, with the four sites and the
  unauthenticated route to one of them.
- **DECLINED - the substitution also mangles a bracketed value in a diagnostic**,
  such as a JSON path inside an exception message. An exception message can
  quote input this plugin did not compose, so it stays a foreign value; the cost
  is a degraded diagnostic and the alternative is a forgeable one. Disclosed in
  the changelog rather than left implicit.
- **DECLINED - the protection is conditional on the search anchor.** True: the
  rest of a forged sentence survives, so a rule keyed on the sentence without
  the marker still fires. Nothing in a log line can prevent that, the marker is
  the part this trail owns, and the changelog does not claim more.

## Quality checklist

- [x] No duplicated logic in the sense that matters here. The sanitizer chain is
      deliberately repeated inline at every call, which is this file existing
      rule and the reason the analyzer can see it; the rule that says so is now a
      test rather than a comment.
- [x] The change adds no more code than the problem requires: one chained call
      per foreign value, two conformance rules, two test rows.
- [x] Self-documenting; the comments say why the character is substituted rather
      than deleted, and where the exemption comes from.
- [x] Architecture-conformance tests pass, and the new structural property is
      locked in as a rule in `ArchitectureConformanceTests.AuditSanitizers.cs`.
- [x] Docs impact considered. `CHANGELOG.md` carries the entry with the
      operator-facing note, and `docs/THREAT-MODEL-TRUSTED-HEADER.md` now says
      how the `4.4` line diverges from its pinned quotation. The wiki names no
      audit-line format, so nothing there goes stale.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings, on `SSO-Auth.Tests.csproj`.
- [x] `dotnet test` is green. `net9.0` 3788 passed / 0 failed / 4 skipped;
      `net10.0` 3789 passed / 0 failed / 4 skipped. The four skips are the
      pre-existing Windows firewall-bind skips.
- [x] Prettier is clean for the two `.md` files this change touches, checked
      against the pristine copies as well so the pass is the edit and not the
      file.

Guards proven by deleting them:

| Deletion                                            | What goes red                                                     |
| --------------------------------------------------- | ----------------------------------------------------------------- |
| the substitution, at all sites                       | both payload rows and the line-ending row on the presented name    |
| the substitution, at the `AccountRenamed` sites only | that entry payload row AND the conformance rule                    |
| the substitution ADDED to an exactly-printed path    | the conformance rule, from the other direction                     |

## Notes

Out of scope and carried as its own issue: #1557, the same forged text reaching
the log through plugin lines that are not audit entries - including one an
unauthenticated caller can reach through the OpenID callback error description.

A searcher who anchors on the sentence without the marker still matches forged
text. The marker is what this trail owns and what a filter is built on; the rest
of a sentence is not something a log line can defend, and nothing here claims
otherwise.
