### PR TITLE
Substitute the record-marker bracket in every plugin log line that carries a foreign value [#1557]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -813,6 +813,40 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **An identity-provider- or request-supplied value can no longer plant an
+  audit record in ANY line this plugin writes (#1557).** #1555 closed the
+  forgery inside the audit emitter's own entries and said plainly what it did
+  not reach: ordinary plugin log lines elsewhere still carried
+  identity-provider text under the line-ending strip alone, so the audit
+  marker was still plantable through them and an unanchored search over the
+  log file still reported logins that never happened. One of those
+  lines is reachable without any credential: the OpenID callback endpoint is
+  unauthenticated by design, and the `error_description` it logs on a refused
+  redirect is whatever the visitor put in the URL. Three more take an identity
+  provider or a user allowed to edit their own profile: the notice written when
+  a presented username carries a character the host drops (the bracket is one
+  of them, so the attacker's name reaches it by construction), the refusal of an
+  unusable `picture` claim, and the SAML role denial that prints the raw NameID
+  and the role strings. Every logging call in the plugin that carries a foreign
+  value now substitutes the value's opening square bracket with a round one
+  beside the line-ending strip, exactly as the audit emitter already did, and
+  the conformance rule that guarded the emitter now reads every logging call in
+  the tree, so a line added later cannot arrive with the older sanitizer alone.
+  Each of the four sites above is driven by a forging payload in the suite.
+
+  **What this does NOT cover, stated plainly.** The rule reaches a value the
+  code has already marked foreign with the line-ending strip. A value logged
+  with no sanitizer at all is not this rule's subject and never was; that is
+  CodeQL's log-forging query, which is why both sanitizers stay written out at
+  the logging call. What an operator's own tooling does with the log file is
+  still that tooling's business. Anchoring a search at the start of a line was
+  sound before this and remains the sound way to read the trail.
+
+  **If you parse plugin log lines, read this.** A foreign value that legitimately
+  carries an opening square bracket - a provider name, a role, a relay state, a
+  rejected avatar URL - now prints a round one in every plugin line, not only in
+  audit entries. Filesystem paths this server composed for itself are unchanged.
+
 - **The account-link import no longer stores an issuer the provider could not
   have issued (#1518).** The import wrote the OpenID issuer an operator's backup
   file named and compared it to nothing. The one guard beside it fires only when
@@ -867,14 +901,15 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   value, and a conformance rule fails the build if a future entry arrives
   without it.
 
-  **What this does NOT cover, stated plainly.** The property is the audit
-  emitter's, not the log file's. Ordinary plugin log lines elsewhere - the
-  OpenID callback error, the username-sanitization notice, the rejected avatar
-  URL, the SAML denial - still carry identity-provider text under the
-  line-ending strip alone, so the marker is still plantable through them and an
-  unanchored search over the whole log is still not sound. That is tracked as
-  #1557 and is not fixed here. Anchoring a search at the start of a line is,
-  and was already made sound for the first field by #1551.
+  **What this entry does NOT cover, stated plainly.** The property this change
+  delivered is the audit emitter's, not the log file's. Ordinary plugin log
+  lines elsewhere - the OpenID callback error, the username-sanitization
+  notice, the rejected avatar URL, the SAML denial - still carried
+  identity-provider text under the line-ending strip alone after it, so the
+  marker was still plantable through them and an unanchored search over the
+  whole log was still not sound. That was #1557, which is its own entry above
+  in this release and not part of this one. Anchoring a search at the start of
+  a line is, and was already made sound for the first field by #1551.
 
   **If you parse this trail, read this.** A name legitimately containing an
   opening square bracket now prints a round one instead, as a name containing a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -834,13 +834,30 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   the tree, so a line added later cannot arrive with the older sanitizer alone.
   Each of the four sites above is driven by a forging payload in the suite.
 
+  The review of this change found two more routes the rule cannot see, and
+  both are closed here with their own payload tests. The refusal written when a
+  discovery document names a member twice printed that member's name through
+  a control-character filter that let the bracket through; the name is
+  substituted the same way now, with the screen's own truncation marker joined
+  afterwards so it stays whole. And the avatar fetch handed its exception to
+  the log, which renders on the lines that follow the message and quotes the
+  remote host's HTTP reason phrase verbatim - a host the picture claim chose.
+  That entry now carries the exception type and its sanitized message inline
+  and no exception object, at the cost of the stack trace for a best-effort
+  fetch.
+
   **What this does NOT cover, stated plainly.** The rule reaches a value the
-  code has already marked foreign with the line-ending strip. A value logged
-  with no sanitizer at all is not this rule's subject and never was; that is
-  CodeQL's log-forging query, which is why both sanitizers stay written out at
-  the logging call. What an operator's own tooling does with the log file is
-  still that tooling's business. Anchoring a search at the start of a line was
-  sound before this and remains the sound way to read the trail.
+  code has already marked foreign with the line-ending strip; a foreign value
+  that reaches a log line by another route is caught by review and by a payload
+  test, as the two above were, not by the rule. A value logged with no
+  sanitizer at all is not this rule's subject and never was; that is CodeQL's
+  log-forging query, which is why both sanitizers stay written out at the
+  logging call. The substitution is byte-exact: a fullwidth bracket is not the
+  marker's byte and is left alone, so a tool that normalises text before
+  matching is outside what this can promise. What an operator's own tooling
+  does with the log file is still that tooling's business. Anchoring a search
+  at the start of a line was sound before this and remains the sound way to
+  read the trail.
 
   **If you parse plugin log lines, read this.** A foreign value that legitimately
   carries an opening square bracket - a provider name, a role, a relay state, a

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -150,9 +150,7 @@ public partial class ArchitectureConformanceTests
                 {
                     strips++;
                     var receiver = text[Math.Max(0, start - 40)..start];
-                    var exempt = AuditValuesPrintedExactly.Any(value =>
-                        receiver.EndsWith(value + "?.", StringComparison.Ordinal)
-                        || receiver.EndsWith(value + ".", StringComparison.Ordinal));
+                    var exempt = AuditValuesPrintedExactly.Any(value => IsWholeReceiver(receiver, value));
                     var substituted = string.CompareOrdinal(text, end, "." + RecordMarkerSanitizer, 0, RecordMarkerSanitizer.Length + 1) == 0;
 
                     if (exempt == substituted)
@@ -183,14 +181,35 @@ public partial class ArchitectureConformanceTests
     }
 
     /// <summary>
-    /// The character ranges of every <c>.Log&lt;Level&gt;(...)</c> argument list in a source text, found by walking
-    /// from the opening parenthesis to its match while skipping string literals, character literals and line
-    /// comments, so a parenthesis inside a message template does not end the span early.
+    /// Whether the text before a sanitizer ends in exactly <paramref name="value"/> as a whole identifier
+    /// followed by <c>.</c> or <c>?.</c>. A plain suffix test would also exempt <c>someResource.</c> for the
+    /// value <c>source</c>, in the direction that lets a strip-alone value pass.
+    /// </summary>
+    private static bool IsWholeReceiver(string receiver, string value)
+    {
+        foreach (var access in new[] { "?.", "." })
+        {
+            var suffix = value + access;
+            if (receiver.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                var before = receiver.Length - suffix.Length - 1;
+                return before < 0 || !(char.IsLetterOrDigit(receiver[before]) || receiver[before] == '_');
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The character ranges of every <c>.Log&lt;Level&gt;(...)</c> and bare <c>.Log(...)</c> argument list in a
+    /// source text, found by walking from the opening parenthesis to its match while skipping string literals,
+    /// character literals and both comment forms, so a parenthesis inside a message template or a remark does
+    /// not end the span early.
     /// </summary>
     private static List<(int Start, int End)> LoggingCallSpans(string text)
     {
         var spans = new List<(int Start, int End)>();
-        foreach (Match call in Regex.Matches(text, @"\.Log(Trace|Debug|Information|Warning|Error|Critical)\s*\("))
+        foreach (Match call in Regex.Matches(text, @"\.Log(Trace|Debug|Information|Warning|Error|Critical)?\s*\("))
         {
             var i = call.Index + call.Length;
             var depth = 1;
@@ -246,6 +265,13 @@ public partial class ArchitectureConformanceTests
                         i++;
                     }
 
+                    continue;
+                }
+
+                if (c == '/' && i + 1 < text.Length && text[i + 1] == '*')
+                {
+                    var close = text.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                    i = close < 0 ? text.Length : close + 2;
                     continue;
                 }
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -5,14 +5,18 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <content>
-/// Conformance rule for the audit emitter's two inline sanitizers (#1555): every foreign value the audit
-/// trail prints carries BOTH of them, spelled out at the logging call, and the handful of values that
-/// deliberately carry only one are named here rather than being noticed as an absence.
+/// Conformance rules for the two inline log sanitizers. The first (#1555) is the audit emitter's: every
+/// foreign value the audit trail prints carries BOTH of them, spelled out at the logging call. The second
+/// (#1557) is the log FILE's: every foreign value ANY logging call in the plugin prints carries both, so
+/// no ordinary line can hand an unanchored search a record the audit emitter never wrote. The handful of
+/// values that deliberately carry only the line-ending strip are named here rather than being noticed as
+/// an absence.
 /// </content>
 public partial class ArchitectureConformanceTests
 {
@@ -28,6 +32,7 @@ public partial class ArchitectureConformanceTests
         "preservedCopyPath",
         "markerPath",
         "source",
+        "sourcePath",
     };
 
     private const string LineEndingSanitizer = "ReplaceLineEndings(string.Empty)";
@@ -90,9 +95,9 @@ public partial class ArchitectureConformanceTests
     {
         // The substitution is only worth anything while ONE file can write the marker: a second writer with
         // a foreign value in its template would reopen the hole from a direction this rule cannot see. The
-        // marker is plantable today through ordinary plugin log lines that are not audit entries at all -
-        // that is #1557 and is deliberately not this rule's subject - but a second EMITTER of the marker
-        // itself is, because it would be claiming to be the audit trail.
+        // marker WAS plantable through ordinary plugin log lines that are not audit entries at all, which
+        // #1557 closed with the tree-wide rule below rather than with this one - but a second EMITTER of the
+        // marker itself is this rule's subject, because it would be claiming to be the audit trail.
         var sources = Directory
             .EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
             .Where(file => File.ReadAllText(file).Contains("\"[SSO Audit] ", StringComparison.Ordinal))
@@ -103,5 +108,154 @@ public partial class ArchitectureConformanceTests
         Assert.Equal(
             new[] { "SSO-Auth/Api/Audit/SsoAudit.cs", "SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs" },
             sources);
+    }
+
+    [Fact]
+    public void EveryForeignValueAnyPluginLogLinePrints_CarriesBothInlineSanitizers()
+    {
+        // #1557. The emitter rule above makes the audit trail's OWN entries sound and stops there; the thing an
+        // operator actually searches is the whole log file, and an ordinary plugin line carrying a foreign
+        // value under the line-ending strip alone still hands an unanchored search a record the emitter never
+        // wrote. The OpenID callback error is the one reachable without any credential: `error_description`
+        // is attacker-chosen on a crafted redirect, and it was rendered verbatim on one physical line.
+        //
+        // The rule therefore holds over EVERY logging call in the plugin, not one file: inside a
+        // `.Log<Level>(...)` argument list, each line-ending strip carries the bracket substitution right
+        // behind it, so no line can be added next month with the older sibling alone. The population is
+        // derived from the source rather than listed, and the exact-print exemption is the same list the
+        // emitter rule uses, for the same reason: those are paths this server composed for itself.
+        //
+        // WHAT THE RULE CAN SEE IS THE VALUE ALREADY MARKED FOREIGN BY THE STRIP. A value logged with no
+        // sanitizer at all is not this rule's subject and never was: that is CodeQL's cs/log-forging query,
+        // which is why both sanitizers stay spelled out inline at the call rather than behind a helper.
+        var offenders = new List<string>();
+        var strips = 0;
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(RepoTree.Root, file).Replace(Path.DirectorySeparatorChar, '/');
+            if (relative.StartsWith("SSO-Auth/bin/", StringComparison.Ordinal) || relative.StartsWith("SSO-Auth/obj/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(file);
+            var spans = LoggingCallSpans(text);
+            var at = 0;
+            while ((at = text.IndexOf(LineEndingSanitizer, at, StringComparison.Ordinal)) >= 0)
+            {
+                var end = at + LineEndingSanitizer.Length;
+                var start = at;
+                if (spans.Any(span => start > span.Start && start < span.End))
+                {
+                    strips++;
+                    var receiver = text[Math.Max(0, start - 40)..start];
+                    var exempt = AuditValuesPrintedExactly.Any(value =>
+                        receiver.EndsWith(value + "?.", StringComparison.Ordinal)
+                        || receiver.EndsWith(value + ".", StringComparison.Ordinal));
+                    var substituted = string.CompareOrdinal(text, end, "." + RecordMarkerSanitizer, 0, RecordMarkerSanitizer.Length + 1) == 0;
+
+                    if (exempt == substituted)
+                    {
+                        var lineNumber = text.AsSpan(0, start).Count('\n') + 1;
+                        offenders.Add(
+                            relative + ":" + lineNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                            + (exempt
+                                ? " prints a value this rule names as printed exactly, and substitutes its bracket anyway"
+                                : " logs a foreign value with the line-ending strip alone"));
+                    }
+                }
+
+                at = end;
+            }
+        }
+
+        // Sentinel against a vacuous pass: the scan must still be finding the emitter's own arguments, or the
+        // span walker has stopped recognising logging calls and every file passes for the wrong reason.
+        Assert.True(strips > 100, "The logging-call scan found only " + strips.ToString(System.Globalization.CultureInfo.InvariantCulture) + " sanitized arguments; it has stopped seeing the calls it exists to judge.");
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every foreign value ANY plugin log line prints carries the line-ending strip AND the record-marker "
+            + "substitution, inline at the logging call (#1557); the values printed exactly are named in "
+            + "AuditValuesPrintedExactly and carry only the first. These lines break that: "
+            + string.Join(" | ", offenders));
+    }
+
+    /// <summary>
+    /// The character ranges of every <c>.Log&lt;Level&gt;(...)</c> argument list in a source text, found by walking
+    /// from the opening parenthesis to its match while skipping string literals, character literals and line
+    /// comments, so a parenthesis inside a message template does not end the span early.
+    /// </summary>
+    private static List<(int Start, int End)> LoggingCallSpans(string text)
+    {
+        var spans = new List<(int Start, int End)>();
+        foreach (Match call in Regex.Matches(text, @"\.Log(Trace|Debug|Information|Warning|Error|Critical)\s*\("))
+        {
+            var i = call.Index + call.Length;
+            var depth = 1;
+            while (i < text.Length && depth > 0)
+            {
+                var c = text[i];
+                if (c == '"')
+                {
+                    var verbatim = i > 0 && (text[i - 1] == '@' || (i > 1 && text[i - 1] == '$' && text[i - 2] == '@'));
+                    i++;
+                    while (i < text.Length)
+                    {
+                        if (text[i] == '\\' && !verbatim)
+                        {
+                            i += 2;
+                            continue;
+                        }
+
+                        if (text[i] == '"')
+                        {
+                            if (verbatim && i + 1 < text.Length && text[i + 1] == '"')
+                            {
+                                i += 2;
+                                continue;
+                            }
+
+                            break;
+                        }
+
+                        i++;
+                    }
+
+                    i++;
+                    continue;
+                }
+
+                if (c == '\'')
+                {
+                    i++;
+                    while (i < text.Length && text[i] != '\'')
+                    {
+                        i += text[i] == '\\' ? 2 : 1;
+                    }
+
+                    i++;
+                    continue;
+                }
+
+                if (c == '/' && i + 1 < text.Length && text[i + 1] == '/')
+                {
+                    while (i < text.Length && text[i] != '\n')
+                    {
+                        i++;
+                    }
+
+                    continue;
+                }
+
+                depth += c == '(' ? 1 : c == ')' ? -1 : 0;
+                i++;
+            }
+
+            spans.Add((call.Index, i));
+        }
+
+        return spans;
     }
 }

--- a/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
@@ -168,6 +168,24 @@ public class AvatarServiceTests
     }
 
     [Fact]
+    public async Task TrySetAsync_PictureClaimCarryingAForgedRecord_CannotPlantTheMarkerInTheRefusal()
+    {
+        // #1557: the refusal names the rejected value, and it is reached precisely because the value is NOT
+        // a usable URL - so an identity provider (or a user allowed to edit their own picture claim) needs
+        // no parseable address to land a whole audit record on this line. The value still prints, because
+        // an operator debugging a missing avatar needs to see what was refused; the record marker does not.
+        var (service, providers, users, log) = Build();
+        const string forged = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).";
+
+        await service.TrySetAsync(TestUsers.Named("alice"), forged);
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        var refusal = Assert.Single(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("disallowed URL", StringComparison.Ordinal));
+        Assert.Contains("(SSO Audit] Login succeeded: root", refusal.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(log.Entries, e => e.Message.Contains("[SSO Audit] ", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task StoreAsync_SaveFails_LeavesThePreviousAvatarUntouched()
     {
         // The #377 regression: a transient save failure must not downgrade the user from a working

--- a/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
@@ -225,6 +225,30 @@ public class AvatarServiceTests
     }
 
     [Fact]
+    public async Task TrySetAsync_AvatarHostAnsweringWithAForgedReasonPhrase_CannotPlantTheMarkerThroughTheException()
+    {
+        // #1557: a non-success status makes EnsureSuccessStatusCode throw an HttpRequestException whose message
+        // quotes the remote server's reason phrase verbatim, and the host is whatever the picture claim named.
+        // Handing that exception object to the sink renders it on the lines that FOLLOW the message, which put
+        // a provider-chosen value at the start of a physical line. The entry now carries the type and the
+        // sanitized message inline and no exception object at all, so nothing is rendered after it.
+        using var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            ReasonPhrase = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).",
+        };
+        var (service, providers, _, log) = Build(response);
+
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        var failure = Assert.Single(log.Records, r => r.Message.Contains("Failed to fetch or save", StringComparison.Ordinal));
+        Assert.Null(failure.Exception);
+        Assert.Contains("HttpRequestException", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("(SSO Audit] Login succeeded: root", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(log.Records, r => r.Message.Contains("[SSO Audit] ", StringComparison.Ordinal) || (r.Exception?.ToString().Contains("[SSO Audit] ", StringComparison.Ordinal) ?? false));
+    }
+
+    [Fact]
     public async Task StoreAsync_ChangedPath_ClearsTheOldImageOnlyAfterTheWrite()
     {
         // A changed content type moves the stored path: the old record+file are dropped only once

--- a/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
@@ -274,6 +274,28 @@ public class SSOControllerOidPostTests
     }
 
     [Fact]
+    public async Task OidPost_IdpErrorRedirect_CannotForgeAnAuditRecordThroughTheWarningLine()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // #1557: the one forging surface reachable without any credential. OidCallback carries no [Authorize],
+        // and the error_description the callback logs server-side is parsed from the query, so a visitor who
+        // took a state and a cookie from the challenge leg returns with a whole plausible audit record in it.
+        // Before this, the warning rendered it verbatim on one physical line, and an unanchored search over
+        // the log file - grep -F "[SSO Audit] Login succeeded: root" - reported a login that never happened.
+        // The line still carries the description, because it is the troubleshooting content of the warning;
+        // what it cannot carry is the record marker, whose opening bracket now prints as a round one.
+        const string forged = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).";
+        var harness = ArrangeCallback(fixture, query: $"?error=access_denied&error_description={Uri.EscapeDataString(forged)}&state=state-1");
+
+        var result = await harness.Controller.OidCallback("kc", "state-1");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+        var warning = Assert.Single(harness.ControllerLog.Entries, e => e.Message.Contains("authorization-response processing failed", StringComparison.Ordinal));
+        Assert.Contains("(SSO Audit] Login succeeded: root", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(harness.ControllerLog.Entries, e => e.Message.Contains("[SSO Audit] ", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task OidPost_IdTokenWithoutSub_Returns401()
     {
         using var fixture = new OidcTokenFixture(Authority, "jf");

--- a/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
@@ -105,6 +105,32 @@ public class SSOControllerSamlPostTests
     }
 
     [Fact]
+    public async Task SamlPost_RoleNotAllowed_CannotForgeAnAuditRecordThroughTheNameIdOrTheRoles()
+    {
+        // #1557 on the SAML leg: the denial warning prints the raw NameID and every role string the
+        // assertion carried, both chosen by the identity provider. Either could hold a complete audit record
+        // and, before this, land it verbatim on one physical line. Both values still print - the NameID and
+        // the roles are what an operator needs to see to fix the allow-list - and neither can carry the
+        // record marker. The assertion is signed by the fixture, so the real validation path runs first.
+        const string forged = "[SSO Audit] Login succeeded: root via SAML provider 'adfs' (admin=True).";
+        var fixture = SamlTestFactory.Create(nameId: forged, role: forged);
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            Roles = new[] { "only-admins" },
+        });
+
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
+        var warning = Assert.Single(harness.ControllerLog.Entries, e => e.Message.Contains("has insufficient roles", StringComparison.Ordinal));
+        Assert.Contains("(SSO Audit] Login succeeded: root", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(harness.ControllerLog.Entries, e => e.Message.Contains("[SSO Audit] ", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task SamlPost_SignedByAnotherCertificate_PublishesNoDenial()
     {
         // The one-change neighbour: a rejection that is NOT the role gate publishes nothing. Without this the

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -90,6 +90,30 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_PresentedNameCarryingAForgedRecord_CannotPlantTheMarkerInTheSanitizationNotice()
+    {
+        // #1557: the sanitization notice fires on the FIRST login of any user whose presented name carries a
+        // character the host's allowlist drops, and the opening bracket is one of them - so the notice is
+        // reached by exactly the name an attacker would choose. The raw presented name is the actionable
+        // content of that line (it tells an operator which spelling the provider sent), so it is still
+        // printed; what it cannot print is the record marker. The provisioned name on the same line is the
+        // host-sanitized one, which never carried the bracket at all.
+        var (service, _, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        const string forged = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).";
+        var created = TestUsers.Named("SSO Audit Login succeeded root via OpenID provider 'kc' admin=True.", Other);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        users.CreateUserAsync(Arg.Any<string>()).Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", forged, allowExistingAccountLink: false);
+
+        Assert.Equal(Other, resolved);
+        var notice = Assert.Single(log.Entries, e => e.Message.Contains("carries characters Jellyfin does not accept", StringComparison.Ordinal));
+        Assert.Contains("(SSO Audit] Login succeeded: root", notice.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(log.Entries, e => e.Message.Contains("[SSO Audit] ", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ResolveOrCreateAsync_ProvisionDisabled_NewAccount_CreatesItDisabledAndPersists()
     {
         // #737: with the policy on, a brand-new account is created disabled and PERSISTED here (the deferred

--- a/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
+++ b/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
@@ -70,6 +70,36 @@ public class RefusalEntryMemberNameTests
         Assert.DoesNotContain("[truncated]", entry, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task AMemberNameCarryingAForgedRecord_CannotPlantTheMarkerInTheEntry()
+    {
+        // Kills: deleting the bracket substitution on the filtered name (#1557). The three filter classes
+        // above let an opening bracket through, and the tree-wide sanitizer rule cannot see this value because
+        // it deliberately carries no line-ending strip - so this row is the only thing that pins it. The name
+        // is reachable from an anonymous challenge: the screen reads whatever document the provider serves.
+        const string Forged = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).";
+
+        var entry = await RefusalEntryFor(Forged);
+
+        Assert.Contains(NameLeadIn + " \"(SSO Audit] Login succeeded: root", entry, StringComparison.Ordinal);
+        Assert.DoesNotContain("[SSO Audit] ", entry, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ATruncatedMemberName_StillCarriesTheScreensOwnMarkerWhole()
+    {
+        // The one-change neighbour of the row above: substituting the bracket AFTER the truncation marker is
+        // joined would rewrite the screen's own "[truncated]" into "(truncated]", and the overlong-name row
+        // would go red for the wrong reason. The marker is joined after the substitution, so both survive.
+        var name = new string('[', 8192);
+
+        var entry = await RefusalEntryFor(name);
+
+        Assert.Contains("[truncated]\"", entry, StringComparison.Ordinal);
+        Assert.DoesNotContain("[SSO Audit] ", entry, StringComparison.Ordinal);
+        Assert.DoesNotContain("[[", entry, StringComparison.Ordinal);
+    }
+
     [Theory]
     // The two ReplaceLineEndings passes through, which is why this class exists at all.
     [InlineData("\\u0000")]

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -35,11 +35,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Audit;
 /// the line: the unreadable-configuration lines tell an operator which file to move out of the way,
 /// and a data directory whose name carries a bracket would be named as a path that does not exist,
 /// in the one line written for a total lockout. They keep the line-ending strip and nothing more.
-/// WHAT THIS DOES NOT REACH IS EVERY OTHER LOG LINE THE PLUGIN WRITES. The property is this
-/// emitter's, not the log file's: ordinary plugin lines elsewhere carry identity-provider values
-/// under the line-ending strip alone, so the marker text is still plantable through them and an
-/// unanchored search over the whole file is still not sound. That is #1557, and no sentence here or
-/// in the changelog may be read as claiming otherwise.
+/// THE SAME PAIR IS CARRIED BY EVERY OTHER LOG LINE THE PLUGIN WRITES (#1557). The property was this
+/// emitter's alone until then: ordinary plugin lines elsewhere carried identity-provider values under
+/// the line-ending strip alone, so the marker text was still plantable through them and an unanchored
+/// search over the whole file was not sound. Every logging call in the plugin now carries both, and the
+/// conformance rule that reads this file reads all of them. What the pair still does not reach is a
+/// value logged with no sanitizer at all, which is CodeQL's question rather than this one.
 /// Each call is guarded by <see cref="ILogger.IsEnabled(LogLevel)"/> so the inline sanitizers are
 /// not evaluated when the level is disabled (net10 CA1873, #566); both stay spelled out at the
 /// logging call, never handed down from a helper, so CodeQL's log-forging taint tracking still

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -141,7 +141,7 @@ internal sealed class AvatarService
 
         if (!AvatarUrlValidator.IsAllowedUrl(avatarUrl, out var avatarUri))
         {
-            _logger.LogWarning("Refusing to fetch avatar from disallowed URL: {AvatarUrl}", avatarUrl.ReplaceLineEndings(string.Empty));
+            _logger.LogWarning("Refusing to fetch avatar from disallowed URL: {AvatarUrl}", avatarUrl.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return;
         }
 
@@ -203,7 +203,7 @@ internal sealed class AvatarService
                 // Log the rejected type sanitized inline at the log call (mediaType is server-controlled),
                 // and keep the thrown/caught exception message generic so no untrusted text reaches the
                 // logged exception - mirrors the disallowed-URL warning above.
-                _logger.LogWarning("Refusing avatar with disallowed content type: {MediaType}", (mediaType ?? "(none)").ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("Refusing avatar with disallowed content type: {MediaType}", (mediaType ?? "(none)").ReplaceLineEndings(string.Empty).Replace('[', '('));
                 throw new InvalidOperationException("Avatar content type is not an allowed raster image.");
             }
 
@@ -264,7 +264,7 @@ internal sealed class AvatarService
             _logger.LogWarning(
                 "Timed out after {TimeoutSeconds}s waiting for another login to finish storing the SSO avatar for user: {Username}; skipping this store.",
                 _storeLockAcquireTimeout.TotalSeconds,
-                user.Username?.ReplaceLineEndings(string.Empty));
+                user.Username?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return;
         }
 
@@ -291,7 +291,7 @@ internal sealed class AvatarService
         {
             _logger.LogWarning(
                 "Refusing to store the SSO avatar: username is not a safe path component: {Username}",
-                user.Username?.ReplaceLineEndings(string.Empty));
+                user.Username?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return;
         }
 

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -220,7 +220,16 @@ internal sealed class AvatarService
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Failed to fetch or save the SSO avatar.");
+            // The exception TYPE and its message, inline, rather than the exception object (#1557). A sink renders
+            // a handed-over exception on the lines that FOLLOW the message, and HttpRequestException quotes the
+            // remote server's reason phrase verbatim - a host the identity provider's picture claim chose. That
+            // put a provider-authored value at the start of a physical line, which is the one place an anchored
+            // search of the audit trail trusts. The message still names what failed; the stack trace is the
+            // price, and for a best-effort avatar fetch it is one an operator never needed.
+            _logger.LogError(
+                "Failed to fetch or save the SSO avatar ({ExceptionType}): {Reason}",
+                e.GetType().Name,
+                e.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
     }
 

--- a/SSO-Auth/Api/Events/SsoLoginEvents.cs
+++ b/SSO-Auth/Api/Events/SsoLoginEvents.cs
@@ -155,7 +155,7 @@ internal sealed class SsoLoginEvents
         {
             // Never let a notification decide a login's answer. The denial has already been settled by the
             // policy above this call; this only reports it.
-            _logger.LogWarning(ex, "Could not publish the SSO denial event ({Reason}) for provider {Provider} within {Budget}. The login was refused regardless.", reason, provider?.ReplaceLineEndings(string.Empty), _budget);
+            _logger.LogWarning(ex, "Could not publish the SSO denial event ({Reason}) for provider {Provider} within {Budget}. The login was refused regardless.", reason, provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), _budget);
         }
     }
 }

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -215,7 +215,7 @@ internal sealed class OidcLoginService
             // discovery, PrepareLoginAsync could not build the authorize redirect either.
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization server's discovery document could not be read.", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization server's discovery document could not be read.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login: the authorization server's discovery document could not be read.");
@@ -232,7 +232,7 @@ internal sealed class OidcLoginService
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                    _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
 
                 return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
@@ -262,7 +262,7 @@ internal sealed class OidcLoginService
             // the user-facing error page. Sanitized against log forging. Fail-closed is unchanged (400).
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: preparing the authorization request failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty), state.Error?.ReplaceLineEndings(string.Empty), state.ErrorDescription?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login refused for provider {Provider}: preparing the authorization request failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.Error?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.ErrorDescription?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login.");
@@ -298,7 +298,7 @@ internal sealed class OidcLoginService
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                    _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
             }
 
@@ -364,7 +364,7 @@ internal sealed class OidcLoginService
             // fail-closed is unchanged (400, no session minted).
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization-response processing failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty), result.Error?.ReplaceLineEndings(string.Empty), result.ErrorDescription?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization-response processing failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), result.Error?.ReplaceLineEndings(string.Empty).Replace('[', '('), result.ErrorDescription?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             // #1139: the code exchange is the other server-to-provider fetch, and it is counted apart from
@@ -388,7 +388,7 @@ internal sealed class OidcLoginService
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
@@ -426,7 +426,7 @@ internal sealed class OidcLoginService
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
@@ -441,8 +441,8 @@ internal sealed class OidcLoginService
             {
                 _logger.LogWarning(
                     "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
-                    derived.Username?.ReplaceLineEndings(string.Empty),
-                    result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
+                    derived.Username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                    result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty).Replace('[', '('), Value = o.Value?.ReplaceLineEndings(string.Empty).Replace('[', '(') }),
                     config.Roles);
             }
 
@@ -490,7 +490,7 @@ internal sealed class OidcLoginService
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning("OpenID login denied for provider {Provider}: RequireAcr is set but the id_token's acr claim was absent or outside the configured acr_values allow-list.", provider?.ReplaceLineEndings(string.Empty));
+                    _logger.LogWarning("OpenID login denied for provider {Provider}: RequireAcr is set but the id_token's acr claim was absent or outside the configured acr_values allow-list.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
 
                 return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AcrNotSatisfied));
@@ -512,7 +512,7 @@ internal sealed class OidcLoginService
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning("OpenID login denied for provider {Provider}: max_age is configured but the id_token's auth_time was absent or older than the allowed window (the user authenticated too long ago).", provider?.ReplaceLineEndings(string.Empty));
+                    _logger.LogWarning("OpenID login denied for provider {Provider}: max_age is configured but the id_token's auth_time was absent or older than the allowed window (the user authenticated too long ago).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
 
                 return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AuthTooOld));
@@ -581,7 +581,7 @@ internal sealed class OidcLoginService
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login denied for provider {Provider}: RequireVerifiedEmailForLogin is set but the login did not carry email_verified == true (absent, false, or unparseable).", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID login denied for provider {Provider}: RequireVerifiedEmailForLogin is set but the login did not carry email_verified == true (absent, false, or unparseable).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.EmailNotVerified));
@@ -691,7 +691,7 @@ internal sealed class OidcLoginService
             built = default!;
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError("OpenID login refused for provider {Provider}: the stored client secret could not be decrypted ({Reason}); the at-rest key file is missing or corrupt.", provider?.ReplaceLineEndings(string.Empty), ex.Message?.ReplaceLineEndings(string.Empty));
+                _logger.LogError("OpenID login refused for provider {Provider}: the stored client secret could not be decrypted ({Reason}); the at-rest key file is missing or corrupt.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not process login; the OpenID client secret could not be decrypted.");
@@ -734,7 +734,7 @@ internal sealed class OidcLoginService
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID back-channel logout refused for provider {Provider}: the configured endpoint is not a usable URL.", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("OpenID back-channel logout refused for provider {Provider}: the configured endpoint is not a usable URL.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return new OidcLogoutTokenValidator.Result(false, null, null, OidcLogoutTokenValidator.RejectReason.ProviderUnreachable);

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -479,7 +479,7 @@ internal sealed class SamlLoginService
             // material is not part of the message, so nothing sensitive is logged.
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
+                _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -213,7 +213,7 @@ internal sealed class SamlLoginService
         {
             _logger.LogInformation(
                 "SAML request has relayState of {RelayState}",
-                relayState?.ReplaceLineEndings(string.Empty));
+                relayState?.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
@@ -248,8 +248,8 @@ internal sealed class SamlLoginService
             {
                 _logger.LogWarning(
                     "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-                    assertionRoles.Select(r => r?.ReplaceLineEndings(string.Empty)),
+                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                    assertionRoles.Select(r => r?.ReplaceLineEndings(string.Empty).Replace('[', '(')),
                     config.Roles);
             }
 
@@ -322,7 +322,7 @@ internal sealed class SamlLoginService
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning("SAML login outcome refused for provider {Provider}: the per-client sub-cap or the outcome store is at capacity (warning throttled); the assertion was not consumed, so the login can be retried.", provider?.ReplaceLineEndings(string.Empty));
+                    _logger.LogWarning("SAML login outcome refused for provider {Provider}: the per-client sub-cap or the outcome store is at capacity (warning throttled); the assertion was not consumed, so the login can be retried.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
             }
 
@@ -450,7 +450,7 @@ internal sealed class SamlLoginService
                 {
                     if (_logger.IsEnabled(LogLevel.Warning))
                     {
-                        _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                        _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                     }
                 }
 
@@ -479,7 +479,7 @@ internal sealed class SamlLoginService
             // material is not part of the message, so nothing sensitive is logged.
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+                _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -516,7 +516,7 @@ public class SSOController : ControllerBase
                 // is logged.
                 if (_logger.IsEnabled(LogLevel.Error))
                 {
-                    _logger.LogError("SAML SP-initiated logout for provider {Provider} could not build the signed LogoutRequest: {Reason}; the local logout stands and the browser returns to this server.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
+                    _logger.LogError("SAML SP-initiated logout for provider {Provider} could not build the signed LogoutRequest: {Reason}; the local logout stands and the browser returns to this server.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
             }
         }
@@ -1252,7 +1252,7 @@ public class SSOController : ControllerBase
         {
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError("SAML inbound logout for provider {Provider} could not build the signed LogoutResponse: {Reason}; the revocation stands and the endpoint answers 200.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
+                _logger.LogError("SAML inbound logout for provider {Provider} could not build the signed LogoutResponse: {Reason}; the revocation stands and the endpoint answers 200.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
         }
 

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -516,7 +516,7 @@ public class SSOController : ControllerBase
                 // is logged.
                 if (_logger.IsEnabled(LogLevel.Error))
                 {
-                    _logger.LogError("SAML SP-initiated logout for provider {Provider} could not build the signed LogoutRequest: {Reason}; the local logout stands and the browser returns to this server.", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+                    _logger.LogError("SAML SP-initiated logout for provider {Provider} could not build the signed LogoutRequest: {Reason}; the local logout stands and the browser returns to this server.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
                 }
             }
         }
@@ -1252,7 +1252,7 @@ public class SSOController : ControllerBase
         {
             if (_logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError("SAML inbound logout for provider {Provider} could not build the signed LogoutResponse: {Reason}; the revocation stands and the endpoint answers 200.", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+                _logger.LogError("SAML inbound logout for provider {Provider} could not build the signed LogoutResponse: {Reason}; the revocation stands and the endpoint answers 200.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), ex.Message);
             }
         }
 
@@ -1910,7 +1910,7 @@ public class SSOController : ControllerBase
             // importer builds its refusals under.
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", ex.Message?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return BadRequest(ex.Message?.ReplaceLineEndings(string.Empty));

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -384,9 +384,9 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
-                    username?.ReplaceLineEndings(string.Empty),
+                    username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             throw new AccountLinkForbiddenException("The account link was minted under a different issuer; refusing to resolve it after an apparent provider repoint.");
@@ -413,9 +413,9 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
-                    username?.ReplaceLineEndings(string.Empty),
+                    username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             throw new AccountLinkForbiddenException();
@@ -435,7 +435,7 @@ internal sealed class CanonicalLinkService
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
                 mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         return migratedUserId;
@@ -482,7 +482,7 @@ internal sealed class CanonicalLinkService
                 _logger.LogWarning(
                     "SSO login via {Mode}/{Provider}: the identity provider's username is already held by a different Jellyfin account, so the linked account keeps its current name. Rename or merge the other account to let the sync proceed.",
                     mode.ToToken(),
-                    provider.ReplaceLineEndings(string.Empty));
+                    provider.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return userId;
@@ -531,7 +531,7 @@ internal sealed class CanonicalLinkService
                     ex,
                     "SSO login via {Mode}/{Provider}: renaming the linked account to follow the identity provider failed; it keeps its current name and the login continues.",
                     mode.ToToken(),
-                    provider.ReplaceLineEndings(string.Empty));
+                    provider.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return userId;
@@ -561,9 +561,9 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
-                    username?.ReplaceLineEndings(string.Empty),
+                    username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty),
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     DescribeAdoptionRefusal(verdict));
             }
 
@@ -627,15 +627,15 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
-                    username.ReplaceLineEndings(string.Empty),
+                    username.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider.ReplaceLineEndings(string.Empty));
+                    provider.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
         }
 
         if (_logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation("SSO user {Name} doesn't exist, creating...", provisionedName.ReplaceLineEndings(string.Empty));
+            _logger.LogInformation("SSO user {Name} doesn't exist, creating...", provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         var user = await _userManager.CreateUserAsync(provisionedName).ConfigureAwait(false);
@@ -789,7 +789,7 @@ internal sealed class CanonicalLinkService
         {
             _logger.LogWarning(
                 "SSO user {Name}: the provisioning template names a home-screen layout, but this path holds no display-preferences store, so none was written.",
-                provisionedName.ReplaceLineEndings(string.Empty));
+                provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return;
         }
 
@@ -803,7 +803,7 @@ internal sealed class CanonicalLinkService
                 // own layout under a template naming one is not a mystery.
                 _logger.LogWarning(
                     "SSO user {Name}: the provisioning template's home-screen layout names a section that is not a HomeSectionType or lists more than {Slots} entries, so none was written; a save would have refused the same list.",
-                    provisionedName.ReplaceLineEndings(string.Empty),
+                    provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     HomeScreenPolicy.SlotCount);
             }
         }
@@ -816,7 +816,7 @@ internal sealed class CanonicalLinkService
             _logger.LogWarning(
                 ex,
                 "SSO user {Name}: the provisioning template's home-screen layout could not be written; the account was created without it.",
-                provisionedName.ReplaceLineEndings(string.Empty));
+                provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
     }
 
@@ -844,8 +844,8 @@ internal sealed class CanonicalLinkService
             _logger.LogWarning(
                 "SSO provisioning via {Mode}/{Provider}: provisioning profile {Profile} ({Source}) is not defined, so the new account was created with NO provisioning policy. The resolution deliberately does not fall back; define that profile or remove the reference.",
                 mode.ToToken(),
-                provider.ReplaceLineEndings(string.Empty),
-                resolution.UnresolvedProfile.ReplaceLineEndings(string.Empty),
+                provider.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                resolution.UnresolvedProfile.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 resolution.SelectedByRole ? "selected by a role mapping" : "the provider default");
         }
 
@@ -884,7 +884,7 @@ internal sealed class CanonicalLinkService
                 _logger.LogWarning(
                     "SSO login via {Mode}/{Provider} refused: the identity provider's username has no character Jellyfin accepts in an account name, so no account can be provisioned for it.",
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             throw new AccountLinkForbiddenException("The SSO username contains no character Jellyfin accepts in an account name; refusing to provision an account under an invented name.");
@@ -909,10 +909,10 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: the name normalizes to {Provisioned}, which an existing Jellyfin account already bears. Rename that account or the identity provider's username.",
-                    username?.ReplaceLineEndings(string.Empty),
+                    username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty),
-                    provisionedName.ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                    provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             throw new AccountLinkForbiddenException("The sanitized SSO username is already taken by another Jellyfin account; refusing to adopt it by name.");
@@ -922,10 +922,10 @@ internal sealed class CanonicalLinkService
         {
             _logger.LogInformation(
                 "SSO username {Name} via {Mode}/{Provider} carries characters Jellyfin does not accept in an account name; provisioning as {Provisioned}. The account link is keyed on the provider subject, so the rename does not affect which account later logins resolve to.",
-                username?.ReplaceLineEndings(string.Empty),
+                username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty),
-                provisionedName.ReplaceLineEndings(string.Empty));
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                provisionedName.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         return provisionedName;
@@ -1136,7 +1136,7 @@ internal sealed class CanonicalLinkService
             _logger.LogWarning(
                 ex,
                 "[SSO] Could not record the last SSO login for provider {Provider}. The login itself succeeded; the roster timestamp is stale.",
-                provider?.ReplaceLineEndings(string.Empty));
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
     }
 
@@ -1295,9 +1295,9 @@ internal sealed class CanonicalLinkService
                 {
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
-                        username?.ReplaceLineEndings(string.Empty),
+                        username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                         mode.ToToken(),
-                        provider?.ReplaceLineEndings(string.Empty));
+                        provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
                 }
             }
         }
@@ -1307,9 +1307,9 @@ internal sealed class CanonicalLinkService
             {
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                    username?.ReplaceLineEndings(string.Empty),
+                    username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                     mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
         }
 

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -120,14 +120,16 @@ internal static class OidcDiscoveryReader
                 // plugin's string. It quotes the URL the library was connecting to, which on the JWKS leg
                 // the provider chose, so an unbounded entry lets one anonymous challenge write as much log
                 // as the response cap allows. The truncation is inline for the same reason the strip is -
-                // moving either into a helper takes the sanitizer out of the call the analyzer reads.
+                // moving either into a helper takes the sanitizer out of the call the analyzer reads. The
+                // sanitizers run on the foreign text BEFORE the truncation marker is joined to it: the marker
+                // is this reader's own, and it opens with the bracket the substitution exists to remove (#1557).
                 var error = discovery.Error ?? string.Empty;
                 logger.LogWarning(
                     "Could not read the OpenID discovery document for provider {Provider}: {Error}. The login fails closed rather than proceeding on unverified discovery facts.",
-                    provider?.ReplaceLineEndings(string.Empty),
-                    (error.Length > MaxLoggedProviderErrorChars
-                        ? string.Concat(error.AsSpan(0, MaxLoggedProviderErrorChars), ErrorTruncationMarker)
-                        : error).ReplaceLineEndings(string.Empty));
+                    provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                    string.Concat(
+                        error[..Math.Min(error.Length, MaxLoggedProviderErrorChars)].ReplaceLineEndings(string.Empty).Replace('[', '('),
+                        error.Length > MaxLoggedProviderErrorChars ? ErrorTruncationMarker : string.Empty));
 
                 // The screen's own record of what it refused, never a re-reading of the library's error
                 // text, so the reason the admin probe reports (#1064) cannot drift from the reason logged
@@ -173,7 +175,7 @@ internal static class OidcDiscoveryReader
             logger.LogWarning(
                 e,
                 "Could not read the OpenID discovery document for provider {Provider}; the login fails closed rather than proceeding on unverified discovery facts.",
-                provider?.ReplaceLineEndings(string.Empty));
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
 
             // #1139: the catch-all arm is the fetch-error counter, because it is where every unreadable
             // document ends up - a network failure, a timeout, a body that will not parse.

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -216,7 +216,7 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
         _logger.LogWarning(
             "Refused the OpenID {Document} for provider {Provider}: {Reason}{Member}{Cause}. The read fails closed rather than handing on a document whose meaning depends on which reader parses it.",
             DocumentKind(request),
-            _provider?.ReplaceLineEndings(string.Empty),
+            _provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             reason,
             named,
             cause is null ? string.Empty : $" [{cause.GetType().Name}]");

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -180,6 +180,10 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
     //     the rest of the entry as it is displayed - forging by rearranging rather than by inserting.
     //   * The LINE and PARAGRAPH separators, which a line-ending replacement treats as line endings but a
     //     control-character test does not reach.
+    //   * The RECORD-MARKER bracket (#1557), which none of the three classes above touches and which is
+    //     what lets a member name reproduce the audit trail's record-marker prefix inside this entry. The
+    //     tree-wide conformance rule finds a foreign value by its line-ending strip, which this name
+    //     deliberately does not carry, so the substitution here is pinned by its own payload test instead.
     //
     // The fourth class named on #1195, the unpaired surrogate, has no arm, because a provider cannot put one
     // here: a raw one has no UTF-8 encoding and StrictJson refuses the document before the walk starts, and
@@ -200,18 +204,20 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
         // rather than over everything the provider sent. The cut steps BACK off a high surrogate instead of
         // through it: the bound is the one thing here that can manufacture an unpaired surrogate, by
         // separating the halves of a legitimate astral pair, and a half pair corrupts the entry it lands in.
-        var cut = repeatedMember is null || repeatedMember.Length <= MaxLoggedMemberNameChars
-            ? repeatedMember
-            : string.Concat(
-                repeatedMember.AsSpan(0, char.IsHighSurrogate(repeatedMember[MaxLoggedMemberNameChars - 1]) ? MaxLoggedMemberNameChars - 1 : MaxLoggedMemberNameChars),
-                NameTruncationMarker);
+        var truncated = repeatedMember is { Length: > MaxLoggedMemberNameChars };
+        var cut = repeatedMember is { Length: > MaxLoggedMemberNameChars } overlong
+            ? overlong[..(char.IsHighSurrogate(overlong[MaxLoggedMemberNameChars - 1]) ? MaxLoggedMemberNameChars - 1 : MaxLoggedMemberNameChars)]
+            : repeatedMember;
 
         // The filter, in the method that logs rather than behind a call from it. SA1118 forbids the
         // expression inside the argument list, so it is a local here; what the log-forging invariant rules
         // out is a HELPER, and TheNeutralisationLivesInTheMethodThatLogs is the scan that keeps it out.
+        // The record-marker bracket is substituted on the FILTERED name and the truncation marker is joined
+        // only afterwards (#1557): the marker is this screen's own text and opens with the very bracket the
+        // substitution exists to remove, so joining it first would turn the screen's marker into a lie.
         var named = cut is null
             ? string.Empty
-            : ", the repeated member is named \"" + new string(Array.FindAll(cut.ToCharArray(), c => !char.IsControl(c) && char.GetUnicodeCategory(c) is not (UnicodeCategory.Format or UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator))) + "\"";
+            : ", the repeated member is named \"" + new string(Array.FindAll(cut.ToCharArray(), c => !char.IsControl(c) && char.GetUnicodeCategory(c) is not (UnicodeCategory.Format or UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator))).Replace('[', '(') + (truncated ? NameTruncationMarker : string.Empty) + "\"";
 
         _logger.LogWarning(
             "Refused the OpenID {Document} for provider {Provider}: {Reason}{Member}{Cause}. The read fails closed rather than handing on a document whose meaning depends on which reader parses it.",

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -175,7 +175,7 @@ internal sealed class SamlAssertionValidator
             // (a helper-boundary sanitizer is not recognized by CodeQL).
             _logger.LogWarning(
                 "SAML assertion replay cache refused a new assertion for provider {Provider}: the cache is at capacity (warning throttled). This indicates extreme login volume or an identity provider replaying signed assertions.",
-                provider?.ReplaceLineEndings(string.Empty));
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         return consumed;
@@ -304,7 +304,7 @@ internal sealed class SamlAssertionValidator
             // prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
             _logger.LogWarning(
                 "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
-                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
+                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return false;
         }
 

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -125,7 +125,7 @@ internal static class ChallengeNewPathResolver
             // every persist failure is handled identically - but logged so a persistently failing config
             // write stays observable rather than silently accepted forever (mirrors AvatarService's
             // best-effort avatar fetch).
-            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             return derived;
         }
     }

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -557,7 +557,7 @@ internal static class DeclarativeProviderConfig
             logger.LogError(
                 "The declarative SSO configuration at {SourcePath} was rejected and nothing was changed: {Reason}",
                 sourcePath.ReplaceLineEndings(string.Empty),
-                reason.ReplaceLineEndings(string.Empty));
+                reason.ReplaceLineEndings(string.Empty).Replace('[', '('));
         }
 
         return DeclarativeLoadOutcome.Rejected;


### PR DESCRIPTION
# What & why

Closes #1557.

#1555 stopped an identity-provider value from forging a second audit record
inside the audit emitter's own entries, and said plainly what it did not reach:
ordinary plugin lines elsewhere still carried foreign text under the line-ending
strip alone, so the `[SSO Audit] ` marker was still plantable through them and
an unanchored search over the log file still reported logins that never
happened. One of those lines needs no credential at all: the OpenID callback is
unauthenticated by design, and the `error_description` it logs on a refused
redirect is whatever the visitor put in the URL.

I measured the population before changing anything. Inside logging calls
outside `SsoAudit.cs` the tree held 71 line-ending strips, none followed by the
bracket substitution:

```
$ node af01-1557-scan.js G:/Github/wt-sso-1557
in-log-call strips=140 missing-substitution=71
```

Every one of them now carries the same substitution the emitter uses, inline
at the logging call, so CodeQL's log-forging taint tracking still sees both
sanitizers in the argument list. The three host-composed paths in
`DeclarativeProviderConfig` keep the strip alone, for the reason the emitter
rule already gives.

**What holds the property** is a second conformance rule beside the emitter's:
it walks every `.Log<Level>(` and bare `.Log(` argument list in
`SSO-Auth/**/*.cs`, skipping string and character literals and both comment
forms so a parenthesis inside a template cannot end the span early, and refuses
a strip without the substitution behind it. It is sentinel-guarded against a
vacuous pass, and its exempt-list match is by whole identifier.

**The four sites the issue names** are each driven by a forging payload: the
callback `error_description`, the username-sanitization notice on a first
login, the refused `picture` claim, and the SAML role denial's NameID and roles.

**Two more routes the review found** are closed here too, with their own
payload tests. The repeated-member refusal printed a provider-authored JSON
member name through a control-character filter that let the bracket through;
the filtered name is substituted now and the screen's own `[truncated]` marker
is joined afterwards so it stays whole. The avatar fetch handed its exception
object to the log, which a sink renders on the lines AFTER the message, and
`HttpRequestException` quotes the remote host's reason phrase verbatim; that
entry now carries the type and the sanitized message inline and no exception
object.

One pre-existing line needed more than the mechanical edit: the discovery
reader appended its own `[truncated]` marker BEFORE sanitizing, so the
substitution rewrote the reader's marker too. Its own bound test caught it.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: nothing here takes part in an authentication
      decision; it is log text past the decision. No return value or control
      flow changes except the avatar catch, which already swallowed the
      exception and still does.
- [x] No secrets logged; no message template gained a value class. Only the
      rendering of values already printed changes, plus the avatar catch, which
      now prints the exception type and message instead of the exception
      object.
- [x] A security review was performed. Record below.
- [x] Review record, below.
- [x] Log inputs from the IdP are sanitized inline at the log call, and that
      inline shape is now enforced tree-wide rather than for one file.

### Review record

Two refute-by-default lenses read the first commit and its callers, and one
read the fixed state. **No second reader is available on this board; what
stands in place of one is independent lenses over the same state, not a reading
by a second person.**

| Lens                  | Verdict | Raised                      |
| --------------------- | ------- | --------------------------- |
| correctness (round 1) | FAIL    | 4: one high, one medium     |
| bypass (round 1)      | FAIL    | 3: one high, one medium     |
| bypass (fixed state)  | PASS    | 1: three pre-existing sites |

Counts as raised across round 1, deduplicated: **CONFIRMED 2 / PLAUSIBLE 3.**

- CONFIRMED, HIGH, both lenses: `RepeatedMemberScreen.Refuse` printed the
  repeated JSON member name through a filter that passes `[`. FIX: substituted
  on the filtered name, marker joined after; two payload tests.
- CONFIRMED, MEDIUM, both lenses: `AvatarService` logged the exception object,
  whose message quotes the avatar host's HTTP reason phrase; one lens
  reproduced the message against the installed runtime. FIX: type and
  sanitized message inline, no exception object; one payload test.
- PLAUSIBLE, LOW: the exempt-list suffix match also matched `resource.` for
  `source`. FIX: whole-identifier match.
- PLAUSIBLE, LOW: the span walker matched no bare `.Log(` call and did not skip
  block comments; neither shape exists in the tree today. FIX: both handled.
- PLAUSIBLE, LOW, fixed-state lens: three SAML signing-failure messages were
  logged with no sanitizer at all; their exception types are filtered to key-load
  and XML-writer failures whose messages quote at most one character, so none
  can carry the marker. FIX anyway, so the rule covers them.
- PLAUSIBLE, LOW: a fullwidth bracket survives the substitution. DECLINE with
  the reason in the changelog: it is not the marker's byte, `grep -F` does not
  match it, and a tool that normalises text before matching is outside what
  the plugin can promise. Not measured: a Windows console sink under a legacy
  code page may best-fit it to ASCII; the file sink does not.

## Quality checklist

- [x] No duplicated logic: the rule reuses the emitter rule's constants and
      exempt list; the span walker is one private helper.
- [x] No more code than the problem requires: 71 one-token edits, one rule,
      six payload tests, two reorderings so a plugin-owned marker survives.
- [x] Self-documenting; comments explain why a marker is joined after the
      substitution and why one value carries no strip.
- [x] Architecture-conformance tests pass; the new structural property is
      locked in as `EveryForeignValueAnyPluginLogLinePrints_CarriesBothInlineSanitizers`.
- [x] Docs impact: the changelog entry is included, with the disclosure of
      what the rule cannot see. No README or wiki page documents log-line
      rendering, so none changes.

## Verification

- [x] `dotnet build --warnaserror` is green on net9.0 and net10.0 (0 warnings).
- [x] The full suite is green on both: net9.0 3817 tests, net10.0 3818 tests,
      4 skipped on each (pre-existing skips).
- [x] Prettier is clean for `CHANGELOG.md`.

Each guard was proven to bite by deletion: stripping the substitution off the
four named sites turned the four payload tests and the tree-wide rule red (5 of
7 in the targeted run); the two review-found sites each carry a row that goes
red on the same one-token deletion.

## Notes

The fixed-state lens read every logging call in `SSO-Auth/` (127 by its own
extraction) and decompiled the IdentityModel discovery read with ilspycmd to
confirm that the reader's catch-all can only see a cancellation exception, never
remote text; every other failure arrives as `discovery.Error`, which is covered.

What the rule cannot see is stated in the changelog entry and in the test's
own comment: a foreign value that reaches a log line by a route other than the
line-ending strip is caught by review and by a payload test, not by the rule.
Both routes found tonight were of that kind. A value logged with no sanitizer
at all remains CodeQL's question.

The avatar catch loses the stack trace for a best-effort fetch; the message
still names the exception type and what failed.
