### PR TITLE
Pass the caller's lifetime into the hardened OpenID discovery read [#1558]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,31 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A discovery read whose caller has gone away now ends with the caller
+  (#1558).** The hardened OpenID discovery read took no cancellation token, so
+  nothing a caller could do abandoned it: the only bound was the per-request
+  fetch timeout, and the library makes a second request for the JWKS the
+  document names, so a challenge whose browser had already left held its
+  outbound connection for up to two of those. The read now takes the caller's
+  lifetime and hands it to every request it makes, and the login challenge and
+  the admin Test-connection probe pass their request lifetime down. A read the
+  caller abandoned is neither logged as a fail-closed read nor counted against
+  the provider, because it is neither; it answers a fixed 400 that nobody
+  reads, deliberately not an exception, because the server's own middleware
+  logs every escaped exception at Error and a closed tab must not become one.
+  A read the caller is still waiting on that hits the timeout is unchanged: it
+  fails closed, is logged, and counts, exactly as before.
+
+  **The back-channel logout deliberately does NOT pass its request lifetime
+  down**, and the review of this change is where that was decided. The request
+  there is the identity provider's POST, and the party whose outcome depends on
+  the read is the user the provider ordered signed out. A provider whose
+  outbound socket timeout is shorter than the discovery read - Keycloak's
+  default is five seconds - would abort the POST, and a read ended by that
+  abort would turn an ordered termination into a silent no-op, the shape #1183
+  closed. So that read runs to its own budget whether or not the provider is
+  still listening, and a test pins it.
+
 - **A declarative document that could not be written still locked its providers
   against the settings page (#1534).** A provider document mounted as a file or
   set through the environment freezes the providers it names, so the settings

--- a/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
+++ b/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
@@ -55,7 +55,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf", OidSecret = OidSecretSentinel };
         var factory = FactoryFor(Serve(FullDiscovery(Authority)));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Ok);
         Assert.Contains(result.Details, d => d.Contains(Authority, StringComparison.Ordinal) && d.StartsWith("Issuer:", StringComparison.Ordinal));
@@ -72,7 +72,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = "https://idp-unreachable.example.com", OidClientId = "jf" };
         var factory = FactoryFor(_ => throw new HttpRequestException("unreachable"));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.Contains("discovery document", result.Message, StringComparison.OrdinalIgnoreCase);
@@ -93,7 +93,7 @@ public class ProviderConnectionTesterTests
         var repeated = FullDiscovery(Authority).Insert(1, "\"issuer\":\"https://attacker.example\",");
         var logger = new CapturingLogger();
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", FactoryFor(Serve(repeated)), logger);
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", FactoryFor(Serve(repeated)), logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.Contains(RepeatedMemberScreen.RefusalReason, result.Message, StringComparison.Ordinal);
@@ -123,7 +123,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
         var factory = FactoryFor(_ => JsonWithCharset(FullDiscovery(Authority), "zzMarkerCharsetzz"));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.Contains(RepeatedMemberScreen.UninspectableReason, result.Message, StringComparison.Ordinal);
@@ -145,7 +145,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = "https://idp-unreachable.example.com", OidClientId = "jf" };
         var factory = FactoryFor(_ => throw new HttpRequestException("unreachable"));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.Contains("/.well-known/openid-configuration", result.Message, StringComparison.Ordinal);
@@ -161,7 +161,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = endpoint, OidClientId = "jf" };
         var factory = FactoryFor(Serve(FullDiscovery(Authority)));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
     }
@@ -180,7 +180,7 @@ public class ProviderConnectionTesterTests
             return Json(FullDiscovery(Authority));
         });
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.False(contacted); // no endpoint -> no outbound fetch
@@ -200,7 +200,7 @@ public class ProviderConnectionTesterTests
             return Json(FullDiscovery(httpAuthority));
         });
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Ok);
         Assert.False(fetched);
@@ -212,7 +212,7 @@ public class ProviderConnectionTesterTests
         var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf", OidSecret = OidSecretSentinel };
         var factory = FactoryFor(Serve(FullDiscovery(Authority)));
 
-        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         AssertNoSecret(result, OidSecretSentinel);
     }
@@ -239,13 +239,13 @@ public class ProviderConnectionTesterTests
         var strict = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
         var optedIn = new OidConfig { OidEndpoint = Authority, OidClientId = "jf", AllowPrivateNetworkAddresses = true };
 
-        await ProviderConnectionTester.TestOidcAsync(strict, "public-idp", factory, Logger());
+        await ProviderConnectionTester.TestOidcAsync(strict, "public-idp", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotEmpty(requested);
         Assert.All(requested, name => Assert.Equal(SsoHttp.OutboundClientName, name));
 
         requested.Clear();
-        await ProviderConnectionTester.TestOidcAsync(optedIn, "lan-idp", factory, Logger());
+        await ProviderConnectionTester.TestOidcAsync(optedIn, "lan-idp", factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotEmpty(requested);
         Assert.All(requested, name => Assert.Equal(SsoHttp.PrivateOutboundClientName, name));

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
@@ -50,6 +51,31 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
             c.OidConfigs["kc"] = Provider(backChannel: true);
             c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
         });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task ProviderThatWentAway_StillGetsItsOrderedTerminationPerformed()
+    {
+        // #1558's review refused wiring the POST's request lifetime into this read, and this row is what keeps
+        // it refused. The party whose outcome depends on the read is the user the provider ordered signed
+        // out, not the provider: a provider whose outbound socket timeout is shorter than the discovery read
+        // aborts the POST, and a read ended by that abort would turn the ordered termination into a silent
+        // no-op - the #1183 shape, produced by any attacker who can slow the server-to-provider path. So an
+        // aborted POST changes nothing: discovery is read to its own budget, the token validates, and the
+        // session is revoked. Kills: passing HttpContext.RequestAborted into ValidateBackChannelLogoutAsync.
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        });
+        harness.Controller.HttpContext.RequestAborted = new CancellationToken(canceled: true);
 
         var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
 

--- a/SSO-Auth.Tests/Http/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidChallengeTests.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -120,6 +122,34 @@ public class SSOControllerOidChallengeTests
         // per-test reset of the static state store (#289) keeps the added authorize state from leaking.
         var redirect = Assert.IsType<RedirectResult>(result);
         Assert.StartsWith(authority + "/authorize", redirect.Url);
+    }
+
+    [Fact]
+    public async Task OidChallenge_BrowserThatWentAway_EndsTheDiscoveryReadQuietly()
+    {
+        // #1558: the challenge is the login-path caller with a request lifetime, and it passes that lifetime
+        // down to the discovery read. A challenge whose browser is already gone answers a fixed 400 that
+        // nobody reads, and writes NOTHING at Warning or above: not the fail-closed warning that names the
+        // provider as unreadable, and not an exception into the host pipeline, whose middleware logs every
+        // throw at Error and answers 500 - so a closed tab would otherwise become an Error entry naming
+        // nothing. Kills: dropping the token from the challenge's read, or letting the cancellation escape.
+        const string authority = "https://idp-gone.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+            },
+            httpResponder: request => Json(Discovery(authority)));
+        harness.Controller.HttpContext.RequestAborted = new CancellationToken(canceled: true);
+
+        var result = await harness.Controller.OidChallenge("kc");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.DoesNotContain(harness.ControllerLog.Entries, e => e.Level >= LogLevel.Warning);
     }
 
     private static string Discovery(string authority) =>

--- a/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
@@ -15,6 +16,7 @@ using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -90,6 +92,25 @@ public class SSOControllerTestConnectionTests
         Assert.True(result.Ok);
         Assert.Contains(result.Details, d => d.StartsWith("Issuer:", StringComparison.Ordinal) && d.Contains(Authority, StringComparison.Ordinal));
         Assert.Contains(result.Details, d => d.StartsWith("JWKS: reachable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task OidTest_AdminThatWentAway_AnswersQuietlyWithoutAProviderVerdict()
+    {
+        // #1558: the probe passes the admin request's lifetime down to the discovery read. A request already
+        // gone answers a fixed 400 - no verdict about the provider, since none was reached, and nothing at
+        // Warning or above: not the reader's fail-closed warning, and not an exception into the host, whose
+        // middleware would log it at Error and answer 500. Kills: dropping the token from the probe's read,
+        // or letting the cancellation escape the endpoint.
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig { Enabled = true, OidEndpoint = Authority, OidClientId = "jf", OidSecret = OidSecretSentinel },
+            httpResponder: Responder);
+        harness.Controller.HttpContext.RequestAborted = new CancellationToken(canceled: true);
+
+        var result = await harness.Controller.OidTest("kc");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.DoesNotContain(harness.ControllerLog.Entries, e => e.Level >= LogLevel.Warning);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Http/SsoMetricsCallSiteTests.cs
+++ b/SSO-Auth.Tests/Http/SsoMetricsCallSiteTests.cs
@@ -89,7 +89,8 @@ public class SsoMetricsCallSiteTests
             new OidcClientOptions { Authority = Authority },
             "kc",
             factory,
-            new CapturingLogger());
+            new CapturingLogger(),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Equal(1, Counter(SsoMetrics.ProviderFetchErrorTotal, "stage", nameof(ProviderFetchStage.Discovery)));

--- a/SSO-Auth.Tests/Net/ProviderResponseSizeLimitDiscoveryTests.cs
+++ b/SSO-Auth.Tests/Net/ProviderResponseSizeLimitDiscoveryTests.cs
@@ -43,7 +43,7 @@ public sealed class ProviderResponseSizeLimitDiscoveryTests
             Content = new OversizeJson((int)ProviderResponseSizeLimit.MaxProviderResponseBytes + 4096),
         });
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(OidcDiscoveryResult.Unavailable, result);
 
@@ -82,7 +82,7 @@ public sealed class ProviderResponseSizeLimitDiscoveryTests
                 ? Json("{\"keys\":[]}")
                 : Json(FullDiscovery));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotEqual(OidcDiscoveryResult.Unavailable, result);
         Assert.Empty(logger.Entries);

--- a/SSO-Auth.Tests/Oidc/DuplicateJsonKeyPostureTests.cs
+++ b/SSO-Auth.Tests/Oidc/DuplicateJsonKeyPostureTests.cs
@@ -128,7 +128,7 @@ public class DuplicateJsonKeyPostureTests
         var http = new CountingFactory(Serve(hostile));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         // Neither reader produced anything: no metadata for the library's side, no facts for the plugin's.
         Assert.False(result.Available);

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderCancellationTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderCancellationTests.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Api.Metrics;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The caller's lifetime reaches the hardened discovery read (#1558). Before this, <c>ReadAsync</c> took no
+/// token and the only bound on a read whose caller had gone away was <see cref="OidcDiscoveryReader.FetchTimeout"/>,
+/// per request rather than per call - and the library makes a second request for the JWKS, so an abandoned
+/// challenge held its outbound connection for up to two of them. The rows here pin three things apart: the
+/// token reaches the request and ends the read well inside the timeout; a read the caller abandoned is
+/// neither logged as a fail-closed read nor counted against the provider; and a read the caller is still
+/// waiting on, ended by the transport with the same exception type, still fails closed exactly as before.
+/// Two rows read the process-wide metrics store, so the class sits in the non-parallel controller collection.
+/// </summary>
+[Collection("SSOController")]
+public class OidcDiscoveryReaderCancellationTests
+{
+    private const string Authority = "https://idp-cancel.example.com";
+
+    [Fact]
+    public async Task ACallerThatWentAway_EndsTheReadInsideTheTimeout_AndItPropagates()
+    {
+        // Kills: dropping the token from the GetDiscoveryDocumentAsync call. The transport answers only when
+        // the token it was handed fires, so a read that never handed it down waits for FetchTimeout instead.
+        SsoMetricsStore.ResetForTests();
+        var logger = new CapturingLogger();
+        var factory = FactoryFor(new WaitsForCancellationHandler());
+        using var caller = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var clock = Stopwatch.StartNew();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger, cancellationToken: caller.Token));
+
+        clock.Stop();
+        Assert.True(
+            clock.Elapsed < OidcDiscoveryReader.FetchTimeout / 2,
+            $"the read took {clock.Elapsed} to notice a caller that left after 200 ms; FetchTimeout is {OidcDiscoveryReader.FetchTimeout}");
+
+        // Not a provider failure: no fail-closed warning for a browser that closed its tab, and the fetch
+        // error counter an operator alerts on does not move for it.
+        Assert.DoesNotContain(logger.Entries, e => e.Level >= LogLevel.Warning);
+        Assert.Equal(0, DiscoveryFetchErrors());
+    }
+
+    [Fact]
+    public async Task ATransportCancellation_WithTheCallerStillWaiting_StillFailsClosed()
+    {
+        // Kills: widening the rethrow to every OperationCanceledException. HttpClient ends a read that hit its
+        // timeout with the same exception type, and THAT read is a provider failure: it returns Unavailable,
+        // logs the fail-closed warning and counts against the provider, exactly as before the token arrived.
+        SsoMetricsStore.ResetForTests();
+        var logger = new CapturingLogger();
+        var factory = FactoryFor(new StubHttpMessageHandler(_ => throw new TaskCanceledException("the request timed out")));
+
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Available);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("fails closed", StringComparison.Ordinal));
+        Assert.Equal(1, DiscoveryFetchErrors());
+    }
+
+    [Fact]
+    public async Task TheAdminProbe_PassesItsRequestLifetimeDown()
+    {
+        // The probe is the second caller with a request lifetime the issue names. A pre-cancelled token
+        // must surface as the cancellation rather than as a Failure result naming connectivity.
+        var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
+        var factory = FactoryFor(new WaitsForCancellationHandler());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => ProviderConnectionTester.TestOidcAsync(config, "kc", factory, new CapturingLogger(), new CancellationToken(canceled: true)));
+    }
+
+    private static long DiscoveryFetchErrors() =>
+        SsoMetricsStore.Snapshot()
+            .Where(entry => entry.Series.Equals(new SsoMetricSeries(SsoMetrics.ProviderFetchErrorTotal, "stage", nameof(ProviderFetchStage.Discovery))))
+            .Select(entry => entry.Value)
+            .FirstOrDefault();
+
+    private static OidcClientOptions OptionsFor(string authority)
+    {
+        var options = new OidcClientOptions { Authority = authority };
+        options.Policy.Discovery.RequireHttps = true;
+        return options;
+    }
+
+    private static IHttpClientFactory FactoryFor(HttpMessageHandler handler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(handler, disposeHandler: false));
+        return factory;
+    }
+
+    // Answers only when the token the transport was handed fires. A read that did not pass the caller's token
+    // down reaches this handler with HttpClient's own timeout token alone, and waits for FetchTimeout.
+    private sealed class WaitsForCancellationHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException("unreachable: the delay above ends only by cancellation");
+        }
+    }
+}

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
@@ -141,7 +141,7 @@ public class OidcDiscoveryReaderErrorBoundTests
         options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(Authority).GetLeftPart(UriPartial.Authority));
         options.Policy.Discovery.ValidateEndpoints = false;
 
-        return await OidcDiscoveryReader.ReadAsync(options, "bound", factory, logger);
+        return await OidcDiscoveryReader.ReadAsync(options, "bound", factory, logger, cancellationToken: TestContext.Current.CancellationToken);
     }
 
     private static string FailClosedWarning(CapturingLogger logger)

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -65,7 +65,7 @@ public class OidcDiscoveryReaderTests
     {
         var http = new CountingFactory(Serve(FullDiscovery(Authority)));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
         // Facts read from the SAME discovery response the metadata is built from (#450).
@@ -93,7 +93,7 @@ public class OidcDiscoveryReaderTests
             + "\"authorization_response_iss_parameter_supported\":true}";
         var http = new CountingFactory(Serve(discovery));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
         Assert.False(result.Facts.PkceS256);
@@ -114,7 +114,7 @@ public class OidcDiscoveryReaderTests
             + "\"code_challenge_methods_supported\":[\"S256\"]}";
         var http = new CountingFactory(Serve(discovery));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
         Assert.True(result.Facts.PkceS256);
@@ -128,7 +128,7 @@ public class OidcDiscoveryReaderTests
         // than proceeding on unverified facts (#450). Never a tolerant default that silently weakens iss.
         var http = new CountingFactory(_ => throw new HttpRequestException("unreachable"));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Null(result.ProviderInformation);
@@ -153,7 +153,7 @@ public class OidcDiscoveryReaderTests
         const string httpAuthority = "http://idp-plaintext.example.com";
         var http = new CountingFactory(Serve(FullDiscovery(httpAuthority)));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(httpAuthority, requireHttps: true), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(httpAuthority, requireHttps: true), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Equal(0, http.DiscoveryRequests); // policy rejected the address before any fetch
@@ -168,7 +168,7 @@ public class OidcDiscoveryReaderTests
         var duplicated = FullDiscovery(Authority).Insert(1, $"\"issuer\":\"https://attacker.example\",");
         var http = new CountingFactory(Serve(duplicated));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
     }
@@ -181,7 +181,7 @@ public class OidcDiscoveryReaderTests
         // screen's body read leaves the response readable for the library that parses it afterwards.
         var http = new CountingFactory(Serve(FullDiscovery(Authority)));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
         Assert.Equal(Authority, result.ProviderInformation.IssuerName);
@@ -204,7 +204,7 @@ public class OidcDiscoveryReaderTests
         var duplicated = FullDiscovery(Authority).TrimEnd('}') + $",\"jwks_uri\":\"{attackerJwks}\"}}";
         var http = new CountingFactory(Serve(duplicated));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Equal(1, http.DiscoveryRequests);
@@ -223,7 +223,7 @@ public class OidcDiscoveryReaderTests
         // reader that materialises it.
         var http = new CountingFactory(Serve(FullDiscovery(Authority), "{\"keys\":[{\"kty\":\"RSA\",\"kty\":\"oct\"}]}"));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Equal(1, http.JwksRequests);
@@ -241,7 +241,7 @@ public class OidcDiscoveryReaderTests
             + "{\"kty\":\"RSA\",\"use\":\"sig\",\"alg\":\"RS256\",\"kid\":\"b2\",\"n\":\"yHPs\",\"e\":\"AQAB\"}]}";
         var http = new CountingFactory(Serve(FullDiscovery(Authority), twoKeys));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
         Assert.NotNull(result.ProviderInformation.KeySet);
@@ -261,7 +261,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(Serve("{\"a\\ud800\":1}"));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         AssertScreenRefused(logger, http, RepeatedMemberScreen.UninspectableReason);
@@ -278,7 +278,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(Serve(body));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         AssertScreenRefused(logger, http, RepeatedMemberScreen.UninspectableReason);
@@ -306,7 +306,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(_ => JsonWithCharset(FullDiscovery(Authority), MarkerCharset));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         AssertScreenRefused(logger, http, RepeatedMemberScreen.UninspectableReason);
@@ -340,7 +340,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UncopyableContent() });
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.DoesNotContain(logger.Entries, e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));
@@ -357,7 +357,7 @@ public class OidcDiscoveryReaderTests
         // that had established nothing about it.
         var http = new CountingFactory(ServeWithEncoding(FullDiscovery(Authority), Encoding.Unicode));
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(result.Available);
     }
@@ -375,7 +375,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(ServeWithEncoding(duplicated, Encoding.Unicode));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         AssertScreenRefused(logger, http, RepeatedMemberScreen.RefusalReason);
@@ -395,7 +395,7 @@ public class OidcDiscoveryReaderTests
         });
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.DoesNotContain(logger.Entries, e => e.Message.Contains(RepeatedMemberScreen.UninspectableReason, StringComparison.Ordinal));
@@ -424,7 +424,7 @@ public class OidcDiscoveryReaderTests
             Content = new StringContent(hostile, Encoding.UTF8, "application/json"),
         });
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger());
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         Assert.Null(result.ProviderInformation);
@@ -477,7 +477,7 @@ public class OidcDiscoveryReaderTests
         var http = new CountingFactory(Serve(duplicated));
         var logger = new CapturingLogger();
 
-        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
         var entry = Assert.Single(logger.Entries, e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));

--- a/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
+++ b/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
@@ -250,7 +250,7 @@ public class RefusalEntryMemberNameTests
         options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(Authority).GetLeftPart(UriPartial.Authority));
         options.Policy.Discovery.ValidateEndpoints = false;
 
-        var result = await OidcDiscoveryReader.ReadAsync(options, "name", factory, logger);
+        var result = await OidcDiscoveryReader.ReadAsync(options, "name", factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(result.Available);
 

--- a/SSO-Auth.Tests/Oidc/RoleClaimScopeScreenTests.cs
+++ b/SSO-Auth.Tests/Oidc/RoleClaimScopeScreenTests.cs
@@ -164,7 +164,7 @@ public class RoleClaimScopeScreenTests
         var http = new StubFactory(Unreadable);
         var logger = new CapturingLogger();
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+        var discovery = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.False(discovery.Available);
         Assert.Equal(OidcDiscoveryRefusal.Uninspectable, discovery.Refusal);

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -205,7 +206,20 @@ internal sealed class OidcLoginService
             return secretError;
         }
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
+        OidcDiscoveryResult discovery;
+        try
+        {
+            discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses, request.HttpContext.RequestAborted).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (request.HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // The browser left before discovery answered (#1558). Not a refusal and not a provider failure,
+            // so no warning and no fetch-error count - and not an exception either: the host's exception
+            // middleware catches every throw, logs it at Error and answers 500, so propagating would turn a
+            // closed tab into an Error entry that names nothing. A fixed 400 to a socket nobody reads instead.
+            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login.");
+        }
+
         if (!discovery.Available)
         {
             // Fail closed (#450): the discovery document the login itself needs could not be read, so there
@@ -782,6 +796,14 @@ internal sealed class OidcLoginService
     /// </summary>
     private async Task<OidcDiscoveryResult> ReadDiscoveryForLogoutAsync(OidcClientOptions options, string provider, OidConfig config)
     {
+        // DELIBERATELY NO CALLER TOKEN (#1558). The request whose lifetime this read runs under is the
+        // provider's POST, and the party whose outcome depends on the read is the user whose session the
+        // provider ordered terminated. A provider whose outbound socket timeout is shorter than this read
+        // - Keycloak's default is five seconds against a ten-second fetch - would abort the POST, and a read
+        // ended by that abort turns an ordered termination into a silent no-op, which is exactly what #1183
+        // closed and what the docstring above says an attacker on the server-to-provider path could produce
+        // on purpose. So this read runs to its own budget whether or not the provider is still listening,
+        // and the review of #1558 is where wiring the request lifetime in here was refused.
         for (var attempt = 1; ; attempt++)
         {
             var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);

--- a/SSO-Auth/Api/Http/ProviderConnectionTester.cs
+++ b/SSO-Auth/Api/Http/ProviderConnectionTester.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -43,8 +44,9 @@ internal static class ProviderConnectionTester
     /// <param name="provider">The provider name, for the reader's fail-closed warning only.</param>
     /// <param name="httpClientFactory">The shared HTTP client factory the hardened discovery fetch is built over.</param>
     /// <param name="logger">The logger the reader logs its fail-closed warning to (never a secret).</param>
+    /// <param name="cancellationToken">The admin request's own lifetime, passed down to the discovery read (#1558).</param>
     /// <returns>The probe result, safe to return to an administrator.</returns>
-    internal static async Task<ProviderTestResult> TestOidcAsync(OidConfig config, string provider, IHttpClientFactory httpClientFactory, ILogger logger)
+    internal static async Task<ProviderTestResult> TestOidcAsync(OidConfig config, string provider, IHttpClientFactory httpClientFactory, ILogger logger, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(config.OidEndpoint))
         {
@@ -64,7 +66,7 @@ internal static class ProviderConnectionTester
 
         // The probe uses the provider's own transport tier, so "Test connection" reports what the login will
         // actually do - an opted-in provider on the admin's LAN must not fail here and then succeed at login.
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, httpClientFactory, logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
+        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, httpClientFactory, logger, config.AllowPrivateNetworkAddresses, cancellationToken).ConfigureAwait(false);
         if (!discovery.Available)
         {
             // The reader already logged the fail-closed warning (with the library error, never a secret).

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -957,7 +957,17 @@ public class SSOController : ControllerBase
             return NotFound(NoMatchingProviderMessage);
         }
 
-        return Ok(await ProviderConnectionTester.TestOidcAsync(config, provider, _httpClientFactory, _logger).ConfigureAwait(false));
+        try
+        {
+            return Ok(await ProviderConnectionTester.TestOidcAsync(config, provider, _httpClientFactory, _logger, HttpContext.RequestAborted).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // The admin's browser left before the probe answered (#1558). The host's exception middleware
+            // would log a propagated cancellation at Error and answer 500; a probe nobody is waiting for is
+            // neither, so it answers a fixed 400 with no log line and no provider verdict.
+            return BadRequest("The request was cancelled before the probe finished.");
+        }
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
@@ -78,6 +79,11 @@ internal static class OidcDiscoveryReader
     /// transient failure, a policy rejection (e.g. non-HTTPS under <c>RequireHttps</c>), a malformed document,
     /// or a document refused by <see cref="RepeatedMemberScreen"/> for naming a member twice all return
     /// <c>Unavailable</c> so the caller fails the login closed rather than proceeding on unverified facts.
+    /// The one exception is the caller's own <paramref name="cancellationToken"/> (#1558): a read the caller
+    /// abandoned is neither a provider failure nor a login decision, so it propagates as
+    /// <see cref="OperationCanceledException"/> instead of being logged as a fail-closed read and counted
+    /// against the provider. <see cref="FetchTimeout"/> still ends a read the caller is waiting on, and that
+    /// path is unchanged: it arrives with the token NOT cancelled and returns <c>Unavailable</c>.
     /// </summary>
     /// <param name="options">The OidcClient options whose <c>Authority</c> and discovery policy the read uses - the same the login is built with.</param>
     /// <param name="provider">The provider name, for the failure warning only.</param>
@@ -87,11 +93,22 @@ internal static class OidcDiscoveryReader
     /// The provider's <c>AllowPrivateNetworkAddresses</c> opt-in, selecting the private-permitted outbound
     /// transport for this one read (#1179). Defaults to <see langword="false"/> - the full guard.
     /// </param>
+    /// <param name="cancellationToken">
+    /// The caller's lifetime, passed to every request this read makes - the well-known document and the JWKS
+    /// it points at (#1558). A request that has gone away no longer holds the outbound connection until
+    /// <see cref="FetchTimeout"/> runs out on each of them.
+    /// </param>
     /// <returns>The facts and provider metadata from the one discovery response, or <see cref="OidcDiscoveryResult.Unavailable"/>.</returns>
-    internal static async Task<OidcDiscoveryResult> ReadAsync(OidcClientOptions options, string provider, IHttpClientFactory httpClientFactory, ILogger logger, bool allowPrivateNetworkAddresses = false)
+    internal static async Task<OidcDiscoveryResult> ReadAsync(OidcClientOptions options, string provider, IHttpClientFactory httpClientFactory, ILogger logger, bool allowPrivateNetworkAddresses = false, CancellationToken cancellationToken = default)
     {
         try
         {
+            // A caller that has already gone away opens no outbound connection at all (#1558). The transport
+            // would notice the token on its own at the first socket operation; checking here first keeps a
+            // dead request from spending a connection, and it is the one place a test can observe the wiring
+            // without a transport that honours cancellation.
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var client = SsoHttp.CreateClient(httpClientFactory, allowPrivateNetworkAddresses);
             client.Timeout = FetchTimeout;
 
@@ -104,11 +121,13 @@ internal static class OidcDiscoveryReader
             using var screen = new RepeatedMemberScreen(client, provider, logger);
             using var invoker = new HttpMessageInvoker(screen, disposeHandler: false);
 
-            var discovery = await invoker.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
-            {
-                Address = options.Authority,
-                Policy = options.Policy.Discovery,
-            }).ConfigureAwait(false);
+            var discovery = await invoker.GetDiscoveryDocumentAsync(
+                new DiscoveryDocumentRequest
+                {
+                    Address = options.Authority,
+                    Policy = options.Policy.Discovery,
+                },
+                cancellationToken).ConfigureAwait(false);
 
             if (discovery.IsError)
             {
@@ -167,6 +186,15 @@ internal static class OidcDiscoveryReader
             };
 
             return OidcDiscoveryResult.From(facts, providerInformation);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller went away (#1558). Not a fail-closed read and not a provider fetch failure: logging
+            // it as one would tell an operator the provider is unhealthy for a browser that closed its tab,
+            // and counting it would move the fetch-error gauge for the same non-event. The filter keeps the
+            // timeout on its old path: HttpClient ends a slow read with the same exception type, but with
+            // THIS token still live, so it falls through to the arm below exactly as before.
+            throw;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
# What & why

Closes #1558.

`OidcDiscoveryReader.ReadAsync` took no `CancellationToken`, so no caller could
abandon a discovery fetch. The only bound was `FetchTimeout`, per request rather
than per call, and the library's read makes a second request for the JWKS the
document names, so a challenge whose browser had already gone held its outbound
connection for up to two of those:

```
$ git grep -n 'internal static async Task<OidcDiscoveryResult> ReadAsync' origin/4.4 -- SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
origin/4.4:SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs:91:    internal static async Task<OidcDiscoveryResult> ReadAsync(OidcClientOptions options, string provider, IHttpClientFactory httpClientFactory, ILogger logger, bool allowPrivateNetworkAddresses = false)
```

`ReadAsync` now takes an optional token, checks it once before opening a client
so an already-aborted request opens no outbound connection at all, and hands it
to `GetDiscoveryDocumentAsync`. The login challenge passes its request lifetime
from its `HttpRequest` and the admin Test-connection probe from the
controller's `RequestAborted`. The link import is not among the callers, as the
issue's own correction records: it reads no discovery.

**The back-channel logout deliberately does NOT pass its request lifetime
down.** The first version did, mechanically, and the review refused it: that
request is the identity provider's POST, and the party whose outcome depends on
the read is the user the provider ordered signed out. A provider whose outbound
socket timeout is shorter than the read - Keycloak's documented default is five
seconds against a ten-second fetch - aborts the POST, and a read ended by that
abort turns an ordered termination into a silent no-op, the shape #1183 closed.
The read runs to its own budget whether or not the provider is still listening,
and `ProviderThatWentAway_StillGetsItsOrderedTerminationPerformed` pins it.

**The two callers that do pass it answer a fixed 400 rather than throwing.**
The review decompiled the running container's `Jellyfin.Api.dll` (10.11.11):
its exception middleware catches every exception, a cancellation included, logs
it at Error and answers 500. So a closed tab propagating out of the challenge
would have become an Error entry naming nothing. Both callers catch the
cancellation when their own `RequestAborted` fired and answer a 400 nobody
reads, with nothing at Warning or above.

**The rethrow is filtered on the caller's token, deliberately.** `HttpClient`
ends a timed-out read with the same exception type, and that read IS a provider
failure. Only a cancellation the caller asked for propagates; the timeout still
returns `Unavailable`, logs the fail-closed warning and counts against the
provider exactly as before. A read the caller abandoned is neither logged as a
fail-closed read nor counted, because it is neither.

The 37 existing test call sites of `ReadAsync` and `TestOidcAsync` now pass
`TestContext.Current.CancellationToken`, as xUnit1051 asks under
`--warnaserror`.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no validation is relaxed. A cancelled read never
      returns a result, so nothing downstream can mistake it for an available
      document; the two callers that see it answer a fixed 400 and mint nothing.
      The timeout path is byte-for-byte the old one, and the back-channel logout
      read is untouched.
- [x] No secrets logged; no log line changes content.
- [x] A security review was performed. Record below.
- [x] Review record, below.
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged
      by this change.

### Review record

One refute-by-default lens with the availability question in its brief read
the diff, the three controller actions and their pre-read side effects. **No
second reader is available on this board; what stands in place of one is a
lens over the state, not a reading by a second person.**

| Lens                       | Verdict | Raised                           |
| -------------------------- | ------- | -------------------------------- |
| correctness + availability | FAIL    | 3: one high, one medium, one low |

Counts as raised: **CONFIRMED 2 / PLAUSIBLE 1.**

- CONFIRMED, HIGH: wiring the provider's `RequestAborted` into the back-channel
  logout read let a provider-side socket timeout drop an ordered termination
  silently, and the new test pinned that regression. FIX: the logout read takes
  no caller token; the test now proves an aborted POST still revokes.
- CONFIRMED, MEDIUM: the claim that an abandoned read is "not logged" was false
  in the deployed host, verified by decompiling its exception middleware, which
  logs every escaped exception at Error. FIX: the challenge and the probe catch
  the cancellation when their own request aborted and answer a fixed 400; the
  tests assert nothing at Warning or above.
- PLAUSIBLE, LOW: the reader row asserts the abandoned read ends inside half of
  FetchTimeout against a 200 ms trigger; the class is serialised, so the margin
  is wide. DECLINE: no change.

The lens verified by decompiling IdentityModel 7.0.0 and 8.1.0 that the library
rethrows a cancellation on every leg and folds nothing else into it, so the
reader's `when` filter is the sole discriminator and is correct.

## Quality checklist

- [x] No duplicated logic: one parameter threaded through two callers.
- [x] No more code than the problem requires; the early check is one line and
      the filter one clause.
- [x] Self-documenting; the comments explain why the filter exists and why the
      early check is where a test can observe the wiring.
- [x] Architecture-conformance tests pass. The new test class reads the
      process-wide metrics store, so it sits in the non-parallel controller
      collection, which the conformance suite refused until it did. No new
      structural property to lock in.
- [x] Docs impact: the changelog entry is included; no README or wiki page
      describes the discovery read's timeout behaviour.

## Verification

- [x] `dotnet build --warnaserror` is green on net9.0 and net10.0 (0 warnings).
- [x] The full suite is green on both, on the branch merged with the current
      `4.4`: net9.0 3823 tests, net10.0 3824 tests, 4 skipped on each
      (pre-existing skips).
- [x] Prettier is clean for `CHANGELOG.md`.

I proved each guard bites by inverting it and running the rows. Round one:
dropping the token from the fetch, the early check and the challenge wiring
turned the reader and challenge rows red. Round two: wiring an aborted token
into the logout read turned the termination row red, and letting the
cancellation escape the challenge and the probe turned both quiet-400 rows red.
Restoring each turned them green.

## Notes

The mechanical `TestContext.Current.CancellationToken` pass touches
`OidcDiscoveryReaderTests.cs`, which the issue's comment says another branch
was editing. That branch's work (#1061) is closed and merged; the checkout that
still carries uncommitted edits to the file is not on any remote branch, so
nothing on the remote conflicts with this.
