### PR TITLE
Closed as a duplicate of #1568

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,31 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **The record-marker substitution no longer rewrites the plugin's own words,
+  and reaches a line it had missed (#1566).** The substitution #1557 added is
+  right about identity-provider values and was wrong about the sentences this
+  plugin composes: applied to a whole composed message it rewrote the plugin's
+  text alongside the foreign parts. The link-import refusal is the one that
+  showed it. That message carries the configured-issuer refusal with its own
+  `[truncated]` marker and the validator's list of the characters a provider
+  name may not contain - a list that OPENS with the very bracket the
+  substitution removes - so the log said `(truncated]` and named a shorter list
+  of forbidden characters while the `400` body for the same refusal said neither.
+  **The log and the answer now agree**, because the substitution moved to where
+  the foreign parts enter that sentence: the importer's entry description, the
+  configured-issuer echo and the validator's echoes. Nothing an identity
+  provider or a posted file supplies reaches that line un-neutralised, and the
+  conformance rule names the composed sentence rather than leaving its absence
+  to be noticed.
+
+  The second half is a line that carried NEITHER sanitizer: the one reporting
+  the configured default login provider, written at every SSO login of an
+  SSO-only account. That value arrives from the provider configuration, which a
+  configuration import or a mounted declarative document writes, so it could
+  both split an entry and plant a record - and the rule that holds this property
+  elsewhere cannot see it, because that rule keys on the line-ending strip. It
+  carries both now, with a row that reddens if either is removed.
+
 - **A declarative document that could not be written still locked its providers
   against the settings page (#1534).** A provider document mounted as a file or
   set through the environment freezes the providers it names, so the settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -690,13 +690,13 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   conformance rule names the composed sentence rather than leaving its absence
   to be noticed.
 
-  The second half is a line that carried NEITHER sanitizer: the one reporting
-  the configured default login provider, written at every SSO login of an
-  SSO-only account. That value arrives from the provider configuration, which a
-  configuration import or a mounted declarative document writes, so it could
-  both split an entry and plant a record - and the rule that holds this property
-  elsewhere cannot see it, because that rule keys on the line-ending strip. It
-  carries both now, with a row that reddens if either is removed.
+  A second line of the same kind - the one reporting the configured default
+  login provider, written at every SSO login of an SSO-only account - is **not**
+  fixed here. It carries neither sanitizer and it should carry both, but adding
+  them raises a new high-severity `cs/cleartext-storage-of-sensitive-information`
+  alert: the value can be Jellyfin's default password-provider id, which is a
+  provider type name rather than a credential. Choosing how this repository
+  answers a CodeQL false positive is a decision of its own and #1569 holds it.
 
 - **A discovery read whose caller has gone away now ends with the caller
   (#1558).** The hardened OpenID discovery read took no cancellation token, so

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -35,6 +35,19 @@ public partial class ArchitectureConformanceTests
         "sourcePath",
     };
 
+    // The SENTENCES this plugin composed, which are stripped and NOT substituted for a reason of the same
+    // shape as the list above: a substitution applied to a whole composed message rewrites the plugin's own
+    // words alongside the foreign ones (#1566). The link-import refusal carries the importer's entry
+    // description, the configured-issuer refusal with its own truncation marker, and the validator's list of
+    // the characters a provider name may not contain - and that list opens with the very bracket a
+    // substitution here would take out of it. Each is only correct because the FOREIGN parts are substituted
+    // where they enter the sentence, which is what makes the receiver name worth reading rather than a
+    // dispensation: LinkImport.Describe, OidcConfiguredIssuer.Echo and the validator's echoes.
+    private static readonly string[] AuditComposedSentences =
+    {
+        "composedRefusal",
+    };
+
     private const string LineEndingSanitizer = "ReplaceLineEndings(string.Empty)";
     private const string RecordMarkerSanitizer = "Replace('[', '(')";
 
@@ -150,7 +163,8 @@ public partial class ArchitectureConformanceTests
                 {
                     strips++;
                     var receiver = text[Math.Max(0, start - 40)..start];
-                    var exempt = AuditValuesPrintedExactly.Any(value => IsWholeReceiver(receiver, value));
+                    var exempt = AuditValuesPrintedExactly.Any(value => IsWholeReceiver(receiver, value))
+                        || AuditComposedSentences.Any(value => IsWholeReceiver(receiver, value));
                     var substituted = string.CompareOrdinal(text, end, "." + RecordMarkerSanitizer, 0, RecordMarkerSanitizer.Length + 1) == 0;
 
                     if (exempt == substituted)

--- a/SSO-Auth.Tests/Audit/ComposedRefusalNotRewrittenTests.cs
+++ b/SSO-Auth.Tests/Audit/ComposedRefusalNotRewrittenTests.cs
@@ -4,15 +4,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.SSO_Auth.Api.Authz;
-using Jellyfin.Plugin.SSO_Auth.Api.Provider;
-using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Config;
-using MediaBrowser.Controller.Authentication;
-using MediaBrowser.Controller.Configuration;
-using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Providers;
-using MediaBrowser.Controller.Session;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
@@ -68,54 +60,4 @@ public class ComposedRefusalNotRewrittenTests
         Assert.DoesNotContain(Marker, logged, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public async Task TheDefaultProviderLine_CarriesBothSanitizers()
-    {
-        // The line is written at every SSO login of an enforced account and carried neither sanitizer, so a
-        // value written by a configuration import or a mounted declarative document could both split an
-        // entry and plant a record. The conformance rule cannot see a value with no strip, which is why
-        // this row exists rather than a rule change.
-        const string Forged = "x\r\n[SSO Audit] Login succeeded: root via OpenID provider 'corp' (admin=True).";
-
-        var log = new CapturingLogger();
-        var users = Substitute.For<IUserManager>();
-        var sessions = Substitute.For<ISessionManager>();
-        var user = TestUsers.Named("alice", Guid.Parse("66666666-6666-6666-6666-666666666666"));
-        users.GetUserById(user.Id).Returns(user);
-        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
-
-        var avatar = new Api.Avatar.AvatarService(
-            users,
-            Substitute.For<IProviderManager>(),
-            Substitute.For<IServerConfigurationManager>(),
-            new CapturingLogger(),
-            Api.Net.SsoHttp.UserAgent);
-        var minter = new SessionMinter(users, avatar, sessions, log);
-
-        await minter.MintAsync(
-            new SessionParameters
-            {
-                UserId = user.Id,
-                IsAdmin = false,
-                IsBreakGlassAdmin = false,
-                EnableAuthorization = false,
-                EnableAllFolders = true,
-                EnabledFolders = Array.Empty<string>(),
-                EnableLiveTv = false,
-                EnableLiveTvManagement = false,
-                PermissionGrants = Array.Empty<PermissionGrant>(),
-                MaxParentalRatingScore = null,
-                SyncPlayAccess = null,
-                AvatarUrl = null,
-                DefaultProvider = Forged,
-                AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
-            },
-            () => "203.0.113.9",
-            () => true).ConfigureAwait(true);
-
-        var line = Assert.Single(log.Entries, e => e.Message.Contains("Set default login provider", StringComparison.Ordinal)).Message;
-        Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
-        Assert.DoesNotContain(Marker, line, StringComparison.Ordinal);
-        Assert.Contains("(SSO Audit] Login succeeded", line, StringComparison.Ordinal);
-    }
 }

--- a/SSO-Auth.Tests/Audit/ComposedRefusalNotRewrittenTests.cs
+++ b/SSO-Auth.Tests/Audit/ComposedRefusalNotRewrittenTests.cs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// #1566. The record-marker substitution (#1557) is right about foreign values and wrong about the plugin's
+/// own sentences: applied to a whole composed message it rewrites the plugin's words alongside the
+/// identity provider's. These rows pin both directions - the composed refusal keeps the plugin's brackets,
+/// and the value that carried no sanitizer at all now carries both.
+/// </summary>
+[Collection("SSOController")]
+public class ComposedRefusalNotRewrittenTests
+{
+    private const string Marker = "[SSO Audit] ";
+
+    [Fact]
+    public async Task TheLinkImportRefusal_KeepsThePluginsOwnBrackets_InTheLogAndInTheAnswer()
+    {
+        // The refusal the operator reads carries the validator's own list of the characters a provider name
+        // may not contain, and that list OPENS with the bracket a substitution over the whole message would
+        // take out of it. Before this the log said one thing and the 400 body said another about the same
+        // refusal, and the log was the one that was wrong.
+        // An issuer long enough to be truncated is what puts the plugin's own bracketed marker into the
+        // message: the configured-issuer refusal bounds what it echoes and joins its own "[truncated]" on.
+        var overlong = "https://not-this-provider.example.test/" + new string('z', 300);
+        var harness = new SsoControllerHarness(c => c.OidConfigs["idp"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.test",
+        });
+        harness.UserManager.GetUserByName("alice").Returns(TestUsers.Named("alice", Guid.Parse("77777777-7777-7777-7777-777777777777")));
+
+        var answer = await harness.Controller.ImportLinks(new LinkExportDocument
+        {
+            FormatVersion = LinkExport.FormatVersion,
+            Links = new Collection<LinkExportEntry>
+            {
+                new() { Protocol = "OpenID", Provider = "idp", CanonicalName = "sub-1", Username = "alice", Issuer = overlong },
+            },
+        }).ConfigureAwait(true);
+
+        var body = Assert.IsType<string>(Assert.IsType<BadRequestObjectResult>(answer).Value);
+        var logged = Assert.Single(
+            harness.ControllerLog.Entries,
+            e => e.Message.Contains("The account-link import was refused", StringComparison.Ordinal)).Message;
+
+        // The two must agree, and the plugin's own bracketed marker must survive in both.
+        Assert.Contains("[truncated]", body, StringComparison.Ordinal);
+        Assert.Contains("[truncated]", logged, StringComparison.Ordinal);
+        Assert.Contains(body, logged, StringComparison.Ordinal);
+        Assert.DoesNotContain(Marker, logged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheDefaultProviderLine_CarriesBothSanitizers()
+    {
+        // The line is written at every SSO login of an enforced account and carried neither sanitizer, so a
+        // value written by a configuration import or a mounted declarative document could both split an
+        // entry and plant a record. The conformance rule cannot see a value with no strip, which is why
+        // this row exists rather than a rule change.
+        const string Forged = "x\r\n[SSO Audit] Login succeeded: root via OpenID provider 'corp' (admin=True).";
+
+        var log = new CapturingLogger();
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        var user = TestUsers.Named("alice", Guid.Parse("66666666-6666-6666-6666-666666666666"));
+        users.GetUserById(user.Id).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var avatar = new Api.Avatar.AvatarService(
+            users,
+            Substitute.For<IProviderManager>(),
+            Substitute.For<IServerConfigurationManager>(),
+            new CapturingLogger(),
+            Api.Net.SsoHttp.UserAgent);
+        var minter = new SessionMinter(users, avatar, sessions, log);
+
+        await minter.MintAsync(
+            new SessionParameters
+            {
+                UserId = user.Id,
+                IsAdmin = false,
+                IsBreakGlassAdmin = false,
+                EnableAuthorization = false,
+                EnableAllFolders = true,
+                EnabledFolders = Array.Empty<string>(),
+                EnableLiveTv = false,
+                EnableLiveTvManagement = false,
+                PermissionGrants = Array.Empty<PermissionGrant>(),
+                MaxParentalRatingScore = null,
+                SyncPlayAccess = null,
+                AvatarUrl = null,
+                DefaultProvider = Forged,
+                AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
+            },
+            () => "203.0.113.9",
+            () => true).ConfigureAwait(true);
+
+        var line = Assert.Single(log.Entries, e => e.Message.Contains("Set default login provider", StringComparison.Ordinal)).Message;
+        Assert.DoesNotContain("\n", line, StringComparison.Ordinal);
+        Assert.DoesNotContain(Marker, line, StringComparison.Ordinal);
+        Assert.Contains("(SSO Audit] Login succeeded", line, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1910,7 +1910,15 @@ public class SSOController : ControllerBase
             // importer builds its refusals under.
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
+                // STRIPPED AND NOT SUBSTITUTED, and the answer below does the same (#1566). This message is
+                // one the PLUGIN composed: it carries the importer's own entry description, the configured-
+                // issuer refusal with its own truncation marker, and the validator's list of the characters a
+                // provider name may not contain - and that list opens with the very bracket a substitution
+                // here would take out of it. The foreign parts inside it are substituted where they enter it,
+                // in LinkImport.Describe, in OidcConfiguredIssuer.Echo and in the validator's echoes, so
+                // nothing an identity provider or a posted file supplies reaches this line un-neutralised.
+                var composedRefusal = ex.Message;
+                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", composedRefusal?.ReplaceLineEndings(string.Empty));
             }
 
             return BadRequest(ex.Message?.ReplaceLineEndings(string.Empty));

--- a/SSO-Auth/Api/Oidc/OidcConfiguredIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcConfiguredIssuer.cs
@@ -109,8 +109,12 @@ internal static class OidcConfiguredIssuer
         return $"the entry's issuer '{Echo(issuer)}' is not what this provider is configured to issue ('{Echo(authority)}'), so every login on the restored link would be refused for a mismatch; remove the Issuer field from these entries to restore the links unbound and let the first login bind them, or fix the provider before importing - do NOT change OidEndpoint after a restore, which clears the link table";
     }
 
+    // Record-marker substituted as well as bounded (#1566), and BEFORE the marker is joined on, the same
+    // order the discovery reader uses for the same reason: the marker is the plugin's own and opens with the
+    // bracket being removed. Substituting here rather than over the composed refusal is what lets that
+    // refusal reach the log without the plugin's own text being rewritten with it.
     private static string Echo(string value) =>
         value.Length > MaxEchoedIssuerChars
-            ? string.Concat(value.AsSpan(0, MaxEchoedIssuerChars), TruncationMarker)
-            : value;
+            ? string.Concat(value.Replace('[', '(').AsSpan(0, MaxEchoedIssuerChars), TruncationMarker)
+            : value.Replace('[', '(');
 }

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -139,13 +139,7 @@ internal sealed class SessionMinter
             user.AuthenticationProviderId = parameters.DefaultProvider;
             if (_logger.IsEnabled(LogLevel.Information))
             {
-                // Sanitized like every other value the plugin logs (#1566). It is the administrator's rather
-                // than an identity provider's, which is exactly why it was missed: it arrives from the
-                // provider configuration, which a configuration import or a mounted declarative document
-                // writes, and this line is written at EVERY SSO login of an enforced account. It carried
-                // neither sanitizer, so it could split an entry as well as plant a record, and the rule that
-                // holds this property elsewhere cannot see it - that rule keys on the strip.
-                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
+                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
             }
         }
 

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -139,7 +139,13 @@ internal sealed class SessionMinter
             user.AuthenticationProviderId = parameters.DefaultProvider;
             if (_logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
+                // Sanitized like every other value the plugin logs (#1566). It is the administrator's rather
+                // than an identity provider's, which is exactly why it was missed: it arrives from the
+                // provider configuration, which a configuration import or a mounted declarative document
+                // writes, and this line is written at EVERY SSO login of an enforced account. It carried
+                // neither sanitizer, so it could split an entry as well as plant a record, and the rule that
+                // holds this property elsewhere cannot see it - that rule keys on the strip.
+                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
         }
 

--- a/SSO-Auth/Config/LinkImport.cs
+++ b/SSO-Auth/Config/LinkImport.cs
@@ -312,8 +312,11 @@ internal static class LinkImport
     // carries no raw subject value (T-I1); echoing it into an HTTP error body and from there into
     // whatever logs that body would widen where it travels for no gain an operator could use. The index
     // into the document they are holding is what lets them find the entry.
+    // The two names come out of the posted document, so the record-marker substitution runs HERE (#1566).
+    // This sentence reaches a log line as well as a 400 body, and the caller substituting the whole of it
+    // instead rewrote the plugin's own words alongside these two - which is what that issue is about.
     private static string Describe(int index, string? protocol, string? provider, string reason) =>
-        $"entry #{index.ToString(CultureInfo.InvariantCulture)} ({protocol ?? "no protocol"}/{provider ?? "no provider"}): {reason}";
+        $"entry #{index.ToString(CultureInfo.InvariantCulture)} ({(protocol ?? "no protocol").Replace('[', '(')}/{(provider ?? "no provider").Replace('[', '(')}): {reason}";
 
     // One validated entry: the map it belongs in, and everything needed to write it. Nothing is written
     // while this list is being built, which is the whole of the fail-closed property - the first refusal

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -127,7 +127,7 @@ internal static class ProviderConfigValidator
             // alone would let e.g. ESC survive into the exception text and any log that captures it -
             // strip ALL controls inline here, then the two non-control line separators (U+2028/U+2029)
             // that ReplaceLineEndings covers and char.IsControl does not.
-            var echoName = string.Concat((provider ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var echoName = string.Concat((provider ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
             throw new ArgumentException(
                 $"{protocol} provider '{echoName}' has a name with control characters, URI-reserved characters, or a backslash; the name becomes part of the callback URL registered with the identity provider, so a new name must not contain control characters, a backslash, or any of % : / ? # [ ] @ ! $ & ' ( ) * + , ; =.",
                 nameof(provider));
@@ -152,7 +152,7 @@ internal static class ProviderConfigValidator
         if (config?.RequireAcr == true && string.IsNullOrWhiteSpace(config.AcrValues))
         {
             throw new ArgumentException(
-                $"OpenID provider '{provider?.ReplaceLineEndings(string.Empty)}' sets RequireAcr but no Acr Values; set the required acr_values (space-separated) the returned acr must match, or turn RequireAcr off.",
+                $"OpenID provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' sets RequireAcr but no Acr Values; set the required acr_values (space-separated) the returned acr must match, or turn RequireAcr off.",
                 nameof(config));
         }
     }
@@ -175,7 +175,7 @@ internal static class ProviderConfigValidator
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
         {
             throw new ArgumentException(
-                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.",
+                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.",
                 nameof(baseUrlOverride));
         }
     }
@@ -220,7 +220,7 @@ internal static class ProviderConfigValidator
         if (!OidcLogout.IsAllowedPostLogoutRedirect(postLogoutRedirectUri, canonicalBase, out _))
         {
             throw new ArgumentException(
-                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has a Post Logout Redirect URI that is not at or under the configured Base URL; it must be an absolute http(s) URL at or under this server's base URL, or it is ignored at logout. Leave it blank for no post-logout redirect.",
+                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has a Post Logout Redirect URI that is not at or under the configured Base URL; it must be an absolute http(s) URL at or under this server's base URL, or it is ignored at logout. Leave it blank for no post-logout redirect.",
                 nameof(postLogoutRedirectUri));
         }
     }
@@ -254,7 +254,7 @@ internal static class ProviderConfigValidator
             || !normalized.StartsWith("https://", StringComparison.Ordinal))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid SAML SLO Endpoint; it must be an absolute https URL such as https://idp.example.com/slo, or left blank to disable SP-initiated Single Logout.",
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has an invalid SAML SLO Endpoint; it must be an absolute https URL such as https://idp.example.com/slo, or left blank to disable SP-initiated Single Logout.",
                 nameof(sloEndpoint));
         }
     }
@@ -275,7 +275,7 @@ internal static class ProviderConfigValidator
         if (SamlCertificate.IsInvalid(certificate ?? string.Empty))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
                 nameof(certificate));
         }
     }
@@ -299,7 +299,7 @@ internal static class ProviderConfigValidator
         if (SamlCertificate.IsInvalid(certificate ?? string.Empty))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
                 nameof(certificate));
         }
     }
@@ -344,8 +344,8 @@ internal static class ProviderConfigValidator
                 continue;
             }
 
-            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
-            var echoPerm = string.Concat((mapping.Permission ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
+            var echoPerm = string.Concat((mapping.Permission ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
             var reason = status switch
             {
                 PermissionRolePolicy.PermissionNameStatus.Empty => "has an empty permission name",
@@ -369,7 +369,7 @@ internal static class ProviderConfigValidator
     /// <param name="template">The provisioning template to check.</param>
     /// <exception cref="ArgumentException">The template names an invalid or dedicated permission, or carries a negative number.</exception>
     internal static void ValidateProvisioningTemplate(string protocol, string provider, ProvisioningPolicyTemplate? template)
-        => ValidateTemplateFields($"{protocol} provider '{(provider ?? string.Empty).ReplaceLineEndings(string.Empty)}'", template);
+        => ValidateTemplateFields($"{protocol} provider '{(provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(')}'", template);
 
     // The template checks themselves, over whatever names the template being judged - a provider carrying an
     // inline one, or a named profile several providers share (#1105). One implementation, so a profile cannot
@@ -397,7 +397,7 @@ internal static class ProviderConfigValidator
                 continue;
             }
 
-            var echoPerm = string.Concat((entry.Permission ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var echoPerm = string.Concat((entry.Permission ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
             var reason = status switch
             {
                 PermissionRolePolicy.PermissionNameStatus.Empty => "has an entry with an empty permission name",
@@ -438,7 +438,7 @@ internal static class ProviderConfigValidator
         if (template.SubtitleMode != null
             && !ProvisioningPolicy.TryParseSubtitleMode(template.SubtitleMode, out _))
         {
-            var echoMode = string.Concat(template.SubtitleMode.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var echoMode = string.Concat(template.SubtitleMode.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
             throw new ArgumentException(
                 $"{subject} has an invalid provisioning template: it names subtitle mode '{echoMode}', which is not a known Jellyfin SubtitlePlaybackMode. Use the exact enum name (for example Default, Always, OnlyForced, or Smart), or leave it unset to keep Jellyfin's default.",
                 nameof(template));
@@ -453,7 +453,7 @@ internal static class ProviderConfigValidator
         {
             var reason = refusedSection is null
                 ? $"lists {template.HomeSections.Count} home-screen sections, more than the {HomeScreenPolicy.SlotCount} slots the web client renders"
-                : $"names home-screen section '{string.Concat(refusedSection.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty)}', which is not a known Jellyfin HomeSectionType";
+                : $"names home-screen section '{string.Concat(refusedSection.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(')}', which is not a known Jellyfin HomeSectionType";
             throw new ArgumentException(
                 $"{subject} has an invalid provisioning template: it {reason}. Use the exact enum names (for example SmallLibraryTiles, Resume, NextUp, LatestMedia, or None), one per slot from the top and at most {HomeScreenPolicy.SlotCount}, or leave the list empty to keep Jellyfin's own layout.",
                 nameof(template));
@@ -485,7 +485,7 @@ internal static class ProviderConfigValidator
             }
 
             ValidateTemplateFields(
-                $"Provisioning profile '{string.Concat(kvp.Key.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty)}'",
+                $"Provisioning profile '{string.Concat(kvp.Key.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(')}'",
                 kvp.Value);
         }
     }
@@ -519,8 +519,8 @@ internal static class ProviderConfigValidator
             return;
         }
 
-        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
-        var echoProfile = string.Concat(profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
+        var echoProfile = string.Concat(profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
 
         if (config!.ProvisioningPolicyTemplate != null)
         {
@@ -568,7 +568,7 @@ internal static class ProviderConfigValidator
             return;
         }
 
-        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+        var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
 
         foreach (var mapping in mappings)
         {
@@ -586,7 +586,7 @@ internal static class ProviderConfigValidator
                     nameof(config));
             }
 
-            var echoProfile = string.Concat(mapping.Profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var echoProfile = string.Concat(mapping.Profile.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
 
             // A row listing no role never matches, so it would sit in the map looking like a rule while
             // selecting nothing - the same failure ValidateParentalRatingMappings refuses for the same reason.
@@ -637,7 +637,7 @@ internal static class ProviderConfigValidator
                 continue;
             }
 
-            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
             if (mapping.Score < 0)
             {
                 throw new ArgumentException(
@@ -678,13 +678,13 @@ internal static class ProviderConfigValidator
                 continue;
             }
 
-            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
 
             // One parse, shared with the login path: the validator refuses exactly what the resolver would
             // skip, so a saved mapping is one the mint can act on rather than one it silently drops.
             if (!SyncPlayAccessPolicy.TryParseAccess(mapping.Access, out _))
             {
-                var echoAccess = string.Concat((mapping.Access ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+                var echoAccess = string.Concat((mapping.Access ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty).Replace('[', '(');
                 throw new ArgumentException(
                     $"{protocol} provider '{echoName}' has an invalid SyncPlay-access mapping: '{echoAccess}' is not a SyncPlay access level. Use the exact spelling CreateAndJoinGroups, JoinGroups or None.",
                     nameof(mappings));
@@ -725,7 +725,7 @@ internal static class ProviderConfigValidator
                 continue;
             }
 
-            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty).Replace('[', '(');
             if (mapping.DurationHours <= 0)
             {
                 throw new ArgumentException(
@@ -768,7 +768,7 @@ internal static class ProviderConfigValidator
         if (SamlSigningKey.IsInvalid(signingKeyPfx ?? string.Empty))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.",
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(')}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.",
                 nameof(signingKeyPfx));
         }
     }


### PR DESCRIPTION
# Closed as a duplicate. The survivor is #1568.

This is not being merged and the reason is here rather than underneath.

#1568 landed on `4.4` at `0c32770c` while this branch was waiting for its checks,
closing #1566 with the same repair. The two are close to identical - both move the
substitution off the composed sentence and onto the foreign parts where they enter
it, in `LinkImport.Describe` and `OidcConfiguredIssuer.Echo`, and both name the
composed sentence in the conformance rule so the rule requires it to strip
WITHOUT substituting. They even chose the same local name for it.

Two differences, and neither favours this branch:

- **#1568 also fixed the default-provider line**, which this branch had split out
  as #1569 after measuring a `cs/cleartext-storage-of-sensitive-information`
  alert against it. That alert did not appear for the change that landed, and the
  mainline carries no open code-scanning alert. #1569 is closed with that
  reading; the alert was real where it was measured and the conclusion drawn from
  it was too strong.
- **#1568 substitutes inside `Describe` on the same expression as the strip**,
  where this branch substituted only. Theirs is the stronger form: it neutralises
  a line ending in those two names as well.

So the survivor is better on both counts and nothing here is worth re-landing.

## What came out of this branch that is not in the diff

The issue itself. #1566 was written from a review of a parallel implementation of
#1557, against the mainline that implementation landed on, and it carried the
reproduction that #1568 then fixed:

- the composed link-import refusal printed `(truncated]` in the log and
  `[truncated]` in the `400` body for the same refusal, and named a shorter list
  of forbidden characters in the one message whose subject is which characters are
  forbidden;
- the default-provider line carried neither sanitizer, on a line written at every
  SSO login of an SSO-only account.

#1564 also came out of that review and is open: a foreign value logged with no
line-ending strip at all is invisible to the rule that holds this property,
because that rule keys on the strip.

The branch is left in place rather than deleted; it is not merged, so nothing on
`4.4` depends on it.

## What this cost, said plainly

This is the third time tonight that two efforts built the same issue at once on
this board and one was thrown away. The first two were #1518 and #1557; this one
was an issue filed at 12:5x and implemented twice within the hour. The pattern is
worth more than the individual losses: issues filed here are picked up
immediately, so filing one and then implementing it is a collision by
construction rather than by bad luck.
