### PR TITLE
Substitute the import refusal's foreign parts where they enter it, not the sentence [#1566]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -673,6 +673,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A refused account-link import no longer logs a different sentence from
+  the one it answers, and the default-provider line is sanitized (#1566).**
+  Two residuals of #1557. The refusal a link import answers is a sentence this
+  plugin composes out of the document's own values, and the log line carrying
+  it substituted the whole sentence, so the plugin's own `[truncated]` marker
+  on an overlong issuer read `(truncated]` in the log while the answer on the
+  wire kept it. The document's values - protocol, provider, username, issuer -
+  are now substituted where they enter the sentence, and the sentence reaches
+  the log unchanged except for the line-ending strip, so the log and the wire
+  agree. And the line written at every SSO login of an enforced account, naming
+  the configured default provider, carried neither sanitizer; it carries both
+  now, like every other provider name the plugin prints.
+
 - **A discovery read whose caller has gone away now ends with the caller
   (#1558).** The hardened OpenID discovery read took no cancellation token, so
   nothing a caller could do abandoned it: the only bound was the per-request

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -26,6 +26,11 @@ public partial class ArchitectureConformanceTests
     // a data directory whose name carries a bracket would otherwise be named as a path that does not exist,
     // in the one line written for a total lockout. No untrusted party can write any of them, so the bracket
     // substitution buys nothing here and costs the whole point of the line.
+    //
+    // composedRefusal is the one value of a different kind (#1566): a sentence this plugin composed whose
+    // foreign parts were substituted where they entered it, in LinkImport.Describe and
+    // OidcConfiguredIssuer.Echo. Substituting the sentence whole rewrote the plugin's own "[truncated]"
+    // marker, so the log disagreed with the answer on the wire about one refusal.
     private static readonly string[] AuditValuesPrintedExactly =
     {
         "configurationFilePath",
@@ -33,6 +38,7 @@ public partial class ArchitectureConformanceTests
         "markerPath",
         "source",
         "sourcePath",
+        "composedRefusal",
     };
 
     private const string LineEndingSanitizer = "ReplaceLineEndings(string.Empty)";

--- a/SSO-Auth.Tests/Http/SSOControllerImportLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerImportLinksTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Jellyfin.Extensions.Json;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -51,6 +52,44 @@ public class SSOControllerImportLinksTests
         // count the audit line has carried since #1129.
         Assert.Equal(TargetAlice, harness.Configuration.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
         Assert.Equal(TargetBob, harness.Configuration.SamlConfigs["adfs"].CanonicalLinks["nameid-bob"]);
+    }
+
+    [Fact]
+    public async Task ARefusedImport_LogsThePluginsOwnMarkerWhole_AndNoForgedRecord()
+    {
+        // #1566. The refusal is a sentence the plugin composes out of the document's own values, and the log
+        // line used to substitute it WHOLE: the plugin's "[truncated]" marker on an overlong issuer became
+        // "(truncated]" in the log while the answer on the wire kept it, so the two disagreed about one
+        // refusal. Now the document's values are substituted where they enter the sentence, and the sentence
+        // itself reaches the log with the line-ending strip alone. The provider name here is the forging
+        // payload; the issuer is overlong so the marker is reached; both entries are refused, and the entry
+        // that names the forged provider is refused for naming no configured provider, which echoes it, and
+        // the issuer is echoed by the fail-closed arm, which never parses it, so its spaces stay. Kills:
+        // substituting composedRefusal whole (the plugin's marker goes), dropping the substitution in
+        // Describe (the provider plants the audit marker) or in Echo (the issuer plants it).
+        const string Forged = "[SSO Audit] Login succeeded: root via OpenID provider 'idp' (admin=True).";
+        var harness = Harness();
+        var document = new LinkExportDocument
+        {
+            FormatVersion = LinkExport.FormatVersion,
+            Links = new Collection<LinkExportEntry>
+            {
+                new() { Protocol = LinkExport.OpenIdProtocol, Provider = Forged, CanonicalName = "sub-x", Username = "alice" },
+                new() { Protocol = LinkExport.OpenIdProtocol, Provider = "idp", CanonicalName = "sub-alice", Username = "alice", Issuer = "https://" + Forged + "/" + new string('a', 4000) },
+            },
+        };
+
+        var answer = await harness.Controller.ImportLinks(document).ConfigureAwait(true);
+
+        var wire = Assert.IsType<string>(Assert.IsType<BadRequestObjectResult>(answer).Value);
+        var logged = Assert.Single(harness.ControllerLog.Entries, e => e.Message.Contains("was refused and nothing was restored", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, logged.Level);
+        Assert.Contains("[truncated]", wire, StringComparison.Ordinal);
+        Assert.Contains("[truncated]", logged.Message, StringComparison.Ordinal);
+        Assert.Contains("(SSO Audit] Login succeeded: root", logged.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("[SSO Audit] ", logged.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("[SSO Audit] ", wire, StringComparison.Ordinal);
+        Assert.Empty(harness.Configuration.OidConfigs["idp"].CanonicalLinks);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Session/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/Session/SessionMinterTests.cs
@@ -42,6 +42,31 @@ public class SessionMinterTests
         return (minter, users, sessions);
     }
 
+    [Fact]
+    public async Task MintAsync_DefaultProviderCarryingAForgedRecord_CannotPlantTheMarkerInTheLoginLine()
+    {
+        // #1566: the configured default provider is written to the log at every SSO login of an enforced
+        // account, and it carried neither sanitizer - the one provider-name value in the plugin that did
+        // not. It is administrator- or import-supplied rather than identity-provider-supplied, and provider
+        // names from the same hands are substituted everywhere else, so this was an inconsistency and not an
+        // exemption. Kills: dropping either sanitizer on that line.
+        const string Forged = "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True).\r\n";
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        var log = new CapturingLogger();
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, log);
+        users.GetUserById(UserId).Returns(TestUsers.Named("alice", UserId));
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(defaultProvider: Forged), () => "203.0.113.7", () => true);
+
+        var line = Assert.Single(log.Entries, e => e.Message.Contains("Set default login provider", StringComparison.Ordinal));
+        Assert.Contains("(SSO Audit] Login succeeded: root", line.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", line.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(log.Entries, e => e.Message.Contains("[SSO Audit] ", StringComparison.Ordinal));
+    }
+
     private static SessionParameters Params(
         bool enableAuthorization = false,
         bool isAdmin = false,

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1920,7 +1920,14 @@ public class SSOController : ControllerBase
             // importer builds its refusals under.
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", ex.Message?.ReplaceLineEndings(string.Empty).Replace('[', '('));
+                // The refusal is a sentence this plugin composed, and its foreign parts - the document's
+                // protocol, provider, username and issuer - are substituted where they enter it, in
+                // LinkImport.Describe and OidcConfiguredIssuer.Echo (#1566). Substituting the whole sentence
+                // here rewrote the plugin's own "[truncated]" marker in the log while the answer on the wire
+                // kept it, so the log and the wire disagreed about one refusal. The strip stays inline for
+                // cs/log-forging; composedRefusal is named in the conformance rule's exact-print list.
+                var composedRefusal = ex.Message;
+                _logger.LogWarning("The account-link import was refused and nothing was restored: {Reason}", composedRefusal?.ReplaceLineEndings(string.Empty));
             }
 
             return BadRequest(ex.Message?.ReplaceLineEndings(string.Empty));

--- a/SSO-Auth/Api/Oidc/OidcConfiguredIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcConfiguredIssuer.cs
@@ -109,8 +109,11 @@ internal static class OidcConfiguredIssuer
         return $"the entry's issuer '{Echo(issuer)}' is not what this provider is configured to issue ('{Echo(authority)}'), so every login on the restored link would be refused for a mismatch; remove the Issuer field from these entries to restore the links unbound and let the first login bind them, or fix the provider before importing - do NOT change OidEndpoint after a restore, which clears the link table";
     }
 
+    // The caller's value is stripped of line endings and has its record-marker bracket substituted before
+    // the plugin's own truncation marker is joined to it (#1566): the marker opens with the very bracket the
+    // substitution removes, so sanitizing the joined text would rewrite the marker instead of the value.
     private static string Echo(string value) =>
-        value.Length > MaxEchoedIssuerChars
-            ? string.Concat(value.AsSpan(0, MaxEchoedIssuerChars), TruncationMarker)
-            : value;
+        string.Concat(
+            value[..Math.Min(value.Length, MaxEchoedIssuerChars)].ReplaceLineEndings(string.Empty).Replace('[', '('),
+            value.Length > MaxEchoedIssuerChars ? TruncationMarker : string.Empty);
 }

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -139,7 +139,7 @@ internal sealed class SessionMinter
             user.AuthenticationProviderId = parameters.DefaultProvider;
             if (_logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
+                _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
         }
 

--- a/SSO-Auth/Config/LinkImport.cs
+++ b/SSO-Auth/Config/LinkImport.cs
@@ -138,7 +138,7 @@ internal static class LinkImport
             // different and much larger primitive than one that restores links between things that exist.
             if (resolveUserId(entry.Username) is not { } userId)
             {
-                refusals.Add(Describe(index, entry.Protocol, entry.Provider, $"no Jellyfin account is named '{entry.Username}' on this instance"));
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, $"no Jellyfin account is named '{entry.Username.ReplaceLineEndings(string.Empty).Replace('[', '(')}' on this instance"));
                 continue;
             }
 
@@ -312,8 +312,14 @@ internal static class LinkImport
     // carries no raw subject value (T-I1); echoing it into an HTTP error body and from there into
     // whatever logs that body would widen where it travels for no gain an operator could use. The index
     // into the document they are holding is what lets them find the entry.
+    //
+    // The document's own values - protocol, provider, and the username the caller above interpolates - are
+    // stripped of line endings and have their record-marker bracket substituted HERE, where they enter the
+    // sentence (#1566). The sentence is then the plugin's own, and the log line that carries it applies the
+    // line-ending strip alone: substituting the composed sentence whole rewrote the plugin's own
+    // "[truncated]" marker in the log while the answer on the wire kept it.
     private static string Describe(int index, string? protocol, string? provider, string reason) =>
-        $"entry #{index.ToString(CultureInfo.InvariantCulture)} ({protocol ?? "no protocol"}/{provider ?? "no provider"}): {reason}";
+        $"entry #{index.ToString(CultureInfo.InvariantCulture)} ({protocol?.ReplaceLineEndings(string.Empty).Replace('[', '(') ?? "no protocol"}/{provider?.ReplaceLineEndings(string.Empty).Replace('[', '(') ?? "no provider"}): {reason}";
 
     // One validated entry: the map it belongs in, and everything needed to write it. Nothing is written
     // while this list is being built, which is the whole of the fail-closed property - the first refusal


### PR DESCRIPTION
# What & why

Closes #1566.

Two residuals of #1557, both live on `4.4` at `7c3bb908`.

**The composed refusal.** The account-link import refusal is a sentence this
plugin composes out of the document's own values, and the log line carrying it
substituted the whole sentence, so the plugin's own `[truncated]` marker on an
overlong issuer read `(truncated]` in the log while the answer on the wire kept
it. The log and the wire disagreed about one refusal, and the log was the wrong
one. The document's protocol, provider, username and issuer are now stripped
and substituted where they enter the sentence - in `LinkImport.Describe`, at
the username interpolation, and in `OidcConfiguredIssuer.Echo`, whose foreign
slice is sanitized before the marker is joined - and the sentence reaches the
log with the line-ending strip alone, on a local the conformance rule names as
printed exactly. The validator's character list the issue also names never
reaches this log line; the validator's refusals go to the wire only.

**The default-provider line.** Written at every SSO login of an enforced
account, it named the configured default provider with neither sanitizer, the
one provider-name value in the plugin that did not. It carries both now.

Both carry a row. The import row drives a forged provider name and an overlong
issuer carrying the marker through the endpoint and reads the wire and the log
together; the mint row drives a forged default provider with a line ending
through the minter.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the import still refuses the same documents and
      writes nothing on refusal; only the text of the refusal and of one log
      line changes.
- [x] No secrets logged; no canonical name enters any refusal, as before.
- [x] A security review was performed. Record below.
- [x] Review record, below.
- [x] Log inputs from the IdP are sanitized inline at the log call; the one
      composed sentence is sanitized where its foreign parts enter it, and the
      rule names that local by name.

### Review record

One refute-by-default lens read the diff, the importer, the issuer echo, the
controller action and both tests. **No second reader is available on this
board; what stands in place of one is a lens over the state, not a reading by
a second person.**

| Lens        | Verdict | Raised                 |
| ----------- | ------- | ---------------------- |
| correctness | FAIL    | 3: one medium, two low |

Counts as raised: **CONFIRMED 1 / PLAUSIBLE 2.**

- CONFIRMED, MEDIUM: the import row claimed to kill the substitution in the
  issuer echo, but the payload had hyphenated the marker's spaces, so removing
  that guard left every assertion green. FIX: the issuer keeps its spaces (the
  fail-closed arm never parses it); removing the echo substitution now turns
  the row red, verified by running it.
- PLAUSIBLE, LOW: exempting the composed sentence by a local's name is
  provenance-blind; a future local of the same name would be exempt too. This
  is the exact-print list's existing shape and is disclosed in the rule's
  comment. DECLINE: no better key exists in one line of text, which is #1564's
  question.
- PLAUSIBLE, LOW: an IPv6-literal issuer now echoes as `(fd00::1]` on the wire
  as well as in the log. DECLINE: the issue asks for entry-point substitution
  so log and wire agree, and no test asserts a raw bracket in the body.

The lens could construct no document that plants the marker into the refusal
log line after the change, and confirmed the importer does not stop at the
first refusal, so the row's overlong issuer really reaches the marker.

## Quality checklist

- [x] No duplicated logic: each foreign value is sanitized once, where it
      enters the sentence.
- [x] No more code than the problem requires.
- [x] Self-documenting; comments say why the sentence is not substituted whole
      and why the marker is joined after the slice.
- [x] Architecture-conformance tests pass; the exact-print list gains one named
      local with its reason.
- [x] Docs impact: the changelog entry is included; nothing public documents
      the refusal's rendering.

## Verification

- [x] `dotnet build --warnaserror` is green on net9.0 and net10.0 (0 warnings).
- [x] The full suite is green on both: net9.0 3825 tests, net10.0 3826 tests,
      4 skipped on each (pre-existing skips).
- [x] Prettier is clean for `CHANGELOG.md`.

I proved the guards bite by inverting them: substituting the composed sentence
whole again and dropping the sanitizers on the default-provider line turned
both rows red; dropping the substitution in `Describe` turned the import row
red; dropping it in `Echo` turned the import row red once the payload kept its
spaces.

## Notes

#1564 asks whether anything can find a foreign value logged with no strip at
all; the default-provider line here was one such value, and it is fixed here
rather than there. The mechanism question stays with #1564.
