### PR TITLE
Record why the sanitizer rule cannot see a value logged with no strip [#1564]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -134,6 +134,21 @@ public partial class ArchitectureConformanceTests
         // WHAT THE RULE CAN SEE IS THE VALUE ALREADY MARKED FOREIGN BY THE STRIP. A value logged with no
         // sanitizer at all is not this rule's subject and never was: that is CodeQL's cs/log-forging query,
         // which is why both sanitizers stay spelled out inline at the call rather than behind a helper.
+        //
+        // WHY THAT RESIDUAL IS NOT CLOSED BY WIDENING THIS RULE (#1564), measured rather than supposed. On 4.4
+        // at 0c32770c the tree held 127 logging calls with 219 arguments past the template: 128 carried both
+        // sanitizers, 16 the strip alone (every one of them named in AuditValuesPrintedExactly), and 71 neither.
+        // Of the 71, every string-typed value is the plugin's own - a protocol label, a reason code, an enum
+        // token, a constant sentence, an embedded resource path, a record whose ToString redacts itself - and
+        // the rest are counts, booleans, Guids and durations. The one foreign value among them is the repeated
+        // JSON member name in RepeatedMemberScreen, neutralised by hand and pinned by its own payload row. What
+        // separates a constant label from a foreign name is the value's type and where it came from, and
+        // neither is in the text of one argument, so a widened text rule would refuse the 71 and pass the
+        // seventy-second the moment it looked like a label. A semantic pass could tell them apart, at the
+        // cost of compiling the plugin inside this test; the population it would guard is a dozen
+        // string-valued arguments, and that price was not paid. The census is reproduced by counting the
+        // arguments inside LoggingCallSpans the way this rule does and sorting them by whether they contain
+        // LineEndingSanitizer and RecordMarkerSanitizer; the classification of the 71 was by hand.
         var offenders = new List<string>();
         var strips = 0;
 


### PR DESCRIPTION
# What & why

Closes #1564, on the issue's second branch: the question is answered with a
measurement of why a mechanism is not achievable at an acceptable false-positive
rate, and the residual is recorded where the rule states it.

The tree-wide sanitizer rule keys on the line-ending strip, so a foreign value
logged with no sanitizer at all passes it. I measured that population on `4.4`
at `0c32770c`, walking the same logging-call spans the rule walks and sorting
every argument past the template by which sanitizer it carries:

```
calls=127 arguments=219 both=128 strip-only=16 neither=75
```

Four of the 75 are templates behind an exception argument the census did not
recognise, so the real count is 71. I classified the 71 by hand:

- Not strings at all: counts, booleans, Guids, durations, a slot count.
- Plugin-authored strings: the protocol label the audit trail carries (a
  constant on every caller), reason codes (constants), the mode token
  (`ToToken()` on an enum), constant refusal sentences, the option-name join,
  the embedded resource path of a served view, a record whose `ToString`
  redacts its own bearer token, an exception type name.
- Exactly one foreign value: the repeated JSON member name in
  `RepeatedMemberScreen`, neutralised by hand and pinned by its own payload
  row since #1557.

The 16 strip-only arguments are all named in the rule's exact-print list.

**Why the rule is not widened.** What separates a constant label from a
foreign name is the value's type and where it came from, and neither is in the
text of one argument. A widened text rule would refuse all 71 and still pass
the next foreign value the moment it looked like a label, which is the
"widened rule nobody can keep green" the issue rules out. A semantic pass over
the compiled plugin could separate them, at the cost of compiling the plugin
inside the test project; the population it would guard is about a dozen
string-valued arguments today. That price was not paid.

The issue's claim that the `SessionMinter` default-provider line was fixed in
#1557 was not right: it was fixed in #1566, which this measurement was taken
after.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no production code changes; a comment in a test.
- [x] No secrets logged: nothing logged changes.
- [x] A security review was performed: not for a comment; the measurement is
      the review, and the commands that produced it are above and in the rule's
      comment.
- [x] Review record: none owed for a documentation-only change to a test file.
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged.

## Quality checklist

- [x] No duplicated logic.
- [x] No more code than the problem requires: the record is one comment block.
- [x] Self-documenting.
- [x] Architecture-conformance tests pass; no new structural property.
- [x] Docs impact: none public; the residual lives beside the rule.

## Verification

- [x] `dotnet build --warnaserror` is green on net9.0 and net10.0 (0 warnings).
- [x] The conformance class is green (245 tests); the change is a comment.
- [x] Prettier: no formatted file changed.

## Notes

The census script is in my scratchpad and not in the tree; the rule's comment
says how to reproduce the count from the rule's own span walker, and the
classification of the 71 was by hand and is listed above.
