### PR TITLE
Give the settings pages one Save, an unsaved-changes line and inline outcomes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,6 +57,13 @@ jobs:
       # #1527 widened it and gated it here). Node is preinstalled on the runner and the tool has no
       # dependencies, so this adds no install.
       run: node tools/ui-mock-fields.js
+    - name: Unsaved-changes state of the settings pages
+      # The step above and every C# rule over these assets read their TEXT, so none of them can say what
+      # the unsaved-changes state DOES - and inverting its one condition is exactly how it fails: a page
+      # that reads clean while it holds an edit is re-read on the next tab return and the edit is gone
+      # (#1572). This runs the shipped sso-core.js against the shipped serverPage.html and refuses each
+      # arm by name. Same runtime and same absence of dependencies as the step above.
+      run: node tools/ui-unsaved-state.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -596,6 +596,40 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   and its Save rather than after them. Overview re-reads the server on every
   visit; the four pages that hold controls do not, because re-reading them would
   discard an edit made and not yet saved.
+- **One Save on the Server page, an unsaved-changes indicator, and the outcome
+  where the button is (#1572).** The Server page carried two Save buttons for
+  two server-wide switches, and each one re-read the whole configuration, set
+  its own flag and posted the result. They are now one Save that reads that
+  document once and posts it once, so there is no moment at which one switch is
+  stored and the other is not: a refusal leaves **both** exactly as they were
+  stored. It writes only the switches you actually moved, so pressing Save on a
+  page loaded ten minutes ago cannot silently undo a change somebody made in the
+  meantime to the switch you did not touch. Every page that holds a control now
+  tracks whether it has been edited and shows a line saying so, and each Save is
+  closed while a control the save needs is empty - the on-blur warnings that
+  mirror a server check go on warning and go on **not** blocking, because one of
+  those can be wrong about a value the server would have taken and an empty
+  required field cannot. The freeze on a provider or a profile a configuration
+  file owns is untouched: that freeze now records its own reason on the button
+  and the gate reads it, so the gate can never hand back a Save the freeze
+  closed. The thirteen modal alerts these pages raised for a save, a delete or a
+  failure are gone, and each outcome is written into the page instead - beside
+  the button that was pressed, in the sticky footer, rather than in the editor
+  header many screens above it, and announced to a screen reader.
+  `tools/ui-unsaved-state.js` runs the shipped page script against the shipped
+  pages in the `.NET` workflow and refuses each way that state can be wrong by
+  name.
+
+  **The tab that refreshes itself is deliberately not part of this**, and the
+  reason is worth stating: the review found that re-reading a page which holds
+  an open editor empties both library checklists and does not refill them, so
+  the next save would persist an empty Enabled Folders and every user of that
+  provider would lose library access at their next sign-in. Removing a
+  permission row is a click, which the edit tracking cannot see, so a re-read
+  would render the removed row straight back out of storage. Those are
+  properties of the load path rather than of the new state, and making it safe
+  to run twice is its own change.
+
 - **The login audit line now names the Jellyfin account, and the
   provider-presented name beside it where the two differ (#1551).** The
   `[SSO Audit] Login succeeded` line carried the username the identity provider

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -204,5 +204,12 @@
   "overview.next_none_configured": "Fügen Sie im Reiter Anbieter einen Anbieter hinzu, um Einmalanmeldung anzubieten.",
   "overview.next_nothing": "Jeder eingerichtete Anbieter ist vollständig und eingeschaltet. Ob er auch antwortet, meldet die Verbindungsprüfung im Reiter Anbieter.",
   "overview.sso_only_on": "Nur-SSO ist AN: Die Anmeldung mit einem Jellyfin-Kennwort wird für die von diesem Plugin verwalteten Konten abgelehnt.",
-  "overview.no_providers": "Es ist noch kein Anbieter eingerichtet. Fügen Sie im Reiter Anbieter einen hinzu."
+  "overview.no_providers": "Es ist noch kein Anbieter eingerichtet. Fügen Sie im Reiter Anbieter einen hinzu.",
+  "config.unsaved": "Ungespeicherte Änderungen in diesem Editor. Speichern Sie sie, bevor Sie einen anderen Anbieter öffnen oder diese Seite verlassen, sonst gehen sie verloren.",
+  "config.save_server": "Servereinstellungen speichern",
+  "config.server_settings_saved": "Beide Servereinstellungen gespeichert.",
+  "config.server_settings_save_failed": "Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde KEINER der beiden Schalter geändert – beide gehören zu einem Dokument und werden gemeinsam oder gar nicht geschrieben. Laden Sie die Seite neu, um den gespeicherten Stand zu sehen, und versuchen Sie es erneut.",
+  "config.server_settings_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts gespeichert und keiner der beiden Schalter geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
+  "config.provider_removed": "Anbieter entfernt.",
+  "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -204,5 +204,12 @@
   "overview.next_none_configured": "Add a provider on the Providers tab to offer single sign-on.",
   "overview.next_nothing": "Every configured provider is complete and switched on. Whether each one answers is what Test Connection on the Providers tab reports.",
   "overview.sso_only_on": "SSO-only is ON: Jellyfin password sign-in is refused for the accounts this plugin manages.",
-  "overview.no_providers": "No provider is configured yet. Add one on the Providers tab."
+  "overview.no_providers": "No provider is configured yet. Add one on the Providers tab.",
+  "config.unsaved": "Unsaved changes in this editor. Save them before you open another provider or leave this page, or they are lost.",
+  "config.save_server": "Save server settings",
+  "config.server_settings_saved": "Both server settings saved.",
+  "config.server_settings_save_failed": "The server refused the saved configuration, so NEITHER switch was changed - the two ride one document and are written together or not at all. Reload the page to see what is stored, and try again.",
+  "config.server_settings_read_failed": "Could not read the stored configuration, so nothing was saved and neither switch was changed. Reload the page and try again.",
+  "config.provider_removed": "Provider removed.",
+  "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again."
 }

--- a/SSO-Auth/Web/policiesPage.html
+++ b/SSO-Auth/Web/policiesPage.html
@@ -97,6 +97,21 @@
             hidden
           ></div>
 
+          <!--
+            The unsaved-changes indicator (#1572). Hidden until a control on this page is edited by a
+            person; the text is written by sso-core.js renderUnsavedNotice with textContent (#221) and
+            carries no configuration value. It is above the columns rather than beside the save, because
+            its second job is to say why a tab returned to was NOT refreshed, and that has to be readable
+            at the moment of arrival rather than after scrolling past every field.
+          -->
+          <div
+            id="sso-unsaved"
+            class="fieldDescription sso-unsaved"
+            role="status"
+            aria-live="polite"
+            hidden
+          ></div>
+
           <div class="sso-columns">
             <div class="sso-column-main">
               <!--
@@ -109,7 +124,7 @@
             guarded here either. ProvisioningProfiles is a root PluginConfiguration member, not a provider
             field, so this section sits OUTSIDE both provider forms and carries no flat sso-* marker: it
             is saved by its own handler (sso-core.js saveProvisioningProfile), which re-posts the whole
-            configuration with only the profile set changed, exactly as saveLoginButtons does.
+            configuration with only the profile set changed, exactly as saveServerSettings does.
 
             Delete and rename are the two acts that can break a provider from here, and both are checked
             against the live configuration BEFORE the PUT rather than left to the server's refusal: a

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -97,6 +97,33 @@
             hidden
           ></div>
 
+          <!--
+            The unsaved-changes indicator (#1572). Hidden until a control on this page is edited by a
+            person; the text is written by sso-core.js renderUnsavedNotice with textContent (#221) and
+            carries no configuration value. It is above the columns rather than beside the save, because
+            its second job is to say why a tab returned to was NOT refreshed, and that has to be readable
+            at the moment of arrival rather than after scrolling past every field.
+          -->
+          <div
+            id="sso-unsaved"
+            class="fieldDescription sso-unsaved"
+            role="status"
+            aria-live="polite"
+            hidden
+          ></div>
+
+          <!--
+            The page-level outcome region (#1572). What a delete, or a save whose own section is no longer
+            on screen, has to say: the editor's status region lives INSIDE the editor, and a delete closes
+            that editor, so an outcome written there would be invisible. Written with textContent (#221).
+          -->
+          <div
+            id="sso-page-status"
+            class="sso-save-status"
+            role="status"
+            aria-live="polite"
+          ></div>
+
           <div class="sso-columns">
             <div class="sso-column-main">
               <!--
@@ -325,12 +352,6 @@
                       New provider
                     </h3>
                     <div class="sso-editor-header-actions">
-                      <div
-                        id="sso-save-status"
-                        class="sso-save-status"
-                        role="status"
-                        aria-live="polite"
-                      ></div>
                       <button
                         id="DeleteProvider"
                         is="emby-button"
@@ -2381,6 +2402,21 @@
                     <div class="fieldDescription sso-restart-reminder">
                       Saving requires a restart of Jellyfin to take effect.
                     </div>
+                    <!--
+                      The save outcome sits WITH the button (#1572), not in the editor header where it
+                      used to. The footer is sticky, so this is on screen whenever the editor is; the
+                      header is up to fifty-seven controls above, and the footer exists precisely so an
+                      administrator never scrolls back up to it. While a modal also carried the reason
+                      that did not matter. Now this is the only channel, so it has to be where the press
+                      happened. role/aria-live are kept from its old home, so it is announced as well as
+                      seen.
+                    -->
+                    <div
+                      id="sso-save-status"
+                      class="sso-save-status"
+                      role="status"
+                      aria-live="polite"
+                    ></div>
                     <button
                       id="SaveProvider"
                       is="emby-button"
@@ -2534,12 +2570,6 @@
                       New provider
                     </h3>
                     <div class="sso-editor-header-actions">
-                      <div
-                        id="saml-save-status"
-                        class="sso-save-status"
-                        role="status"
-                        aria-live="polite"
-                      ></div>
                       <button
                         id="saml-DeleteProvider"
                         is="emby-button"
@@ -4084,6 +4114,21 @@
                     <div class="fieldDescription sso-restart-reminder">
                       Saving requires a restart of Jellyfin to take effect.
                     </div>
+                    <!--
+                      The save outcome sits WITH the button (#1572), not in the editor header where it
+                      used to. The footer is sticky, so this is on screen whenever the editor is; the
+                      header is up to fifty-seven controls above, and the footer exists precisely so an
+                      administrator never scrolls back up to it. While a modal also carried the reason
+                      that did not matter. Now this is the only channel, so it has to be where the press
+                      happened. role/aria-live are kept from its old home, so it is announced as well as
+                      seen.
+                    -->
+                    <div
+                      id="saml-save-status"
+                      class="sso-save-status"
+                      role="status"
+                      aria-live="polite"
+                    ></div>
                     <button
                       id="saml-SaveProvider"
                       is="emby-button"

--- a/SSO-Auth/Web/serverPage.html
+++ b/SSO-Auth/Web/serverPage.html
@@ -97,6 +97,21 @@
             hidden
           ></div>
 
+          <!--
+            The unsaved-changes indicator (#1572). Hidden until a control on this page is edited by a
+            person; the text is written by sso-core.js renderUnsavedNotice with textContent (#221) and
+            carries no configuration value. It is above the columns rather than beside the save, because
+            its second job is to say why a tab returned to was NOT refreshed, and that has to be readable
+            at the moment of arrival rather than after scrolling past every field.
+          -->
+          <div
+            id="sso-unsaved"
+            class="fieldDescription sso-unsaved"
+            role="status"
+            aria-live="polite"
+            hidden
+          ></div>
+
           <div class="sso-columns">
             <div class="sso-column-main">
               <!--
@@ -161,10 +176,10 @@
               <!--
             Login-page buttons (#722): GLOBAL setting. ManageLoginPageButtons lives on the root
             PluginConfiguration, not on a provider, so it deliberately sits OUTSIDE both provider forms
-            and carries NO sso-* marker class: it is saved by its own handler (sso-core.js
-            saveLoginButtons), which re-posts the whole configuration with only this flag changed, and
-            loaded by loadConfiguration. The per-provider button settings (HideLoginButton,
-            LoginButtonText) are ordinary persisting provider-form fields in each editor below.
+            and carries NO sso-* marker class: it is saved by this page's own Save (sso-core.js
+            saveServerSettings), which re-posts the whole configuration with only this page's two flags
+            changed, and loaded by loadConfiguration. The per-provider button settings (HideLoginButton,
+            LoginButtonText) are ordinary persisting provider-form fields in each provider's editor.
           -->
               <form id="sso-login-buttons" class="esqConfigurationForm">
                 <div
@@ -198,15 +213,6 @@
                         custom label.
                       </div>
                     </div>
-
-                    <button
-                      id="SaveLoginButtons"
-                      is="emby-button"
-                      type="button"
-                      class="raised button-submit block emby-button"
-                    >
-                      <span>Save</span>
-                    </button>
                   </div>
                 </div>
               </form>
@@ -214,10 +220,9 @@
               <!--
             Single Logout (#727): GLOBAL setting. EnableSingleLogout lives on the root PluginConfiguration,
             not on a provider, so, like ManageLoginPageButtons above, it sits OUTSIDE both provider forms and
-            carries NO sso-* marker class: it is saved by its own handler (sso-core.js saveSingleLogout), which
-            re-posts the whole configuration with only this flag changed, and loaded by loadConfiguration. The
-            per-provider return URL (PostLogoutRedirectUri) is an ordinary persisting provider-form field in
-            each editor below.
+            carries NO sso-* marker class: it is saved by this page's Save together with that flag (sso-core.js
+            saveServerSettings) and loaded by loadConfiguration. The per-provider return URL
+            (PostLogoutRedirectUri) is an ordinary persisting provider-form field in each provider's editor.
           -->
               <form id="sso-single-logout" class="esqConfigurationForm">
                 <div
@@ -252,18 +257,40 @@
                         optional post-logout redirect URL in its editor below.
                       </div>
                     </div>
-
-                    <button
-                      id="SaveSingleLogout"
-                      is="emby-button"
-                      type="button"
-                      class="raised button-submit block emby-button"
-                    >
-                      <span>Save</span>
-                    </button>
                   </div>
                 </div>
               </form>
+
+              <!--
+            ONE SAVE FOR THIS PAGE (#1572). The two switches above each had their own button and their own
+            handler, and each handler re-read the whole configuration, set its own flag and posted the
+            result. This button replaces both with sso-core.js saveServerSettings, which reads that
+            document ONCE, sets both flags on it and posts it ONCE - so there is no moment at which one
+            flag is stored and the other is not, and a refusal leaves both exactly as they were stored.
+            That is why merging the buttons was #1527's deferral and not its layout work.
+
+            It sits outside both forms, because it belongs to neither: a button inside one of them would
+            read as that section's save. The outcome is rendered into the region below it rather than
+            raised as an alert - a modal that has to be dismissed says nothing a reader can come back to.
+          -->
+              <div class="verticalSection sso-page-save">
+                <button
+                  id="SaveServerSettings"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span data-i18n="config.save_server"
+                    >Save server settings</span
+                  >
+                </button>
+                <div
+                  id="sso-page-status"
+                  class="sso-save-status"
+                  role="status"
+                  aria-live="polite"
+                ></div>
+              </div>
             </div>
             <aside class="sso-column-rail"></aside>
           </div>

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -9,6 +9,13 @@ function tr(key, englishDefault, params) {
   return i18n ? i18n.t(key, params, englishDefault) : englishDefault;
 }
 
+// What the tracked controls of a page held the last time it was read (#1572), keyed on the page element.
+// The unsaved-changes state is the difference between this and what they hold now; markPageClean is the
+// only writer, and what that means is argued where it is defined. Weak, so a view the dashboard discards
+// takes its entry with it, and module-scope rather than an attribute because a 123-control signature is
+// this module's bookkeeping and not a fact about the page.
+const pageBaselines = new WeakMap();
+
 // The Jellyfin account routing that a revoke restores (#1121). The Unregister endpoint PERSISTS
 // whatever the caller sends here onto the account, so a wrong string does not fail the request: it routes
 // that account to core's InvalidAuthenticationProvider, which refuses every password, and nothing on this
@@ -305,8 +312,18 @@ const ssoConfigurationPage = {
       ].forEach((element) => {
         if (element) {
           element.disabled = managed;
+          // The freeze's own record of why (#1572). The Save gate reads it rather than remembering what
+          // it disabled: two owners writing one boolean cannot compose, and the direction that fails is
+          // the gate handing a frozen Save back. Written by the party that knows.
+          element.dataset.ssoManaged = managed ? "true" : "";
         }
       });
+
+      // The freeze runs as a microtask, so on the paths that call it after the gate - addProvider,
+      // addSamlProvider, a profile selected while the report was in flight - it writes `disabled`
+      // directly and clears whatever the gate had just decided. Re-asserting here is what makes the
+      // composition hold in BOTH orders rather than in the one that happened to be tested (#1572).
+      ssoConfigurationPage.updateSaveAvailability(page);
 
       const note = page.querySelector("#profile-managed-note");
       if (note) {
@@ -372,7 +389,14 @@ const ssoConfigurationPage = {
             return;
           }
           element.disabled = managed;
+          // The freeze's own record of why (#1572), read by the Save gate. See the same line in
+          // applyManagedProfileState for the reason it is written here rather than remembered there.
+          element.dataset.ssoManaged = managed ? "true" : "";
         });
+
+      // Same reason as applyManagedProfileState: this pass lands after the gate on the add paths and
+      // writes `disabled` directly, so the gate is re-asserted once the freeze has had its say.
+      ssoConfigurationPage.updateSaveAvailability(page);
 
       if (note) {
         // textContent, never innerHTML (#221). The text is fixed and carries no provider value, so nothing
@@ -445,19 +469,24 @@ const ssoConfigurationPage = {
           );
         }
         // The GLOBAL login-page buttons opt-in (#722) rides the same configuration load. It is a root
-        // PluginConfiguration flag, not a provider field, so it has its own save path (saveLoginButtons)
+        // PluginConfiguration flag, not a provider field, so it has the Server page's save path (saveServerSettings)
         // and no sso-* marker class. On the Server tab since #1527.
         const manage_buttons = page.querySelector("#ManageLoginPageButtons");
         if (manage_buttons) {
           manage_buttons.checked = Boolean(config.ManageLoginPageButtons);
+          // What this switch was FILLED with, so the save can tell a switch the administrator moved from
+          // one they never touched (#1572). See saveServerSettings for why that distinction is the whole
+          // difference between one Save and one lost update.
+          manage_buttons.dataset.ssoLoaded = String(manage_buttons.checked);
         }
 
         // The GLOBAL Single Logout opt-in (#727) rides the same configuration load. Like
         // ManageLoginPageButtons it is a root PluginConfiguration flag, not a provider field, so it has its
-        // own save path (saveSingleLogout) and no sso-* marker class.
+        // own save path (saveServerSettings, together with the flag above) and no sso-* marker class.
         const single_logout = page.querySelector("#EnableSingleLogout");
         if (single_logout) {
           single_logout.checked = Boolean(config.EnableSingleLogout);
+          single_logout.dataset.ssoLoaded = String(single_logout.checked);
         }
 
         // The GLOBAL provisioning profile set (#1105) rides the same configuration load, for the
@@ -471,6 +500,11 @@ const ssoConfigurationPage = {
         // The Overview tab reads the same configuration rather than a second endpoint, so what it says
         // about a provider and what the editor shows for it cannot come apart.
         ssoConfigurationPage.renderOverviewFrom(page, config);
+
+        // What the page now shows IS the stored configuration, so it is clean (#1572). This is the one
+        // place that has to say so, because every save, delete and import path ends here - and it is
+        // what re-runs the Save gate against the values that were just filled in.
+        ssoConfigurationPage.markPageClean(page);
       },
     );
 
@@ -577,9 +611,16 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.resetEditor(page);
     ssoConfigurationPage.clearValidationErrors(page);
     ssoConfigurationPage.renderSaveStatus(page, "");
+    // The page-level region still holds the outcome of the last delete, which was about a provider that
+    // is gone (#1572). Opening another one is a new act, so it starts with nothing asserted.
+    ssoConfigurationPage.renderPageStatus(page, "");
     ssoConfigurationPage.setEditorTitle(page, provider_name);
     ssoConfigurationPage.showEditor(page);
     ssoConfigurationPage.loadProvider(page, provider_name);
+    // Opening an editor is a read, not an edit: whatever the previous provider left behind is gone with
+    // resetEditor, and loadProvider marks the page clean again once its own fill lands (#1572). This call
+    // covers the window before that, so a Save is never live over a half-reset form.
+    ssoConfigurationPage.markPageClean(page);
     page.querySelector("#sso-editor").scrollIntoView({ block: "start" });
   },
   // Open a blank editor for a NEW provider. Every toggle is reset OFF (fail closed), the same security
@@ -590,6 +631,7 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.resetEditor(page);
     ssoConfigurationPage.clearValidationErrors(page);
     ssoConfigurationPage.renderSaveStatus(page, "");
+    ssoConfigurationPage.renderPageStatus(page, "");
     ssoConfigurationPage.setEditorTitle(
       page,
       tr("config.new_provider", "New provider"),
@@ -599,6 +641,9 @@ const ssoConfigurationPage = {
     // left frozen by a managed provider opened just before (#1104).
     ssoConfigurationPage.applyManagedState(page, "oid", "");
     ssoConfigurationPage.showEditor(page);
+    // A blank editor holds nothing anybody typed, so the page is clean and its Save is closed until the
+    // three required fields carry a value (#1572).
+    ssoConfigurationPage.markPageClean(page);
     page.querySelector("#sso-editor").scrollIntoView({ block: "start" });
     page.querySelector("#OidProviderName").focus();
   },
@@ -911,6 +956,226 @@ const ssoConfigurationPage = {
       return;
     }
     ssoConfigurationPage.setFieldError(page, "OidProviderName", "");
+  },
+  // ---- The unsaved-changes state (#1572) ----
+  //
+  // WHAT IT IS FOR, AND WHY THE THREE THINGS BELOW ARE ONE THING. The dashboard keeps three views alive
+  // and hands a cached one back rather than building it again, so a tab returned to has NOT re-run its
+  // controller and still shows whatever it last loaded. #1527 made Overview re-read on every show and
+  // left the other four alone deliberately, because re-reading them re-fills form controls and would
+  // silently discard an edit an administrator had made and not yet saved. Knowing whether the page is
+  // dirty is exactly what makes the safe re-read possible, and it is the same state the indicator needs
+  // and the same state the Save gate needs - so the three arrive together rather than this being built
+  // three times or the refresh being built on a guess.
+  //
+  // THE EVENT IS THE TRIGGER AND THE VALUES ARE THE AUTHORITY, AND THE FIRST DRAFT HAD IT THE OTHER WAY
+  // ROUND. That draft marked the page dirty on an `input` or `change` whose `isTrusted` was true, on the
+  // reasoning that this page's own fills write `.value` and `.checked` directly and fire nothing. The
+  // reasoning was about THIS file and the controls are the host's. Two of them dispatch their own
+  // synthetic events, which carry `isTrusted` false, and both were measured in jellyfin-web rather than
+  // supposed: `emby-checkbox` toggles `checked` and dispatches a bubbling `CustomEvent('change')` when
+  // the control is operated from the KEYBOARD, and `emby-select` dispatches `new Event('change', {
+  // bubbles: false })` when its value is set through the action sheet. Under the first draft a keyboard
+  // user could change every switch on the Server page, have the page go on reading as clean, and lose
+  // the lot to the re-read on the next return to the tab - the exact failure this state exists to stop,
+  // aimed at the people least able to work around it.
+  //
+  // So an event only asks the question, and what answers it is a comparison of the tracked controls
+  // against what the last fill left on them. That is correct whoever dispatched the event and whatever
+  // flag it carries: a fill that fires an event compares equal and stays clean, a person who changes a
+  // control compares different and is dirty, and a person who changes one back is clean again.
+  //
+  // THE LISTENER IS IN THE CAPTURE PHASE AND THAT IS LOAD-BEARING, not defensive. `emby-select`'s event
+  // sets `bubbles: false`, so a bubble-phase listener on the page never sees it at all. Measured in a
+  // browser rather than reasoned: a non-bubbling event dispatched on a descendant IS delivered to a
+  // capture-phase listener on an ancestor, and is NOT delivered to a bubble-phase one.
+  //
+  // WHAT IS DELIBERATELY NOT TRACKED. A file input is a transfer trigger rather than a setting: it is
+  // cleared to "" after every use and nothing saves it. The provider and profile selectors NAVIGATE -
+  // changing one refills the form from the stored configuration, so what it leaves behind is a fresh
+  // read and not an unsaved edit, and those reset the page to clean instead of dirtying it.
+  navigationControlIds: [
+    "selectProvider",
+    "saml-selectProvider",
+    "selectProvisioningProfile",
+  ],
+  // Every control on the page an administrator can edit and a Save on that page would commit. Accounts
+  // holds exactly one control, a hidden file input, so this is empty there and that page can never be
+  // dirty - which is why it re-reads on every show alongside Overview.
+  editableControls: (page) =>
+    [...page.querySelectorAll("input, select, textarea")].filter(
+      (element) =>
+        element.type !== "file" &&
+        ssoConfigurationPage.navigationControlIds.indexOf(element.id) === -1,
+    ),
+  // What the tracked controls hold right now, as one comparable string. A checkbox is read from
+  // `checked` and everything else from `value`, and the id rides along so a control appearing or
+  // disappearing - a permission row, a folder checklist filled from the server - is a difference rather
+  // than something two lengths could cancel out.
+  controlSignature: (page) =>
+    ssoConfigurationPage
+      .editableControls(page)
+      .map(
+        (element) =>
+          element.id +
+          "=" +
+          (element.type === "checkbox" || element.type === "radio"
+            ? String(element.checked)
+            : String(element.value)),
+      )
+      .join(""),
+  isPageDirty: (page) => page.classList.contains("sso-page-dirty"),
+  markPageDirty: (page) => {
+    page.classList.add("sso-page-dirty");
+    ssoConfigurationPage.renderUnsavedNotice(page);
+    ssoConfigurationPage.updateSaveAvailability(page);
+  },
+  // Back to clean, which is what every fill path and every successful save leaves behind, and the ONE
+  // place the baseline is taken: clean means "what is on the page is what the last read put there", so
+  // the two statements cannot come apart. It re-runs the Save gate too, because a fill changes the
+  // values that gate reads.
+  //
+  // The baseline is held in a module-scope map keyed on the view rather than on the element, because it
+  // is this module's bookkeeping and not a fact about the page - and because a 123-control signature is
+  // not something to put in an attribute. The map is weak, so a view the dashboard discards takes its
+  // entry with it.
+  markPageClean: (page) => {
+    pageBaselines.set(page, ssoConfigurationPage.controlSignature(page));
+    page.classList.remove("sso-page-dirty");
+    ssoConfigurationPage.renderUnsavedNotice(page);
+    ssoConfigurationPage.updateSaveAvailability(page);
+  },
+  // Whether the page now holds something other than what the last read left on it. A page whose baseline
+  // was never taken is treated as EDITED rather than clean: the only way to get there is a controller
+  // that did not finish wiring, and the safe answer to "may I replace what is on this page" is no.
+  pageDiffersFromBaseline: (page) => {
+    const baseline = pageBaselines.get(page);
+    return (
+      baseline === undefined ||
+      baseline !== ssoConfigurationPage.controlSignature(page)
+    );
+  },
+  // The indicator. It says what is true of this page and promises nothing about another one: opening a
+  // different provider in the editor still replaces what is in it, which is what it has always done and
+  // is not this change's to alter. textContent, never innerHTML (#221); the text carries no
+  // configuration value.
+  unsavedNoticeText: () =>
+    tr(
+      "config.unsaved",
+      "Unsaved changes in this editor. Save them before you open another provider or leave this page, or they are lost.",
+    ),
+  renderUnsavedNotice: (page) => {
+    const box = page.querySelector("#sso-unsaved");
+    if (!box) {
+      return;
+    }
+    const dirty = ssoConfigurationPage.isPageDirty(page);
+    box.textContent = dirty ? ssoConfigurationPage.unsavedNoticeText() : "";
+    box.hidden = !dirty;
+  },
+  // What each Save on a page needs before it can be pressed, DERIVED from the readiness specs rather
+  // than restated, so a required field added to an editor closes its Save without a second edit here. A
+  // gate whose region is hidden is skipped: the button is not reachable, and touching it would fight
+  // whoever hid it.
+  saveGates: () => [
+    {
+      button: "#SaveProvider",
+      region: "#sso-editor",
+      requiredIds: ssoConfigurationPage.readinessSpecs.oid.requiredIds,
+    },
+    {
+      button: "#saml-SaveProvider",
+      region: "#saml-editor",
+      requiredIds: ssoConfigurationPage.readinessSpecs.saml.requiredIds,
+    },
+    {
+      // The SELECTOR and not the name box: saveProvisioningProfile keys off `#selectProvisioningProfile`
+      // and the name box is the add/rename parameter, so gating on the name closed the Save when an
+      // administrator cleared the rename field and left it open when no profile was selected at all -
+      // both backwards.
+      button: "#SaveProvisioningProfile",
+      region: null,
+      requiredIds: ["selectProvisioningProfile"],
+    },
+    { button: "#SaveServerSettings", region: null, requiredIds: [] },
+  ],
+  // WHICH FAILURES CLOSE A SAVE, AND WHY NOT ALL OF THEM. #365 put the validators beside the fields as
+  // pre-emptive WARNINGS and argued they must never block, because a false positive would lock an
+  // administrator out of saving a value the server would have accepted. That argument is about the
+  // validators that GUESS - an endpoint shape, a base URL - and it still holds for them: they go on
+  // warning and go on not blocking. It does not reach an EMPTY REQUIRED FIELD, which the server refuses
+  // every time, so a Save left live for one is a Save that exists to fail. The emptiness is read from
+  // the VALUES rather than from the validators' output boxes, exactly as the readiness panel reads it,
+  // so typing into a blank field re-opens the Save on the keystroke instead of on the next blur.
+  saveGateEmpties: (page, gate) =>
+    gate.requiredIds.filter((id) => {
+      const field = page.querySelector("#" + id);
+      return field && !String(field.value || "").trim();
+    }),
+  // ONE WRITER, TWO DECLARED REASONS, AND WHY THE FIRST DRAFT OF THIS WAS A FAIL-OPEN.
+  //
+  // Two parties want this button disabled: this gate, while a required field is empty, and the
+  // declarative-source freeze (#1104), because a provider or a profile a configuration file owns may not
+  // be edited here. A boolean with two owners cannot compose, and the draft that tried to remember what
+  // it had disabled handed a frozen Save back: opening the Policies tab with no profile selected left the
+  // gate holding the button down, and selecting a MANAGED profile then filled the name, so the gate saw
+  // nothing left to block and released a Save the freeze had just closed - `applyManagedProfileState`
+  // runs before the fill's `markPageClean`, so its disable was the one being cleared.
+  //
+  // So the freeze records its own reason on the button and this reads it. The write is in one place and
+  // each reason is asserted by the party that knows it; a reason nobody wrote is nobody's, and the only
+  // other writers of `disabled` on these buttons are the two freeze functions, which now both mark.
+  setSaveBlocked: (button, blocked) => {
+    button.disabled = blocked || button.dataset.ssoManaged === "true";
+  },
+  updateSaveAvailability: (page) => {
+    ssoConfigurationPage.saveGates().forEach((gate) => {
+      const button = page.querySelector(gate.button);
+      if (!button) {
+        return;
+      }
+      const region = gate.region ? page.querySelector(gate.region) : null;
+      if (region && region.hidden) {
+        return;
+      }
+      ssoConfigurationPage.setSaveBlocked(
+        button,
+        ssoConfigurationPage.saveGateEmpties(page, gate).length > 0,
+      );
+    });
+  },
+  // One delegated listener per page rather than one per control, so a control the page renders later - a
+  // permission row, a folder checkbox - is tracked from the moment it exists. Capture phase for the two
+  // reasons written at the top of this section: a non-bubbling event reaches nothing else, and a handler
+  // that stops propagation on its own control would otherwise hide the edit from this.
+  bindUnsavedChangeTracking: (page) => {
+    const observe = (event) => {
+      if (!event.target) {
+        return;
+      }
+      if (
+        ssoConfigurationPage.navigationControlIds.indexOf(event.target.id) !==
+        -1
+      ) {
+        ssoConfigurationPage.markPageClean(page);
+        return;
+      }
+      if (
+        ssoConfigurationPage.editableControls(page).indexOf(event.target) === -1
+      ) {
+        return;
+      }
+      // The event only asks; the values answer. `isTrusted` is deliberately NOT read - two of the host's
+      // own controls dispatch synthetic events on real user input, and the reason is at the top of this
+      // section.
+      if (ssoConfigurationPage.pageDiffersFromBaseline(page)) {
+        ssoConfigurationPage.markPageDirty(page);
+      } else {
+        ssoConfigurationPage.markPageClean(page);
+      }
+    };
+    page.addEventListener("input", observe, true);
+    page.addEventListener("change", observe, true);
   },
   renderSaveStatus: (page, message, ok) => {
     const box = page.querySelector("#sso-save-status");
@@ -1271,7 +1536,7 @@ const ssoConfigurationPage = {
   //
   // ProvisioningProfiles is a root PluginConfiguration member - a named set of ProvisioningPolicyTemplate -
   // so every act here fetches the live configuration, changes only that member (and, on a rename, the
-  // references to it), and re-posts the whole document, exactly as saveLoginButtons does. Nothing here adds
+  // references to it), and re-posts the whole document, exactly as saveServerSettings does. Nothing here adds
   // a server route.
   //
   // Two of the four acts can break a provider, and both are checked against the live configuration BEFORE
@@ -1524,15 +1789,20 @@ const ssoConfigurationPage = {
     const name = page.querySelector("#selectProvisioningProfile").value;
     page.querySelector("#ProvisioningProfileName").value = name;
 
-    return ssoConfigurationPage
-      .fillProvisioningTemplate(
-        page,
-        "profile-",
-        (config.ProvisioningProfiles || {})[name] || null,
-        null,
-        [],
-      )
-      .then(() => ssoConfigurationPage.applyManagedProfileState(page, name));
+    return (
+      ssoConfigurationPage
+        .fillProvisioningTemplate(
+          page,
+          "profile-",
+          (config.ProvisioningProfiles || {})[name] || null,
+          null,
+          [],
+        )
+        .then(() => ssoConfigurationPage.applyManagedProfileState(page, name))
+        // The editor now holds the selected profile as it is stored, so the page is clean and the Save gate
+        // is re-run against the name that was just filled in (#1572).
+        .then(() => ssoConfigurationPage.markPageClean(page))
+    );
   },
   // The one write path of the four acts: re-post the whole configuration, then reload the page's view of it.
   // A rejected PUT is reported in this section's own status region rather than swallowed - the server can
@@ -2130,6 +2400,9 @@ const ssoConfigurationPage = {
           );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "oid");
+        // The editor now holds the stored provider, so the page is clean and the Save gate is re-run
+        // against what was filled in rather than against what stood here before (#1572).
+        ssoConfigurationPage.markPageClean(page);
       },
     );
   },
@@ -2261,7 +2534,14 @@ const ssoConfigurationPage = {
             // The deleted provider is gone from the list; close its now-stale editor.
             ssoConfigurationPage.hideEditor(page);
 
-            Dashboard.alert("Provider removed");
+            // The PAGE region and not the editor's (#1572): the line above just hid the editor and the
+            // editor's status box lives inside it, so an outcome written there would be invisible. That
+            // is what an outcome needs now that it is no longer raised as a modal alert.
+            ssoConfigurationPage.renderPageStatus(
+              page,
+              tr("config.provider_removed", "Provider removed."),
+              true,
+            );
           },
           // Report a genuine save failure rather than swallowing it. The delete
           // re-posts the whole configuration, so the server can now reject it for
@@ -2269,85 +2549,139 @@ const ssoConfigurationPage = {
           // reserved-character name became "new" because it was removed from the
           // live config in the meantime (#336). Without this the PUT would reject
           // silently and the provider would appear undeleted with no explanation.
+          // The FAILED arm does not hide the editor, so its outcome goes in the editor's own region, beside
+          // the Delete button that was pressed - not in the page region, which is where the success arm
+          // speaks because the success arm has just closed that editor (#1572).
           function () {
-            Dashboard.alert({
-              title: "Delete failed",
-              message:
-                "Could not remove the provider. The saved configuration was rejected by the server; reload the page and try again.",
-            });
+            ssoConfigurationPage.renderSaveStatus(
+              page,
+              tr(
+                "config.provider_remove_failed",
+                "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
+              ),
+              false,
+            );
           },
         );
       },
     );
   },
-  // Save the GLOBAL login-page buttons opt-in (#722). ManageLoginPageButtons is a root
-  // PluginConfiguration flag, so this fetches the live configuration, changes ONLY this flag, and
-  // re-posts the whole document: the provider dictionaries and every other root setting ride along
-  // unchanged, exactly as the provider save/delete paths do. The server reacts to the saved
-  // configuration itself (LoginButtonManager listens for the configuration change), so no extra
-  // endpoint call is needed: on save the managed block is injected/refreshed, or, with the flag
-  // off, only the managed region is removed and the admin's own branding is preserved.
-  saveLoginButtons: (page) => {
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+  // ONE SAVE FOR THE SERVER PAGE (#1572), AND THE PARTIAL FAILURE IT DOES NOT HAVE.
+  //
+  // The two GLOBAL switches this page carries - ManageLoginPageButtons (#722) and EnableSingleLogout
+  // (#727) - each had their own button and their own handler, and each handler re-read the whole
+  // configuration, set its own flag and posted the result. One Save over two such handlers would be two
+  // writes with no transaction between them: a failure on the second leaves the first applied while the
+  // page shows a single outcome for a half-written pair, which is why #1527 refused to merge the buttons
+  // and left the write path to this issue.
+  //
+  // WHAT REMOVES THE HAZARD IS NOT A TRANSACTION, IT IS THERE BEING ONE WRITE. Both flags are members of
+  // the SAME root PluginConfiguration document, so this reads that document once, sets both flags on it,
+  // and posts it once. There is no moment at which one flag is stored and the other is not: the server
+  // writes the document whole or refuses it whole. A rejected PUT therefore leaves BOTH switches exactly
+  // as they were stored, which is what the failure message says, and the reload that follows a success
+  // is what re-reads the stored pair rather than trusting what was posted.
+  //
+  // What rides along unchanged is the rest of the document - the provider dictionaries, the provisioning
+  // profiles, every other root setting - exactly as the provider save and delete paths carry them, so a
+  // save here is not a way to lose a setting this page does not show. The server reacts to the saved
+  // configuration itself (LoginButtonManager listens for the configuration change), so no extra endpoint
+  // call is needed: on save the managed login block is injected or refreshed, or, with the flag off,
+  // only that managed region is removed and an administrator's own branding is preserved.
+  //
+  // The outcome is rendered INLINE in this page's own status region rather than raised as an alert
+  // (#1572): a modal that has to be dismissed says nothing a reader can come back to, and the failure
+  // sentence here is the one that has to survive being re-read.
+  saveServerSettings: (page) => {
+    ssoConfigurationPage.renderPageStatus(page, "");
+    return ApiClient.getPluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+    ).then(
       (config) => {
-        config.ManageLoginPageButtons = page.querySelector(
+        // ONLY WHAT THE ADMINISTRATOR MOVED, WHICH IS WHAT THE TWO OLD HANDLERS DID BY ACCIDENT OF BEING
+        // TWO. Each of them set its own flag on the freshly-read document and left the other alone, so a
+        // change made elsewhere between this page's load and its save survived. Writing both from the
+        // form takes that away: a second administrator who turns Single Logout on is silently undone by
+        // the first pressing Save over a page loaded before it - a security flag switched off by somebody
+        // who never touched it. So the merge keeps the property rather than the shape: a switch still
+        // showing what it was loaded with is not written at all, and the value the read returned stands.
+        ssoConfigurationPage.applyMovedSwitch(
+          page,
+          config,
           "#ManageLoginPageButtons",
-        ).checked;
+          "ManageLoginPageButtons",
+        );
+        ssoConfigurationPage.applyMovedSwitch(
+          page,
+          config,
+          "#EnableSingleLogout",
+          "EnableSingleLogout",
+        );
 
-        ApiClient.updatePluginConfiguration(
+        return ApiClient.updatePluginConfiguration(
           ssoConfigurationPage.pluginUniqueId,
           config,
         ).then(
-          function (result) {
+          (result) => {
             Dashboard.processPluginConfigurationUpdateResult(result);
             ssoConfigurationPage.loadConfiguration(page);
-            Dashboard.alert("Settings saved.");
+            ssoConfigurationPage.renderPageStatus(
+              page,
+              tr("config.server_settings_saved", "Both server settings saved."),
+              true,
+            );
           },
           // Report a genuine save failure rather than swallowing it: this PUT re-posts the whole
-          // configuration, so the server can reject it for a reason unrelated to this toggle (#336).
-          function () {
-            Dashboard.alert({
-              title: "Save failed",
-              message:
-                "Could not save the login-page button setting. The saved configuration was rejected by the server; reload the page and try again.",
-            });
-          },
+          // configuration, so the server can reject it for a reason neither switch caused (#336).
+          () =>
+            ssoConfigurationPage.renderPageStatus(
+              page,
+              tr(
+                "config.server_settings_save_failed",
+                "The server refused the saved configuration, so NEITHER switch was changed - the two ride one document and are written together or not at all. Reload the page to see what is stored, and try again.",
+              ),
+              false,
+            ),
         );
       },
+      // The read that precedes the write can fail on its own, and a page that says nothing after a
+      // pressed Save reads as a save that worked. Nothing was posted in this arm, so nothing changed.
+      () =>
+        ssoConfigurationPage.renderPageStatus(
+          page,
+          tr(
+            "config.server_settings_read_failed",
+            "Could not read the stored configuration, so nothing was saved and neither switch was changed. Reload the page and try again.",
+          ),
+          false,
+        ),
     );
   },
-  // Save the GLOBAL Single Logout opt-in (#727). EnableSingleLogout is a root PluginConfiguration flag, so
-  // this fetches the live configuration exactly like saveLoginButtons, changes ONLY this flag, and
-  // re-posts the whole document, so the provider dictionaries and every other root setting ride along
-  // unchanged. The per-provider post-logout redirect URL is saved with its provider, not here.
-  saveSingleLogout: (page) => {
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
-      (config) => {
-        config.EnableSingleLogout = page.querySelector(
-          "#EnableSingleLogout",
-        ).checked;
-
-        ApiClient.updatePluginConfiguration(
-          ssoConfigurationPage.pluginUniqueId,
-          config,
-        ).then(
-          function (result) {
-            Dashboard.processPluginConfigurationUpdateResult(result);
-            ssoConfigurationPage.loadConfiguration(page);
-            Dashboard.alert("Settings saved.");
-          },
-          // Report a genuine save failure rather than swallowing it: this PUT re-posts the whole
-          // configuration, so the server can reject it for a reason unrelated to this toggle (#336).
-          function () {
-            Dashboard.alert({
-              title: "Save failed",
-              message:
-                "Could not save the Single Logout setting. The saved configuration was rejected by the server; reload the page and try again.",
-            });
-          },
-        );
-      },
-    );
+  // Writes one switch onto the document being saved, and ONLY where it differs from what the page was
+  // loaded with. A switch nobody moved leaves the read value in place, so this Save cannot carry a stale
+  // view of a flag its user never touched. A control the load never reached carries no loaded value, and
+  // is left alone for the same reason: nothing here knows what it means.
+  applyMovedSwitch: (page, config, selector, property) => {
+    const control = page.querySelector(selector);
+    if (!control || control.dataset.ssoLoaded === undefined) {
+      return;
+    }
+    if (String(control.checked) !== control.dataset.ssoLoaded) {
+      config[property] = control.checked;
+    }
+  },
+  // The Server page's own status region, the exact parallel of renderSaveStatus on Providers, so one
+  // page's outcome can never be written over another's.
+  renderPageStatus: (page, message, ok) => {
+    const box = page.querySelector("#sso-page-status");
+    if (!box) {
+      return;
+    }
+    box.textContent = message || "";
+    box.classList.remove("sso-status-ok", "sso-status-fail");
+    if (message) {
+      box.classList.add(ok ? "sso-status-ok" : "sso-status-fail");
+    }
   },
   saveProvider: (page, provider_name) => {
     return new Promise((resolve, reject) => {
@@ -2413,20 +2747,15 @@ const ssoConfigurationPage = {
             ssoConfigurationPage.loadProvider(page, provider_name);
 
             page.querySelector("#selectProvider").value = provider_name;
-            Dashboard.alert("Settings saved.");
+            // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
             resolve();
           },
           // Rejection handler attached directly to the save call, so it reports only a genuine save
           // failure and not an error thrown by the post-save UI work above. The server can refuse a
           // save for more than one reason (a malformed Base URL Override, #139; a provider name with
-          // URI-reserved or control characters, #336/#360), so the message names both checks instead of
-          // blaming one.
+          // URI-reserved or control characters, #336/#360), so the message the caller renders names both
+          // checks instead of blaming one.
           function () {
-            Dashboard.alert({
-              title: "Save failed",
-              message:
-                "Could not save the provider. Check that the provider name has no control characters (such as a tab or newline, often introduced by copy-paste), no backslash, and none of the URI-reserved characters such as / ? # %, and that the Base URL Override is a full URL such as https://jellyfin.example.com (or blank).",
-            });
             reject(new Error("Provider save failed"));
           },
         );
@@ -3601,9 +3930,13 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.resetSamlEditor(page);
     ssoConfigurationPage.clearSamlValidationErrors(page);
     ssoConfigurationPage.renderSamlSaveStatus(page, "");
+    ssoConfigurationPage.renderPageStatus(page, "");
     ssoConfigurationPage.setSamlEditorTitle(page, provider_name);
     ssoConfigurationPage.showSamlEditor(page);
     ssoConfigurationPage.loadSamlProvider(page, provider_name);
+    // The same reason openProvider states: opening an editor is a read, and loadSamlProvider says so
+    // again once its own fill lands (#1572).
+    ssoConfigurationPage.markPageClean(page);
     page.querySelector("#saml-editor").scrollIntoView({ block: "start" });
   },
   addSamlProvider: (page) => {
@@ -3611,6 +3944,7 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.resetSamlEditor(page);
     ssoConfigurationPage.clearSamlValidationErrors(page);
     ssoConfigurationPage.renderSamlSaveStatus(page, "");
+    ssoConfigurationPage.renderPageStatus(page, "");
     ssoConfigurationPage.setSamlEditorTitle(
       page,
       tr("config.new_provider", "New provider"),
@@ -3619,6 +3953,9 @@ const ssoConfigurationPage = {
     // Restores a form left frozen by a managed provider opened just before (#1104); a new one is never managed.
     ssoConfigurationPage.applyManagedState(page, "saml", "");
     ssoConfigurationPage.showSamlEditor(page);
+    // A blank editor holds nothing anybody typed (#1572); its Save stays closed until the four required
+    // fields carry a value.
+    ssoConfigurationPage.markPageClean(page);
     page.querySelector("#saml-editor").scrollIntoView({ block: "start" });
     page.querySelector("#saml-provider-name").focus();
   },
@@ -3838,6 +4175,9 @@ const ssoConfigurationPage = {
           );
         // The panel summarises the fields and toggles this call just wrote (#1083).
         ssoConfigurationPage.refreshReadiness(page, "saml");
+        // The editor now holds the stored provider, so the page is clean and the Save gate is re-run
+        // against what was filled in rather than against what stood here before (#1572).
+        ssoConfigurationPage.markPageClean(page);
       },
     );
   },
@@ -4182,14 +4522,25 @@ const ssoConfigurationPage = {
             Dashboard.processPluginConfigurationUpdateResult(result);
             ssoConfigurationPage.loadConfiguration(page);
             ssoConfigurationPage.hideSamlEditor(page);
-            Dashboard.alert("Provider removed");
+            // The page region, for the reason the OpenID delete states: the editor this outcome belongs
+            // to has just been closed (#1572).
+            ssoConfigurationPage.renderPageStatus(
+              page,
+              tr("config.provider_removed", "Provider removed."),
+              true,
+            );
           },
+          // The editor is still open on this arm; the outcome belongs beside the button. Same reason as the
+          // OpenID delete above.
           function () {
-            Dashboard.alert({
-              title: "Delete failed",
-              message:
-                "Could not remove the provider. The saved configuration was rejected by the server; reload the page and try again.",
-            });
+            ssoConfigurationPage.renderSamlSaveStatus(
+              page,
+              tr(
+                "config.provider_remove_failed",
+                "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
+              ),
+              false,
+            );
           },
         );
       },
@@ -4261,15 +4612,10 @@ const ssoConfigurationPage = {
             ssoConfigurationPage.loadSamlProvider(page, provider_name);
 
             page.querySelector("#saml-selectProvider").value = provider_name;
-            Dashboard.alert("Settings saved.");
+            // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
             resolve();
           },
           function () {
-            Dashboard.alert({
-              title: "Save failed",
-              message:
-                "Could not save the provider. Check that the provider name has no control characters (such as a tab or newline, often introduced by copy-paste), no backslash, and none of the URI-reserved characters such as / ? # %, and that the Base URL Override is a full URL such as https://jellyfin.example.com (or blank).",
-            });
             reject(new Error("Provider save failed"));
           },
         );
@@ -4587,11 +4933,37 @@ const ssoConfigurationPage = {
 // The three calls every page makes are the prelude below. loadConfiguration fills whatever sections the
 // page in front of it actually has and skips the rest, so one load path serves five pages.
 
-/** The three calls every page makes: the stylesheet, the configuration, and the localized labels. */
+/**
+ * The calls every page with controls makes: the stylesheet, the configuration, the localized labels, and
+ * the unsaved-changes tracking.
+ *
+ * WHY THERE IS NO RE-READ ON `viewshow` HERE, WHICH #1572 SET OUT TO ADD. The dirty state was built so a
+ * tab returned to could re-read the server when it held no unsaved edit. It was built, reviewed, and
+ * taken out again, because the review showed the re-read destroys work the dirty state cannot see:
+ *
+ *   - `loadConfiguration` re-populates both library checklists from the server with NOTHING ticked and
+ *     does not re-run `loadProvider`, so a clean return to Providers with an editor open empties the
+ *     ticks; the next save then persists an empty EnabledFolders and every user of that provider loses
+ *     library access at their next sign-in.
+ *   - Removing a permission row or a role-mapping row is a button click. It fires no `input` and no
+ *     `change`, so the page stays clean while holding a real edit, and the Policies re-read renders the
+ *     removed row straight back out of storage.
+ *   - The dirty test happens before an asynchronous fill that lands after it, so an edit made inside
+ *     that window is overwritten and the page then reports itself clean.
+ *
+ * None of the three is a defect in the dirty state; all three are what `loadConfiguration` does, which
+ * was written to run once, at construction, while the editor is still hidden. Making it safe to run
+ * again is its own piece of work and its own issue. What #1572 keeps is the state itself, the indicator
+ * and the Save gate - and the fourth done-condition it was asked for is the one deliberately not met.
+ *
+ * @param {Element} view The page element Jellyfin hands the controller.
+ */
 function initSharedPage(view) {
   ssoConfigurationPage.addTextAreaStyle(view);
   ssoConfigurationPage.loadConfiguration(view);
   ssoConfigurationPage.localize(view);
+  ssoConfigurationPage.bindUnsavedChangeTracking(view);
+  ssoConfigurationPage.markPageClean(view);
 }
 
 // One registration per template-control prefix that this page actually carries, derived from the
@@ -4685,8 +5057,10 @@ function initProvidersPage(view) {
   view.querySelector("#SaveProvider").addEventListener("click", (e) => {
     const target_provider = view.querySelector("#OidProviderName").value;
 
-    // The save alerts the admin on failure via Dashboard.alert; also surface the outcome inline in the
-    // editor header. Handling the rejection here keeps a failed save from becoming an unhandled promise
+    // The outcome is rendered in the editor's own status region and nowhere else (#1572). It used to be
+    // said twice, inline and in a modal alert, and the inline half then had to point at the modal for the
+    // reason - so a reader who dismissed the alert was left with a failure and no cause. The whole
+    // sentence is here now. Handling the rejection keeps a failed save from becoming an unhandled promise
     // rejection (the rejection still exists so callers can distinguish failure from success).
     ssoConfigurationPage.saveProvider(view, target_provider).then(
       () => {
@@ -4696,7 +5070,7 @@ function initProvidersPage(view) {
       () =>
         ssoConfigurationPage.renderSaveStatus(
           view,
-          "Save failed. See the details in the alert.",
+          "Could not save the provider. Check that the provider name has no control characters (such as a tab or newline, often introduced by copy-paste), no backslash, and none of the URI-reserved characters such as / ? # %, and that the Base URL Override is a full URL such as https://jellyfin.example.com (or blank).",
           false,
         ),
     );
@@ -4850,10 +5224,13 @@ function initProvidersPage(view) {
         );
         ssoConfigurationPage.setSamlEditorTitle(view, target_provider);
       },
+      // The whole reason, inline, rather than a pointer at a modal the reader has already dismissed
+      // (#1572). The server refuses a save for more than one reason, so the sentence names both checks
+      // instead of blaming one.
       () =>
         ssoConfigurationPage.renderSamlSaveStatus(
           view,
-          "Save failed. See the details in the alert.",
+          "Could not save the provider. Check that the provider name has no control characters (such as a tab or newline, often introduced by copy-paste), no backslash, and none of the URI-reserved characters such as / ? # %, and that the Base URL Override is a full URL such as https://jellyfin.example.com (or blank).",
           false,
         ),
     );
@@ -5130,17 +5507,14 @@ function initPoliciesPage(view) {
 function initServerPage(view) {
   initSharedPage(view);
 
-  view.querySelector("#SaveLoginButtons").addEventListener("click", (e) => {
-    ssoConfigurationPage.saveLoginButtons(view);
+  // One Save for both switches (#1572). Two buttons became one because the two flags are members of one
+  // document and are written by one PUT; what that removes is written at saveServerSettings.
+  view.querySelector("#SaveServerSettings").addEventListener("click", (e) => {
+    ssoConfigurationPage.saveServerSettings(view);
     e.preventDefault();
     return false;
   });
 
-  view.querySelector("#SaveSingleLogout").addEventListener("click", (e) => {
-    ssoConfigurationPage.saveSingleLogout(view);
-    e.preventDefault();
-    return false;
-  });
   view.querySelector("#ExportConfig").addEventListener("click", (e) => {
     ssoConfigurationPage.exportConfig(view);
     e.preventDefault();

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -5015,7 +5015,10 @@ function bindTemplatePermissionAdders(view) {
  * would silently discard an edit made before a glance at another tab. Overview has no control at all -
  * none of the page's 123 - so re-reading it can lose nothing. What that leaves is a Providers, Policies
  * or Server tab returned to after a change made elsewhere still showing the older list until it is
- * reloaded, which is stated on the pull request rather than left to be discovered.
+ * reloaded. #1572 tried to close that and was refused: re-reading a page with an open editor empties both
+ * library checklists without refilling them, and renders a removed permission row back out of storage, so
+ * the refresh needs the load path to be safe to run twice rather than the tab to be told to run it. That
+ * is #1576, and this paragraph names it rather than a pull request a later reader cannot find.
  */
 function initOverviewPage(view) {
   ssoConfigurationPage.addTextAreaStyle(view);

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -1070,8 +1070,18 @@ const ssoConfigurationPage = {
       return;
     }
     const dirty = ssoConfigurationPage.isPageDirty(page);
-    box.textContent = dirty ? ssoConfigurationPage.unsavedNoticeText() : "";
-    box.hidden = !dirty;
+    // UNHIDE FIRST, THEN WRITE. `hidden` takes the element out of the accessibility tree, so text set
+    // while it is hidden changes a live region nothing is watching, and the unhide that follows is not
+    // itself a text change for the region to announce. Doing it in this order is what gives the
+    // announcement a chance; whether a particular screen reader takes it is not something this tree can
+    // measure, and nothing here claims it does.
+    if (dirty) {
+      box.hidden = false;
+      box.textContent = ssoConfigurationPage.unsavedNoticeText();
+      return;
+    }
+    box.textContent = "";
+    box.hidden = true;
   },
   // What each Save on a page needs before it can be pressed, DERIVED from the readiness specs rather
   // than restated, so a required field added to an editor closes its Save without a second edit here. A

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -231,6 +231,22 @@
   color: rgba(255, 255, 255, 0.92);
 }
 
+/* Unsaved changes (#1572). A strip rather than a pill: it carries a whole sentence, and its second job
+   is to say why a tab returned to was not refreshed. The left border repeats the state the words already
+   state, so the meaning does not rest on the colour alone (#221). */
+.sso-unsaved {
+  margin: 0.5em 0 1em;
+  padding: 0.6em 0.9em;
+  border-left: 4px solid #f9a825;
+  background: rgba(249, 168, 37, 0.12);
+  border-radius: 0.25em;
+}
+
+/* The page-level Save of the Server tab (#1572): outside both sections, because it commits both. */
+.sso-page-save {
+  margin-top: 1.5em;
+}
+
 /* Required / optional field markers */
 .sso-required-legend {
   margin-top: 0;

--- a/tools/ui-unsaved-state.js
+++ b/tools/ui-unsaved-state.js
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Runs the REAL unsaved-changes state of sso-core.js against the REAL Server
+ * page and refuses each way it can be wrong (#1572).
+ *
+ * WHY THIS EXISTS AS A RUNNING PROOF AND NOT AS A CONFORMANCE RULE. Every other
+ * rule this repository has over the admin assets reads their TEXT: the C# rules
+ * in ArchitectureConformanceTests.WebUi ask whether the surface still carries a
+ * field, a marker class or a call, and tools/ui-mock-fields.js asks where each
+ * control lives. Neither can ask what the code DOES, and what #1572 asks for is
+ * behaviour: a page with an untouched control is not dirty, a page with a
+ * changed one is and says so, and a Save closed by two different parties stays
+ * closed while either of them wants it closed. A text rule matching a token
+ * passes on a file where the condition around it is inverted, and inverted is
+ * exactly how this state fails.
+ *
+ * WHY IT IS NODE AND NOT A BROWSER OR A DOM LIBRARY. The means check, per the
+ * standpoint: node is already carried by this tree - tools/ui-mock-fields.js is
+ * run by the .NET workflow with no install - and a DOM library would add a
+ * dependency and a lockfile to a repository that has neither. What that costs is
+ * stated below rather than hidden.
+ *
+ * WHAT THE STUB CAN AND CANNOT SAY, AND THIS BOUND IS THE PART TO READ. The DOM
+ * below is a stub: id lookup, tag filtering, a class list, a dataset, and a
+ * direct call of the page's own listeners. It is NOT a browser and it has NO
+ * TREE, so it has no propagation and no phases - which means it cannot judge the
+ * capture-phase registration `sso-core.js` calls load-bearing, and a mutation
+ * turning that capture into a bubble passes every arm below. That property was
+ * measured in a real browser instead, and the measurement is recorded at the
+ * code it is about rather than here.
+ *
+ * It also cannot say anything about layout, about which listener a real browser
+ * would run first, or about an event a real control emits that this stub does
+ * not. What keeps it from being a proof about ITSELF is that the CONTROLS are
+ * read out of the shipped serverPage.html by the same regex
+ * tools/ui-mock-fields.js counts with - so a control removed from the page is
+ * removed from this fixture - and that the code under test is the shipped
+ * sso-core.js loaded whole, not a copy and not an extract.
+ *
+ * WHY THE MODULE IS LOADED THROUGH A DATA URL. sso-core.js is an ES module and
+ * this tree carries no package.json, so node would read a `.js` file as
+ * CommonJS and fail on its `export`. Importing the bytes as a data: URL loads
+ * the same source as a module without writing a temporary file beside the tree.
+ *
+ * EVERY LEG REFUSES BY NAME AND THE PASS IS PRINTED. A proof whose result
+ * nobody sees reads exactly like one that never ran.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const CORE = path.join(root, "SSO-Auth", "Web", "sso-core.js");
+const SERVER_PAGE = path.join(root, "SSO-Auth", "Web", "serverPage.html");
+const POLICIES_PAGE = path.join(root, "SSO-Auth", "Web", "policiesPage.html");
+
+/** Replaces every HTML comment with spaces, so a documented control is not a real one. */
+function withoutComments(html) {
+  return html.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, " "));
+}
+
+/** The value of `name="..."` where the name starts an attribute, as ui-mock-fields.js reads it. */
+function attr(tag, name) {
+  const m = tag.match(new RegExp("(?<![-\\w])" + name + '="([^"]*)"'));
+  return m ? m[1] : "";
+}
+
+// ---------------------------------------------------------------------------
+// The stub. Small on purpose: every method here is one the code under test
+// calls, and nothing is added for completeness.
+// ---------------------------------------------------------------------------
+
+class Classes {
+  constructor() {
+    this.set = new Set();
+  }
+  add(name) {
+    this.set.add(name);
+  }
+  remove(...names) {
+    names.forEach((name) => this.set.delete(name));
+  }
+  contains(name) {
+    return this.set.has(name);
+  }
+}
+
+class Element {
+  constructor(tag, id, type) {
+    this.tag = tag;
+    this.id = id;
+    this.type = type;
+    this.value = "";
+    this.checked = false;
+    this.disabled = false;
+    this.hidden = false;
+    this.textContent = "";
+    this.dataset = {};
+    this.classList = new Classes();
+  }
+}
+
+class Page {
+  constructor(elements) {
+    this.elements = elements;
+    this.byId = new Map(elements.map((e) => [e.id, e]));
+    this.dataset = {};
+    this.classList = new Classes();
+    this.listeners = new Map();
+  }
+
+  querySelector(selector) {
+    if (!selector.startsWith("#")) {
+      throw new Error("the stub resolves id selectors only: " + selector);
+    }
+    return this.byId.get(selector.slice(1)) || null;
+  }
+
+  querySelectorAll(selector) {
+    const tags = selector.split(",").map((s) => s.trim());
+    return this.elements.filter((e) => tags.includes(e.tag));
+  }
+
+  addEventListener(name, handler) {
+    if (!this.listeners.has(name)) {
+      this.listeners.set(name, []);
+    }
+    this.listeners.get(name).push(handler);
+  }
+
+  /** Dispatches one event. `trusted` is the property the whole design rests on. */
+  dispatch(name, target, trusted) {
+    (this.listeners.get(name) || []).forEach((handler) =>
+      handler({ isTrusted: trusted, target, type: name }),
+    );
+  }
+}
+
+/**
+ * A Page carrying every form control the shipped Server page declares, plus the
+ * two regions the state writes into. Read from the markup rather than typed
+ * here, so a control that leaves the page leaves this fixture with it.
+ */
+function serverPageFixture() {
+  return pageFixture(SERVER_PAGE, [
+    "sso-unsaved",
+    "sso-page-status",
+    "SaveServerSettings",
+  ]);
+}
+
+/**
+ * The Policies page, where the Save gate actually DECIDES something: its gate
+ * has no region and one required control, so both directions of
+ * `updateSaveAvailability` are reachable. The Server page cannot judge it - that
+ * gate carries an empty required set and can never block.
+ */
+function policiesPageFixture() {
+  return pageFixture(POLICIES_PAGE, ["sso-unsaved", "SaveProvisioningProfile"]);
+}
+
+function pageFixture(file, regionIds) {
+  const html = withoutComments(fs.readFileSync(file, "utf8"));
+  const controls = [
+    ...html.matchAll(/<(input|select|textarea)\b[\s\S]*?>/g),
+  ].map((m) => new Element(m[1], attr(m[0], "id"), attr(m[0], "type") || m[1]));
+  if (controls.length === 0) {
+    throw new Error(
+      path.basename(file) +
+        " declares no form control, so this fixture would prove nothing",
+    );
+  }
+
+  // The regions the state writes into. Their ids are asserted against the page
+  // below rather than trusted, because a renamed region silently turns every
+  // render into a no-op that this stub would otherwise report as a pass.
+  const regions = regionIds.map((id) => new Element("div", id, "div"));
+  const declared = new Set(
+    [...html.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1]),
+  );
+  regions.forEach((region) => {
+    if (!declared.has(region.id)) {
+      throw new Error(
+        path.basename(file) +
+          " declares no #" +
+          region.id +
+          ", so the state would render into nothing",
+      );
+    }
+  });
+
+  return new Page([...controls, ...regions]);
+}
+
+// ---------------------------------------------------------------------------
+// The legs.
+// ---------------------------------------------------------------------------
+
+async function loadCore() {
+  const source = fs.readFileSync(CORE, "utf8");
+  const url =
+    "data:text/javascript;base64," +
+    Buffer.from(source, "utf8").toString("base64");
+  return (await import(url)).default;
+}
+
+/**
+ * Wires one fixture the way initSharedPage does: bind the tracking, then take
+ * the baseline. Nothing is substituted - every function under test is the
+ * shipped one.
+ */
+function wire(core, page) {
+  core.bindUnsavedChangeTracking(page);
+  core.markPageClean(page);
+}
+
+async function main() {
+  const core = await loadCore();
+  const faults = [];
+  const refuse = (leg, detail) => faults.push(leg + ": " + detail);
+
+  // ---- Arm one: a page with an untouched control ----
+  {
+    const page = serverPageFixture();
+    wire(core, page);
+    const notice = page.querySelector("#sso-unsaved");
+    const save = page.querySelector("#SaveServerSettings");
+
+    if (core.isPageDirty(page)) {
+      refuse("untouched", "a page nobody has typed into reads as dirty");
+    }
+    if (!notice.hidden || notice.textContent !== "") {
+      refuse("untouched", "the unsaved indicator is showing on a clean page");
+    }
+
+    if (save.disabled) {
+      refuse(
+        "untouched",
+        "the Save is closed on a page with nothing left to fill in",
+      );
+    }
+  }
+
+  // ---- Arm two: a page with a changed control ----
+  {
+    const page = serverPageFixture();
+    wire(core, page);
+    const notice = page.querySelector("#sso-unsaved");
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+
+    toggle.checked = true;
+    page.dispatch("change", toggle, true);
+
+    if (!core.isPageDirty(page)) {
+      refuse(
+        "changed",
+        "a control an administrator changed did not mark the page dirty",
+      );
+    }
+    if (notice.hidden || notice.textContent === "") {
+      refuse("changed", "the unsaved indicator is hidden on a dirty page");
+    }
+    // The sentence has to name the loss, not merely announce a state: an
+    // indicator that says "unsaved changes" and nothing about what ends them is
+    // one an administrator learns to ignore.
+    if (!/lost/.test(notice.textContent)) {
+      refuse(
+        "changed",
+        "the indicator does not say what happens to the changes: " +
+          notice.textContent,
+      );
+    }
+    // And it goes away again when the page is read afresh.
+    core.markPageClean(page);
+    if (core.isPageDirty(page) || !notice.hidden) {
+      refuse("changed", "a page read afresh went on showing the indicator");
+    }
+  }
+
+  // ---- The host's own synthetic events, in both directions ----
+  //
+  // `emby-checkbox` toggles `checked` and dispatches its own bubbling
+  // CustomEvent('change') when the control is operated from the KEYBOARD, and
+  // `emby-select` dispatches `new Event('change', { bubbles: false })` when the
+  // action sheet sets a value. Both carry isTrusted false. A state that read
+  // that flag would let a keyboard user change every switch on this page while
+  // it went on reading as clean, and the next return to the tab would discard
+  // the lot - so the flag is not read, and these two arms are why.
+  {
+    // The value moved with the synthetic event: that is a person, and it is dirty.
+    const page = serverPageFixture();
+    wire(core, page);
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+    toggle.checked = true;
+    page.dispatch("change", toggle, false);
+    if (!core.isPageDirty(page)) {
+      refuse(
+        "host-synthetic",
+        "a switch changed from the keyboard did not mark the page dirty, so the next tab return would discard it",
+      );
+    }
+  }
+  {
+    // The value did NOT move: whoever dispatched it changed nothing, so nothing
+    // is unsaved. This is the arm that keeps the comparison from reading every
+    // event as an edit.
+    const page = serverPageFixture();
+    wire(core, page);
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+    page.dispatch("change", toggle, false);
+    page.dispatch("change", toggle, true);
+    if (core.isPageDirty(page)) {
+      refuse(
+        "no-op-event",
+        "an event that moved no value marked the page dirty",
+      );
+    }
+  }
+  {
+    // And back again: a control changed and then changed back holds nothing
+    // unsaved, which is the same comparison read in the other direction.
+    const page = serverPageFixture();
+    wire(core, page);
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+    toggle.checked = true;
+    page.dispatch("change", toggle, true);
+    toggle.checked = false;
+    page.dispatch("change", toggle, true);
+    if (core.isPageDirty(page)) {
+      refuse(
+        "undone",
+        "a control changed and changed back left the page reading as edited",
+      );
+    }
+  }
+
+  // ---- The two exclusions, each in its own arm ----
+  {
+    const page = serverPageFixture();
+    wire(core, page);
+    const file = page.querySelector("#ImportConfigFile");
+    // The chooser really does put a name on the control, so the arm has to move
+    // the value: a dispatch that changed nothing would pass whether the input is
+    // excluded or not.
+    file.value = "sso-config.json";
+    page.dispatch("change", file, true);
+    if (core.isPageDirty(page)) {
+      refuse(
+        "file-input",
+        "choosing a file to import marked the page dirty, so the tab would stop refreshing over a control nothing saves",
+      );
+    }
+  }
+  {
+    // A navigation control refills the form, so it CLEANS a dirty page rather
+    // than dirtying it. Run on a page that is dirty first, because a leg that
+    // starts clean cannot tell "cleans" from "does nothing".
+    const page = serverPageFixture();
+    wire(core, page);
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+    toggle.checked = true;
+    page.dispatch("change", toggle, true);
+    if (!core.isPageDirty(page)) {
+      refuse(
+        "navigation",
+        "the fixture for this leg never became dirty, so it proves nothing",
+      );
+    }
+    const selector = new Element("select", "selectProvider", "select");
+    page.elements.push(selector);
+    page.byId.set(selector.id, selector);
+    page.dispatch("change", selector, true);
+    if (core.isPageDirty(page)) {
+      refuse(
+        "navigation",
+        "choosing another provider left the page reading as edited",
+      );
+    }
+  }
+
+  // ---- The Save gate, in the direction that is a fail-open ----
+  //
+  // The freeze on a provider or a profile a configuration file owns (#1104)
+  // disables that form's Save, and the gate must not hand it back when it finds
+  // nothing of its own left to block. The first draft of the gate did exactly
+  // that, by remembering what IT had disabled instead of reading what the freeze
+  // declares; the sequence below is the reproduction, in the order the Policies
+  // tab produces it.
+  {
+    const page = serverPageFixture();
+    wire(core, page);
+    const save = page.querySelector("#SaveServerSettings");
+
+    // 1. the gate closes it for its own reason
+    core.setSaveBlocked(save, true);
+    if (!save.disabled) {
+      refuse(
+        "save-gate",
+        "the gate did not close a Save it had a reason to close",
+      );
+    }
+
+    // 2. the freeze closes it for its own, and says so where the gate can read it
+    save.disabled = true;
+    save.dataset.ssoManaged = "true";
+
+    // 3. the gate's reason goes away
+    core.setSaveBlocked(save, false);
+    if (!save.disabled) {
+      refuse(
+        "save-gate",
+        "the gate handed back a Save the declarative-source freeze had closed",
+      );
+    }
+
+    // ... and the freeze lifting is what re-opens it, not the gate forgetting.
+    save.dataset.ssoManaged = "";
+    core.setSaveBlocked(save, false);
+    if (save.disabled) {
+      refuse(
+        "save-gate",
+        "the Save stayed closed after both reasons were gone, so nothing can re-open it",
+      );
+    }
+  }
+
+  // ---- The gate's decision, in both directions ----
+  //
+  // On the Policies page the profile Save carries one required control and no
+  // region, so both answers are reachable. The Server page cannot judge this:
+  // its gate has an empty required set and can never block, which is why an
+  // earlier version of this file proved nothing about the decision at all.
+  {
+    const page = policiesPageFixture();
+    const save = page.querySelector("#SaveProvisioningProfile");
+    const selector = page.querySelector("#selectProvisioningProfile");
+    wire(core, page);
+
+    if (!save.disabled) {
+      refuse(
+        "gate-decision",
+        "the profile Save is open with no profile selected, and a save then has nothing to write to",
+      );
+    }
+
+    selector.value = "Standard";
+    page.dispatch("change", selector, true);
+    if (save.disabled) {
+      refuse(
+        "gate-decision",
+        "the profile Save stayed closed after a profile was selected",
+      );
+    }
+  }
+
+  // ---- The hidden-region skip ----
+  //
+  // A gate whose editor is closed must be left alone: the button is unreachable
+  // and writing to it would fight whoever hid it.
+  {
+    const page = policiesPageFixture();
+    wire(core, page);
+    const save = page.querySelector("#SaveProvisioningProfile");
+    save.disabled = false;
+    // Give this gate a region and hide it, the shape the two provider gates have.
+    const region = new Element("div", "sso-editor", "div");
+    region.hidden = true;
+    page.elements.push(region);
+    page.byId.set(region.id, region);
+    const gates = core.saveGates;
+    core.saveGates = () =>
+      gates().map((gate) =>
+        gate.button === "#SaveProvisioningProfile"
+          ? { ...gate, region: "#sso-editor" }
+          : gate,
+      );
+    core.updateSaveAvailability(page);
+    core.saveGates = gates;
+    if (save.disabled) {
+      refuse(
+        "hidden-region",
+        "the gate closed a Save inside an editor that is not on screen",
+      );
+    }
+  }
+
+  if (faults.length) {
+    faults.forEach((fault) => console.error(fault));
+    console.error(
+      faults.length + " refusal(s) in the unsaved-changes state (#1572)",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    "unsaved state:     eight arms run against the shipped sso-core.js and the pages it serves",
+  );
+  console.log(
+    "  untouched        a page nobody typed into is clean, shows nothing, and its Save is open",
+  );
+  console.log(
+    "  changed          a changed control marks it dirty and the line names what is at stake",
+  );
+  console.log(
+    "  host-synthetic   a switch changed from the keyboard marks it dirty despite isTrusted=false",
+  );
+  console.log(
+    "  file-input       choosing a file to import does not mark it dirty",
+  );
+  console.log(
+    "  navigation       choosing another provider cleans a dirty page instead of dirtying it",
+  );
+  console.log(
+    "  no-op / undone   an event that moved nothing, and a change undone, leave it clean",
+  );
+  console.log(
+    "  save-gate        the gate never re-enables a Save that something else disabled",
+  );
+  console.log(
+    "  gate-decision    the profile Save is closed with no profile selected and open with one",
+  );
+  console.log(
+    "  hidden-region    a gate whose editor is off screen is left alone",
+  );
+}
+
+main().catch((error) => {
+  console.error(String((error && error.stack) || error));
+  process.exit(1);
+});


### PR DESCRIPTION
# What & why

Stage 1 (#1527) built the five settings pages and left three items behind. They share one dependency — knowing whether a page has been edited — which is why they are one change rather than three.

**One Save on the Server page.** The two server-wide switches each had their own button and their own handler, and each handler re-read the whole configuration, set its own flag and posted the result. #1527 refused to merge the buttons because one Save over two such handlers is two writes with no transaction between them. What removes that hazard is not a transaction: both flags are members of the same root `PluginConfiguration` document, so the save reads it once, sets what it must and posts it once. There is no window in which one flag is stored and the other is not, and a refusal leaves **both** exactly as they were stored.

It writes only the switches the administrator actually moved. Writing both from the form would have taken away a property the two old handlers had by accident of being two: each set only its own flag, so a change made elsewhere between this page's load and its save survived. Without that, a second administrator turning Single Logout on is silently undone by the first pressing Save over a stale page — a security flag switched off by somebody who never touched it.

**The unsaved-changes state.** An `input` or `change` on a tracked control only asks the question; what answers it is a comparison of the tracked controls against what the last read left on them. The first draft read `event.isTrusted` instead, on the reasoning that this file's own fills write `.value` and `.checked` directly and fire nothing. That reasoning was about this file and the controls are the host's:

```
$ grep -rn 'dispatchEvent' src/elements/emby-checkbox src/elements/emby-select
emby-checkbox/emby-checkbox.js:16:        this.dispatchEvent(new CustomEvent('change', {
emby-select/emby-select.js:30:    select.dispatchEvent(evt);
```

`emby-checkbox` does that on **keyboard** input; `emby-select` does it, with `bubbles: false`, when the action sheet sets a value. Both carry `isTrusted` false. Under the first draft a keyboard user could change every switch on the Server page while it went on reading as clean, and lose the lot. The capture-phase registration that a non-bubbling event requires was measured rather than reasoned — a page dispatching both shapes at a capture and a bubble listener on the same ancestor:

```
["s/capture/trusted=false/bubbles=false",
 "c/capture/trusted=false/bubbles=true",
 "c/bubble/trusted=false/bubbles=true"]
```

A non-bubbling event reaches a capture listener on an ancestor and reaches no bubble listener at all.

**The Save gate, and the posture it does not reverse.** A Save is closed while a control that save needs is empty, read from the values so typing re-opens it on the keystroke. The on-blur warnings #365 put beside the fields go on warning and go on **not** blocking: that rule exists because one of those can be wrong about a value the server would have taken, and an empty required field cannot be.

The declarative-source freeze (#1104) also disables these buttons. A boolean with two owners cannot compose by remembering, so the freeze now records its own reason on the button and the gate reads it: one writer, two declared reasons.

**The alerts.** All thirteen are replaced by inline regions, and the outcome moved into the sticky save footer beside the button — the header region it used to use sits up to fifty-seven controls above, and that footer exists precisely so nobody scrolls back up. Every new region carries `role="status"` and `aria-live="polite"`, and the indicator is unhidden before its text is written rather than after — `hidden` takes an element out of the accessibility tree, so writing first would have changed a live region nothing was watching. That buys a chance at the announcement, not a guarantee: whether a given screen reader takes it is not measurable from this tree and nothing here claims it is.

## What is deliberately NOT here

**The tab that re-reads itself** — the fourth done-condition of #1572 — is not delivered, and this is the reason rather than a deferral for room. The review found that re-reading a page with an open editor:

- empties both library checklists and does not refill them (`loadConfiguration` re-populates `#EnabledFolders` with nothing ticked and does not re-run `loadProvider`), so the next save persists an empty `EnabledFolders` and every user of that provider loses library access at their next sign-in;
- renders a permission row the administrator removed straight back out of storage, because removing a row is a **click** — no `input`, no `change` — so no edit tracking of this shape can see it;
- is check-then-act: the dirty test runs before an asynchronous fill that lands after it, so an edit made inside that window is overwritten and the page then reports itself clean.

None of the three is a defect in the new state. All three are what `loadConfiguration` does, which was written to run once, at construction, while the editor is still hidden. Making it safe to run twice is its own change. **#1572 therefore stays open** for that condition, and this pull request does not close it.

Means check: JavaScript for the page script, because that is what the surface is; node with no dependency for the proof, because node is already carried by this tree (`tools/ui-mock-fields.js` runs in the same job with no install) and a DOM library would add a dependency and a lockfile to a repository that has neither.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. No validation path is touched. The fail-closed property this change is about is the Save gate, and it composes with the declarative-source freeze rather than overwriting it.
- [x] No secrets logged; secrets are redacted on config export. Unchanged. Every new DOM write is `textContent` (#221); no configuration value reaches the DOM as markup.
- [x] A security review was performed — this touches the configuration write path.
- [x] Review record: below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call changes.

### Review record

Four refute-by-default lenses over the diff: bypass, correctness, availability, integration. **CONFIRMED 16 / PLAUSIBLE 0.** Every finding carries a disposition.

This body first said 11 and 2, which was a guess at the split rather than a count. Confirmed here means one of two things, and every row has one: a lens produced an executed reproduction, or I re-ran its reading at the head being pushed. The three I was least sure of are the ones I checked last — that `hideEditor` sits only in the delete's success arm, that `saveProvisioningProfile` keys off `#selectProvisioningProfile` and not the name box, and that a permission row is removed by a click handler calling `row.remove()` and firing nothing. All three hold.

| # | Lens(es) | Finding | Disposition |
|---|---|---|---|
| 1 | bypass, integration, availability | The Save gate remembered which disable it had made, so selecting a **managed** provisioning profile released a Save the freeze had just closed. Reproduced independently by two lenses, and by me before they reported. | FIXED — the freeze declares its reason, the gate reads it |
| 2 | integration | The proof's `save-gate` arm asserted the one state that cannot fail, so the new CI step shipped a green light over finding 1. | FIXED — the arm is now the three-step reproduction |
| 3 | correctness, bypass | The `viewshow` re-read empties both library checklists; the next save persists an empty `EnabledFolders` and every user of that provider loses library access. | FIXED by removal — see above |
| 4 | correctness, bypass | Removing a permission/role row is a click, invisible to the tracking, and the re-read renders it back out of storage. | FIXED by removal |
| 5 | correctness | The re-read is check-then-act; an edit inside the fill's latency window is overwritten and then marked clean. Demonstrated. | FIXED by removal |
| 6 | correctness | The dirty flag is page-wide but cleared by section-local fills, so opening an OpenID provider clears the SAML editor's state. | FIXED in part — the indicator no longer promises anything about opening another provider; the page-wide granularity is carried to the follow-up issue |
| 7 | availability | A refused provider save painted its only outcome ~57 controls above a deliberately sticky Save button. | FIXED — the outcome moved into the footer |
| 8 | availability, bypass | The three new regions carried no `role`/`aria-live`, unlike every sibling region on the same pages. | FIXED |
| 9 | availability | `#sso-page-status` was written by four paths and cleared by none. | FIXED — cleared at every new act |
| 10 | bypass | The failed-delete arm does not hide the editor, so its outcome belonged in the editor's region, not the page's. | FIXED |
| 11 | correctness, bypass | The merged Server save wrote both flags from the form: a lost update on `EnableSingleLogout`. | FIXED — only moved switches are written |
| 12 | correctness | The profile Save gate read `#ProvisioningProfileName`; the save keys off `#selectProvisioningProfile`. | FIXED |
| 13 | bypass, correctness | The freeze pass is a microtask and landed after the gate on the add paths, clearing its decision. | FIXED — the gate is re-asserted at the end of each freeze |
| 14 | correctness | The proof could not judge capture phase, the gate's decision, or the hidden-region skip; four mutations passed it. | FIXED for three of four — the gate's decision and the hidden-region skip now have arms and bite. Capture phase is unjudgeable by a stub with no tree; that is stated as the tool's bound and the property was measured in a browser instead. |
| 15 | availability | `saveProvider`, `saveSamlProvider` and the two deletes pass a single argument to the initial `getPluginConfiguration`, so a failed **read** never settles and a pressed Save produces nothing at all. | DEFERRED — pre-existing on all four paths, unrelated to what this change touches, and one attempt to restructure those chains broke the file once tonight. Filed as its own issue, linked in Notes. |
| 16 | correctness | `initOverviewPage`'s comment described the other four pages' behaviour, which this change alters. | FIXED |

Findings 1 and 2 were found and fixed before the lenses reported; both lenses re-ran their reproductions against the fixed state and confirmed the freeze holds.

Mutation proofs on the final state — each makes `tools/ui-unsaved-state.js` refuse, naming its own arm:

```
gate always blocks (>0 -> >=0)                  exit=1  untouched
gate never blocks (>0 -> false)                 exit=1  gate-decision
drop the hidden-region skip                     exit=1  hidden-region
freeze marker ignored by the gate               exit=1  save-gate
baseline comparison inverted                    exit=1  changed
navigation control dirties instead of cleaning  exit=1  navigation
file inputs tracked again                       exit=1  file-input
```

## Quality checklist

- [x] No duplicated logic; the state is one small unit and the freeze's reason is written by the party that knows it.
- [x] The change adds no more code than the problem requires — the re-read was removed rather than patched.
- [x] The code is self-documenting; comments say why.
- [x] Architecture-conformance tests pass, and the new structural property is locked in by `tools/ui-unsaved-state.js`, run by the `.NET` workflow.
- [x] Docs impact considered: see Notes.

## Verification

- [x] `dotnet build --warnaserror` green on both target frameworks, 0 warnings.
- [x] `dotnet test` green on both, run serially: **net9.0 3826 / net10.0 3827, 0 failed, 4 skipped**. The four skips are pre-existing: they bind a listener off loopback, which raises a Windows firewall consent dialog needing an administrator (#1227). Disclosed, not worked around.
- [x] Prettier clean for every changed asset.
- [x] `node tools/ui-mock-fields.js` — 123 fields, 5 controllers, 14 page names.
- [x] `node tools/ui-unsaved-state.js` — eight arms.

**No walk on a real server.** These are browser assets and CI cannot exercise them; the review is the primary verification, as this repository's gate says it is for changes of this kind. The headless-browser probe cited above measured one DOM property and says nothing about how any of this looks.

## On the German catalogue

Seven keys, written in German against the English beside them rather than machine-translated and left, and one key removed with its English twin when the refresh half came out. What the line below proves is that a name is on that reading, never that the reading was thorough — the check that requires it says so itself.

The two worth a second look are the ones that carry a consequence rather than a label: `config.server_settings_save_failed` has to make "**neither** switch was changed" unmissable, because a reader who takes it for "one of them" will go looking for a half-written pair that does not exist; and `config.unsaved` has to end on the loss rather than on the state, since an indicator that only announces a condition is one an administrator learns to scroll past.

Catalogue-Vouch: de read by iderex

## Notes

- **The issue this change belongs to stays open.** Its fourth done-condition is unmet on purpose and the issue carries the reason. The sentence that used to stand here paired a closing keyword with that number in order to deny it, and GitHub read the keyword and not the denial — the same way it did on #1527. It is written without the pairing now, so a later edit of this body cannot shut the issue again.
- Residual: the dirty flag lives on the view element's class list. A host that replaced that class attribute would reset it to clean. Nothing in jellyfin-web is known to do so; it is stated rather than guarded.
- Residual: the indicator is page-wide, and the Providers page carries two editors. Opening one still resets the other's state — the same discard that has always happened when an editor is reopened, now without a line that briefly implied otherwise.
- Docs impact: the wiki still describes one settings page rather than five, which is #1574 and already open. This change adds the save model to that gap rather than a new one.
