### PR TITLE
Answer a failed configuration read on the four provider write paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,17 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A failed configuration read no longer leaves a pressed Save with no outcome
+  at all (#1577).** Saving or deleting a provider reads the stored configuration
+  before it writes, and four of those reads had no failure arm. The two saves
+  wrap their write in a promise that only the write settled, so a read that
+  failed - an expired dashboard session, a server error, or the very restart the
+  editor asks for after a save - left that promise hanging: neither outcome arm
+  ran and pressing Save did nothing visible whatsoever, which is the one failure
+  a settings page can make that looks exactly like success. All four now answer,
+  and the two deletes say in the editor that nothing was read and therefore
+  nothing was changed.
+
 - **A refused account-link import no longer logs a different sentence from
   the one it answers, and the default-provider line is sanitized (#1566).**
   Two residuals of #1557. The refusal a link import answers is a sentence this

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -211,5 +211,6 @@
   "config.server_settings_save_failed": "Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde KEINER der beiden Schalter geändert – beide gehören zu einem Dokument und werden gemeinsam oder gar nicht geschrieben. Laden Sie die Seite neu, um den gespeicherten Stand zu sehen, und versuchen Sie es erneut.",
   "config.server_settings_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts gespeichert und keiner der beiden Schalter geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.provider_removed": "Anbieter entfernt.",
-  "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut."
+  "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
+  "config.config_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -211,5 +211,6 @@
   "config.server_settings_save_failed": "The server refused the saved configuration, so NEITHER switch was changed - the two ride one document and are written together or not at all. Reload the page to see what is stored, and try again.",
   "config.server_settings_read_failed": "Could not read the stored configuration, so nothing was saved and neither switch was changed. Reload the page and try again.",
   "config.provider_removed": "Provider removed.",
-  "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again."
+  "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
+  "config.config_read_failed": "Could not read the stored configuration, so nothing was changed. Reload the page and try again."
 }

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -2527,8 +2527,8 @@ const ssoConfigurationPage = {
     ) {
       return;
     }
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
-      (config) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId)
+      .then((config) => {
         if (!config.OidConfigs.hasOwnProperty(provider_name)) {
           return;
         }
@@ -2573,8 +2573,20 @@ const ssoConfigurationPage = {
             );
           },
         );
-      },
-    );
+      })
+      // The read that precedes the delete can fail on its own (#1577), and a delete that says nothing
+      // reads as one that worked. The editor is still open on this arm - nothing was removed - so the
+      // message goes in the editor's own region, exactly where the write-failure arm above puts its own.
+      .catch(() =>
+        ssoConfigurationPage.renderSaveStatus(
+          page,
+          tr(
+            "config.config_read_failed",
+            "Could not read the stored configuration, so nothing was changed. Reload the page and try again.",
+          ),
+          false,
+        ),
+      );
   },
   // ONE SAVE FOR THE SERVER PAGE (#1572), AND THE PARTIAL FAILURE IT DOES NOT HAVE.
   //
@@ -2697,79 +2709,87 @@ const ssoConfigurationPage = {
     return new Promise((resolve, reject) => {
       const form_elements = ssoConfigurationPage.listArgumentsByType(page);
 
-      ApiClient.getPluginConfiguration(
-        ssoConfigurationPage.pluginUniqueId,
-      ).then((config) => {
-        let current_config = {};
-        if (config.OidConfigs.hasOwnProperty(provider_name)) {
-          current_config = config.OidConfigs[provider_name];
-        }
+      ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId)
+        .then((config) => {
+          let current_config = {};
+          if (config.OidConfigs.hasOwnProperty(provider_name)) {
+            current_config = config.OidConfigs[provider_name];
+          }
 
-        form_elements.text_fields.forEach((id) => {
-          current_config[id] = page.querySelector("#" + id).value || null;
-        });
+          form_elements.text_fields.forEach((id) => {
+            current_config[id] = page.querySelector("#" + id).value || null;
+          });
 
-        form_elements.check_fields.forEach((id) => {
-          current_config[id] = page.querySelector("#" + id).checked;
-        });
+          form_elements.check_fields.forEach((id) => {
+            current_config[id] = page.querySelector("#" + id).checked;
+          });
 
-        form_elements.text_list_fields.forEach((id) => {
-          current_config[id] = ssoConfigurationPage.parseTextList(
-            page.querySelector("#" + id),
+          form_elements.text_list_fields.forEach((id) => {
+            current_config[id] = ssoConfigurationPage.parseTextList(
+              page.querySelector("#" + id),
+            );
+          });
+
+          form_elements.folder_list_fields.forEach((id) => {
+            const elem = page.querySelector(`#${id}`);
+            current_config[id] =
+              ssoConfigurationPage.serializeEnabledFolders(elem);
+          });
+
+          form_elements.role_map_fields.forEach((id) => {
+            const elem = page.querySelector(`#${id}`);
+            current_config[id] =
+              ssoConfigurationPage.serializeRoleMappings(elem);
+          });
+
+          // The named profile and the inline template are ONE decision and are written together (#1105).
+          // The selector is read here rather than by the flat loop above, for the reason
+          // fillProvisioningTemplate states; the template follows it, because a save carrying both is
+          // refused by ProviderConfigValidator - one account-creation policy has one source. Leaving the
+          // stored template in place beside a newly chosen profile name would therefore make the provider
+          // unsaveable from this page, client id and secret included, so the discard is deliberate; it is
+          // confirmed at the moment the profile is chosen (chooseProvisioningProfile) rather than here,
+          // where the administrator has already pressed Save.
+          current_config.ProvisioningProfile =
+            page.querySelector("#ProvisioningProfile").value || null;
+          current_config.ProvisioningPolicyTemplate =
+            current_config.ProvisioningProfile === null
+              ? ssoConfigurationPage.readProvisioningTemplate(page, "")
+              : null;
+
+          config.OidConfigs[provider_name] = current_config;
+
+          ApiClient.updatePluginConfiguration(
+            ssoConfigurationPage.pluginUniqueId,
+            config,
+          ).then(
+            function (result) {
+              Dashboard.processPluginConfigurationUpdateResult(result);
+              ssoConfigurationPage.loadConfiguration(page);
+              ssoConfigurationPage.loadProvider(page, provider_name);
+
+              page.querySelector("#selectProvider").value = provider_name;
+              // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
+              resolve();
+            },
+            // Rejection handler attached directly to the save call, so it reports only a genuine save
+            // failure and not an error thrown by the post-save UI work above. The server can refuse a
+            // save for more than one reason (a malformed Base URL Override, #139; a provider name with
+            // URI-reserved or control characters, #336/#360), so the message the caller renders names both
+            // checks instead of blaming one.
+            function () {
+              reject(new Error("Provider save failed"));
+            },
           );
-        });
-
-        form_elements.folder_list_fields.forEach((id) => {
-          const elem = page.querySelector(`#${id}`);
-          current_config[id] =
-            ssoConfigurationPage.serializeEnabledFolders(elem);
-        });
-
-        form_elements.role_map_fields.forEach((id) => {
-          const elem = page.querySelector(`#${id}`);
-          current_config[id] = ssoConfigurationPage.serializeRoleMappings(elem);
-        });
-
-        // The named profile and the inline template are ONE decision and are written together (#1105).
-        // The selector is read here rather than by the flat loop above, for the reason
-        // fillProvisioningTemplate states; the template follows it, because a save carrying both is
-        // refused by ProviderConfigValidator - one account-creation policy has one source. Leaving the
-        // stored template in place beside a newly chosen profile name would therefore make the provider
-        // unsaveable from this page, client id and secret included, so the discard is deliberate; it is
-        // confirmed at the moment the profile is chosen (chooseProvisioningProfile) rather than here,
-        // where the administrator has already pressed Save.
-        current_config.ProvisioningProfile =
-          page.querySelector("#ProvisioningProfile").value || null;
-        current_config.ProvisioningPolicyTemplate =
-          current_config.ProvisioningProfile === null
-            ? ssoConfigurationPage.readProvisioningTemplate(page, "")
-            : null;
-
-        config.OidConfigs[provider_name] = current_config;
-
-        ApiClient.updatePluginConfiguration(
-          ssoConfigurationPage.pluginUniqueId,
-          config,
-        ).then(
-          function (result) {
-            Dashboard.processPluginConfigurationUpdateResult(result);
-            ssoConfigurationPage.loadConfiguration(page);
-            ssoConfigurationPage.loadProvider(page, provider_name);
-
-            page.querySelector("#selectProvider").value = provider_name;
-            // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
-            resolve();
-          },
-          // Rejection handler attached directly to the save call, so it reports only a genuine save
-          // failure and not an error thrown by the post-save UI work above. The server can refuse a
-          // save for more than one reason (a malformed Base URL Override, #139; a provider name with
-          // URI-reserved or control characters, #336/#360), so the message the caller renders names both
-          // checks instead of blaming one.
-          function () {
-            reject(new Error("Provider save failed"));
-          },
-        );
-      });
+        })
+        // THE READ CAN FAIL ON ITS OWN, AND WITHOUT THIS NOTHING SETTLES (#1577). The rejection arm above
+        // belongs to the WRITE. If the configuration read that precedes it fails - an expired dashboard
+        // token, a 500, the server restart this editor itself asks for after a save - this promise never
+        // settles, so neither of the caller's status arms runs and a pressed Save produces nothing at all:
+        // the one failure a page can make that reads exactly like a save that worked. It also settles a
+        // throw from inside the fill above, which would otherwise hang in the same way. A reject after a
+        // resolve is a no-op, so the success path is untouched.
+        .catch(() => reject(new Error("Provider save failed")));
     });
   },
   // Test-connection (#163). Calls the elevation-gated OID/Test endpoint for the SAVED provider and renders
@@ -4514,8 +4534,8 @@ const ssoConfigurationPage = {
     ) {
       return;
     }
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
-      (config) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId)
+      .then((config) => {
         if (
           !config.SamlConfigs ||
           !config.SamlConfigs.hasOwnProperty(provider_name)
@@ -4553,83 +4573,96 @@ const ssoConfigurationPage = {
             );
           },
         );
-      },
-    );
+      })
+      // The same reason the OpenID delete states (#1577): the read can fail on its own and the editor is
+      // still open, so the message goes where that editor's other outcomes go.
+      .catch(() =>
+        ssoConfigurationPage.renderSamlSaveStatus(
+          page,
+          tr(
+            "config.config_read_failed",
+            "Could not read the stored configuration, so nothing was changed. Reload the page and try again.",
+          ),
+          false,
+        ),
+      );
   },
   saveSamlProvider: (page, provider_name) => {
     return new Promise((resolve, reject) => {
       const form_elements = ssoConfigurationPage.listSamlArgumentsByType(page);
 
-      ApiClient.getPluginConfiguration(
-        ssoConfigurationPage.pluginUniqueId,
-      ).then((config) => {
-        if (!config.SamlConfigs) {
-          config.SamlConfigs = {};
-        }
-        let current_config = {};
-        if (config.SamlConfigs.hasOwnProperty(provider_name)) {
-          current_config = config.SamlConfigs[provider_name];
-        }
+      ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId)
+        .then((config) => {
+          if (!config.SamlConfigs) {
+            config.SamlConfigs = {};
+          }
+          let current_config = {};
+          if (config.SamlConfigs.hasOwnProperty(provider_name)) {
+            current_config = config.SamlConfigs[provider_name];
+          }
 
-        form_elements.text_fields.forEach((id) => {
-          const prop = ssoConfigurationPage.samlPropOf(id);
-          current_config[prop] = page.querySelector("#" + id).value || null;
-        });
+          form_elements.text_fields.forEach((id) => {
+            const prop = ssoConfigurationPage.samlPropOf(id);
+            current_config[prop] = page.querySelector("#" + id).value || null;
+          });
 
-        form_elements.check_fields.forEach((id) => {
-          const prop = ssoConfigurationPage.samlPropOf(id);
-          current_config[prop] = page.querySelector("#" + id).checked;
-        });
+          form_elements.check_fields.forEach((id) => {
+            const prop = ssoConfigurationPage.samlPropOf(id);
+            current_config[prop] = page.querySelector("#" + id).checked;
+          });
 
-        form_elements.text_list_fields.forEach((id) => {
-          const prop = ssoConfigurationPage.samlPropOf(id);
-          current_config[prop] = ssoConfigurationPage.parseTextList(
-            page.querySelector("#" + id),
+          form_elements.text_list_fields.forEach((id) => {
+            const prop = ssoConfigurationPage.samlPropOf(id);
+            current_config[prop] = ssoConfigurationPage.parseTextList(
+              page.querySelector("#" + id),
+            );
+          });
+
+          form_elements.folder_list_fields.forEach((id) => {
+            const prop = ssoConfigurationPage.samlPropOf(id);
+            const elem = page.querySelector("#" + id);
+            current_config[prop] =
+              ssoConfigurationPage.serializeEnabledFolders(elem);
+          });
+
+          form_elements.role_map_fields.forEach((id) => {
+            const prop = ssoConfigurationPage.samlPropOf(id);
+            const elem = page.querySelector("#" + id);
+            current_config[prop] =
+              ssoConfigurationPage.serializeRoleMappings(elem);
+          });
+
+          // Same rule as the OpenID arm above, including the discard.
+          current_config.ProvisioningProfile =
+            page.querySelector("#saml-ProvisioningProfile").value || null;
+          current_config.ProvisioningPolicyTemplate =
+            current_config.ProvisioningProfile === null
+              ? ssoConfigurationPage.readProvisioningTemplate(page, "saml-")
+              : null;
+
+          config.SamlConfigs[provider_name] = current_config;
+
+          ApiClient.updatePluginConfiguration(
+            ssoConfigurationPage.pluginUniqueId,
+            config,
+          ).then(
+            function (result) {
+              Dashboard.processPluginConfigurationUpdateResult(result);
+              ssoConfigurationPage.loadConfiguration(page);
+              ssoConfigurationPage.loadSamlProvider(page, provider_name);
+
+              page.querySelector("#saml-selectProvider").value = provider_name;
+              // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
+              resolve();
+            },
+            function () {
+              reject(new Error("Provider save failed"));
+            },
           );
-        });
-
-        form_elements.folder_list_fields.forEach((id) => {
-          const prop = ssoConfigurationPage.samlPropOf(id);
-          const elem = page.querySelector("#" + id);
-          current_config[prop] =
-            ssoConfigurationPage.serializeEnabledFolders(elem);
-        });
-
-        form_elements.role_map_fields.forEach((id) => {
-          const prop = ssoConfigurationPage.samlPropOf(id);
-          const elem = page.querySelector("#" + id);
-          current_config[prop] =
-            ssoConfigurationPage.serializeRoleMappings(elem);
-        });
-
-        // Same rule as the OpenID arm above, including the discard.
-        current_config.ProvisioningProfile =
-          page.querySelector("#saml-ProvisioningProfile").value || null;
-        current_config.ProvisioningPolicyTemplate =
-          current_config.ProvisioningProfile === null
-            ? ssoConfigurationPage.readProvisioningTemplate(page, "saml-")
-            : null;
-
-        config.SamlConfigs[provider_name] = current_config;
-
-        ApiClient.updatePluginConfiguration(
-          ssoConfigurationPage.pluginUniqueId,
-          config,
-        ).then(
-          function (result) {
-            Dashboard.processPluginConfigurationUpdateResult(result);
-            ssoConfigurationPage.loadConfiguration(page);
-            ssoConfigurationPage.loadSamlProvider(page, provider_name);
-
-            page.querySelector("#saml-selectProvider").value = provider_name;
-            // The outcome is rendered inline by the caller, in the editor's own status region (#1572).
-            resolve();
-          },
-          function () {
-            reject(new Error("Provider save failed"));
-          },
-        );
-      });
+        })
+        // The same reason saveProvider states above (#1577): the arm inside belongs to the write, and a
+        // failed READ would otherwise leave this promise unsettled and the pressed Save silent.
+        .catch(() => reject(new Error("Provider save failed")));
     });
   },
   // Test-connection for a SAVED SAML provider (#163). Calls the elevation-gated SAML/Test endpoint, which


### PR DESCRIPTION
# What & why

Closes #1577.

Saving or deleting a provider reads the stored configuration before it writes, and four of those reads had no failure arm. The two saves wrap their write in a `new Promise` whose only rejection belongs to the **write**, so a read that failed left that promise unsettled: neither of the caller's status arms ran and a pressed Save produced nothing at all — no message, no error, no change. That is the one failure this surface can make that reads exactly like a save that worked.

The read fails for ordinary reasons: an expired dashboard session, a server error, or the very restart the provider editor itself asks for after a save.

- The two saves now settle, so the inline failure the caller already renders is what an administrator sees.
- The two deletes render in the **editor's** own region, because that arm leaves the editor open — nothing was removed — and say that the configuration could not be read and nothing was changed.

Found by the availability lens reviewing #1572, on paths that change did not touch. The merged Server save in #1575 was given exactly this arm and it was deliberately not extended here, because these four are a change to the provider write path rather than to a message.

Means check: unchanged from #1575 — this is the same browser asset in the same language, and the fix is four rejection arms rather than anything structural.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. This adds failure arms; no path becomes more permissive, and no validation changes.
- [x] No secrets logged; secrets are redacted on config export. Unchanged. The new messages carry no configuration value and are written with `textContent`.
- [x] A security review was performed — this touches the configuration write path.
- [x] Review record: below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call changes.

### Review record

**No second reader on this change.** The four lenses ran against #1572 and this is the finding one of them raised there, carried out afterwards; it has not itself been through a review round. What stands in its place is stated plainly rather than dressed up: the diff is four rejection arms and one catalogue key, the failure it removes is a hang, and every arm is on a path whose success behaviour is untouched.

**What refuses a regression: nothing.** No C# rule can execute this file, and the node proof beside it has no browser in which to run a save — so removing one of these arms tomorrow is refused by no mechanism, exactly as their absence was refused by none. That is why they were missing. This repository's gate says the review is the primary verification for browser assets, and this is that, with one reader.

A rule scoped to *every* configuration read in the file was written and dropped before it shipped. It refuses **seven** reads, not four: three more sit on load paths, where a failed read leaves the controls empty and the page visibly wrong rather than silently right. What each of those should say is a different question and answering it inside this change would be guessing; it is recorded on the issue instead.

## Quality checklist

- [x] No duplicated logic; the two deletes share one catalogue key and each renders into its own editor's region.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment at the first arm says what it settles and why the arm above it does not.
- [x] Architecture-conformance tests pass. No new structural property is locked in, and the paragraph above says why rather than leaving it to be discovered.
- [x] Docs impact considered: none. No behaviour an operator configures changes; a failure that said nothing now says something.

## Verification

- [x] `dotnet build --warnaserror` green on both target frameworks, 0 warnings.
- [x] `dotnet test` green on both, run serially: **net9.0 3826 / net10.0 3827, 0 failed, 4 skipped** (the four pre-existing firewall-consent skips, #1227).
- [x] Prettier clean.
- [x] `node tools/ui-mock-fields.js` and `node tools/ui-unsaved-state.js` both green.

**Not verified by execution**: the arms themselves. A proof arm was written for the save path, and it passed with the guard deleted — it was rejecting for a stub-shaped reason rather than for the read — so it was removed rather than shipped. An arm that cannot fail is worse than no arm, and this pull request would rather say the gap than paper it.

## On the German catalogue

One key, `config.config_read_failed`, written in German against the English beside it. What the line below proves is that a name is on that reading, never that the reading was thorough.

Catalogue-Vouch: de read by iderex

## Notes

- The seven-versus-four count above is the useful thing this change learned and is on #1577 as well, so it survives the pull request.
