### PR TITLE
Retarget the net10.0 leg to the Jellyfin 12.0 release [#1579]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -126,8 +126,8 @@ jobs:
           # THE SERVER TAG IS PINNED TO THE VERSION THE PLUGIN COMPILES AGAINST, for the reason the
           # canonical compose file gives at its own image line: .NET will not bind an assembly
           # reference DOWN, so a server older than the referenced Jellyfin assemblies refuses to load
-          # the plugin. SSO-Auth.csproj pins 12.0.0-rc2 for net10.0, so the tag here is 12.0-rc2 and
-          # deliberately not the newest 12.0 image; moving one without the other reintroduces exactly
+          # the plugin. SSO-Auth.csproj pins 12.0.0 for net10.0, so the tag here is 12.0 and
+          # deliberately follows that pin; moving one without the other reintroduces exactly
           # the mismatch that pin exists to prevent.
           #
           #     git grep -n "JellyfinVersion Condition" -- SSO-Auth/SSO-Auth.csproj
@@ -137,7 +137,7 @@ jobs:
           # than a failure, because the alternative is a typo in a caller silently publishing behind a
           # matrix that never ran.
           if [ "${INPUT_GENERATION:-}" = "jf12" ]; then
-            target=net10.0; metadata=build-jf12.yaml; image=12.0-rc2; needs_net10=yes
+            target=net10.0; metadata=build-jf12.yaml; image=12.0; needs_net10=yes
           else
             target=net9.0; metadata=build.yaml; image=10.11.11; needs_net10=no
           fi

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -91,12 +91,12 @@ jobs:
   # build metadata and the server image together, and the three are derived rather than typed twice.
   #
   #     git grep -n 'metadata=build-jf12[.]yaml' -- .github/workflows/e2e-login.yml
-  #     .github/workflows/e2e-login.yml:140:            target=net10.0; metadata=build-jf12.yaml; image=12.0-rc2; needs_net10=yes
+  #     .github/workflows/e2e-login.yml:140:            target=net10.0; metadata=build-jf12.yaml; image=12.0; needs_net10=yes
   #
   # So a packaged load failure of the #181/#590 class - the thing a pass on the other target framework
   # could not see, because the two build metadata files ship different closures - is inside this pass.
   #
-  # WHAT IS STILL OUTSIDE IT, and it is a real bound rather than a formality. The server is 12.0-rc2, the
+  # WHAT IS STILL OUTSIDE IT, and it is a real bound rather than a formality. The server is 12.0, the
   # version SSO-Auth.csproj compiles net10.0 against, so the harness proves the artifact against the
   # server it was built for and against no later 12.0 build. rc3 onward and GA are untested here, and a
   # 12.0 server that has moved under the plugin would not be caught by this job. #1466 records that as
@@ -244,7 +244,7 @@ jobs:
             Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
             https://raw.githubusercontent.com/${{ github.repository }}/manifest-beta/manifest.json
 
-            Scope note (#743/#1466): the JF12/5.0 line has **had no manual Release-QA pass against a live Jellyfin 12.0 server** - no 12.0 GA server exists to run the E2E checklist against, and this line is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate. What it does carry since #1466 is the automated seven-stack provider matrix that gates this publish: it boots a live `jellyfin/jellyfin:12.0-rc2` server, installs the net10.0 artifact this release ships into it, and drives OIDC and SAML login round-trips against seven identity providers. That is the rc the net10.0 build compiles against and no later 12.0 build. The 5.0 line clears its own live-validation gate when a Jellyfin 12.0 GA build exists and the manual checklist has been run against it. Use these betas for testing, not production.
+            Scope note (#743/#1466): the JF12/5.0 line has **had no manual Release-QA pass against a live Jellyfin 12.0 server** - the checklist has not been run since 12.0 GA shipped on 2026-09-07, and this line is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate. What it does carry since #1466 is the automated seven-stack provider matrix that gates this publish: it boots a live `jellyfin/jellyfin:12.0` server, installs the net10.0 artifact this release ships into it, and drives OIDC and SAML login round-trips against seven identity providers. That is the release the net10.0 build compiles against. The 5.0 line clears its own live-validation gate when the manual checklist has been run against a GA server; the GA build exists since 2026-09-07, so that run is the only condition left. Use these betas for testing, not production.
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish the draft release

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -42,11 +42,6 @@
           "xunit.v3.core.mtp-v2": "[3.2.2]"
         }
       },
-      "BitFaster.Caching": {
-        "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "iF2dMiGpaya8Umwi0OfsGKtq3aMVgHVsBChwQL+NhShEsRorcoTinGf9FFNBnBMwJW2Vm0FqhtOaEBY0+74p6g=="
-      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -103,47 +98,46 @@
       },
       "Jellyfin.Common": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "h96ohfL+W9XOkVA5UXOyXOjjccuwq2LaqzvFgrbcuR4BQL4QqvDKRGhR7ZnX1WH/RuY52QNOsotD5SZL6S0/Qw==",
+        "resolved": "12.0.0",
+        "contentHash": "U0XY7mKv1FSc0Dv10GOB+XDoiafTKnPe8zR/e8N/Cy1CMGKpbrRoAGUv7CwkJWBzk8vridlE5rP2L2Xow3QUrA==",
         "dependencies": {
-          "Jellyfin.Model": "12.0.0-rc2"
+          "Jellyfin.Model": "12.0.0"
         }
       },
       "Jellyfin.Controller": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "tLsNj8ecS+QscBT8mvCzhmIjfV987JXJEdqeEyuMmZuO41JKzmYQi8Z1DqN06hnMV9nCNOlbSsXDOnE5Xh92wA==",
+        "resolved": "12.0.0",
+        "contentHash": "CtqEPr2+oXjtHnlk2ZcavhTLLwaSLPa4DNu1qK8tv9S+qrz4PABYqEElO7NWkfPwGVcfaA+XD5mziHmZokAFHw==",
         "dependencies": {
-          "BitFaster.Caching": "2.6.0",
-          "Jellyfin.Common": "12.0.0-rc2",
-          "Jellyfin.MediaEncoding.Keyframes": "12.0.0-rc2",
-          "Jellyfin.Model": "12.0.0-rc2",
-          "Jellyfin.Naming": "12.0.0-rc2",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.9"
+          "Jellyfin.Common": "12.0.0",
+          "Jellyfin.MediaEncoding.Keyframes": "12.0.0",
+          "Jellyfin.Model": "12.0.0",
+          "Jellyfin.Naming": "12.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11"
         }
       },
       "Jellyfin.Data": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "6umXPZDpJw76vE3dMU1sT75gWwSVtw2tIog+mbDVfzTdZ1KZjksH5A1bKL39I4zo4yBKt9J2Xen1xj8eZ5wM5w==",
+        "resolved": "12.0.0",
+        "contentHash": "ogSgr4rjssk6vwAPgSTWrQOb8vj1XWQmROf64FKqq19AWUykGTHcaJiQWRkYiZFruOCXJQeNGOWv8IwCtfagBA==",
         "dependencies": {
-          "Jellyfin.Database.Implementations": "12.0.0-rc2",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Jellyfin.Database.Implementations": "12.0.0",
+          "Microsoft.Extensions.Logging": "10.0.11"
         }
       },
       "Jellyfin.Database.Implementations": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "XsnP+6Bx1CjrozNWA0ArrolJaJ1nzIksopURK6zz0J0kEZmu2l6unq3hiJ6wlAuxwZctf6YNYwGTM8zgLwY7sA==",
+        "resolved": "12.0.0",
+        "contentHash": "9MPKdD1MymXICBOjnt96YooZz1oI4lsL34sV+4iaG0kx4Jmm2qfA2/9uZbb3Y7+ZSWSA1Fa+21SJtyQ3fakboQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
           "Polly": "8.7.0"
         }
       },
       "Jellyfin.Extensions": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "ap/d3fEPZTpK1ihIE4jknKYkCdReab3fUh+cakvpewOdFUoTE11Y+e30GLdUJDjlOf0wYa2Ee/h1X5Q9VvIbGQ==",
+        "resolved": "12.0.0",
+        "contentHash": "p6XEGIE46Fn2SqZlPAlkeaP45SpPPtJ3fJPeNHXoGwOx83d09QENGrs4Ie8rTrWuoPoGvn/7g40d8eBrDzgADA==",
         "dependencies": {
           "Diacritics": "4.1.8",
           "ICU4N.Transliterator": "60.1.0-alpha.356"
@@ -151,28 +145,28 @@
       },
       "Jellyfin.MediaEncoding.Keyframes": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "bUmjVzvL7gxkEpvgsB0bTX3/vrTARrYkZ3A1LRlVytnMZE8UWS63HE7Ml5fH3mBNUUMgHtQxWbVdjd+qWoipUQ==",
+        "resolved": "12.0.0",
+        "contentHash": "RRyxFLr6JNDTatPPsn1xvQ1mhIUvwm7iWjEyh2Lt8FhLbEETsNaWSZKvfQxY2Gm5pMPRjlv0dH3tNUguyk6ZtQ==",
         "dependencies": {
           "NEbml": "1.1.0.5"
         }
       },
       "Jellyfin.Model": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "QrDTDrkoYMps5y9pZXFvWfCcBzOYVODcu3MRFgOsQZBQgZi/m4U5lVX1T+s1Tky3IbRnlACuk/2BJfQS4+vQtA==",
+        "resolved": "12.0.0",
+        "contentHash": "tunpZL+hOVh2CveVwBmGqMLC48ozlDsVbCLK/Xf3HBV0F1iIyeVMsxHahin7AMgYwCjbURfsov/ZA8ZO6CgYTQ==",
         "dependencies": {
-          "Jellyfin.Data": "12.0.0-rc2",
-          "Jellyfin.Extensions": "12.0.0-rc2"
+          "Jellyfin.Data": "12.0.0",
+          "Jellyfin.Extensions": "12.0.0"
         }
       },
       "Jellyfin.Naming": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "r+G0RDbH0wXlElhM8dxX1g0HX4Lmu3efOh9JIlGtyG3EEEte4oIEOz5nMoItq6P0IOdgDASXTSPUVdeYV+b8Ow==",
+        "resolved": "12.0.0",
+        "contentHash": "lHf27aSFmzYQoQ8ggY/7gst2LnjywW7xN6mRkScMzBmH5STvD+kfepGT38Ee4xDM1Fe17yxCiRWJKsKaFwVIcg==",
         "dependencies": {
-          "Jellyfin.Common": "12.0.0-rc2",
-          "Jellyfin.Model": "12.0.0-rc2"
+          "Jellyfin.Common": "12.0.0",
+          "Jellyfin.Model": "12.0.0"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -197,94 +191,94 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.11",
+        "contentHash": "VOSGU8en6HZJs8t7UMFN+9vGcRgVOOn6fA44Ngcg2NyvJ3P1KE94iAb0XzaVaGhXGtt+qaM/VtEn0/hzluQJeg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.11",
+        "contentHash": "6auJR+9+9VunznKfH7WGrHMrnrmA0F7JZ22EXzwXvVhjfnbu9Xq7NSIWaOf3KJsOanM2qf5ajJ2JR5TlcPZTLA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.11",
+        "contentHash": "Bv7X4wSSnzCQED9WYXKJ8fwgyvKwf0xZM1GO8xkf6CF9zl+UBnvjxmcPnokJRy0JKjc1SlHSzzhx1HcL4jitTQ=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.11",
+        "contentHash": "grznnTJgEYxaWpdKAsTzg6j+89jHgCXWYp+QGtlX5O92+w/VuhWM6JLPYb+uw8M9VhGUvOTsO76dYOy9vNPd5Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9",
-          "Microsoft.Extensions.Caching.Memory": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.11",
+          "Microsoft.Extensions.Caching.Memory": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "resolved": "10.0.11",
+        "contentHash": "vUl798SmruTqqlt/xH2gDk3tJlhk6k3HdOXAHirlRfbNKDym4g/kRpUL9S4sl6F6FsOTOMW+ZsDapqlZMOOiEw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "resolved": "10.0.11",
+        "contentHash": "el1g0mBEbDBGY2bT9mcSfrTWO8QlPdq2nOCnvQugioOFwHV+bVBMeiakoI0dNOdj8d6Hi9K6HY2xzRUWJiDR3w==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "resolved": "10.0.11",
+        "contentHash": "wlhRqZW8LcJPa+vk2oLAc/REXDItHtkFQdf/QcXYGZbZOO13izcsKY1pCvuFQYwUiZD+hwSZwsKASjqT+BNaVg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "resolved": "10.0.11",
+        "contentHash": "fVi053xdpda9Em7vSkmgVxO/PtgC2m78ekReKWsgcyskqY0U82Bz/MONwxpGzI0hElYKJfw+fupqMVeKW3fSaA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "resolved": "10.0.11",
+        "contentHash": "rFn8RuszZn3qquPVkDytMUlPc2+rXl9MCoygwc1XmAgC5vg5/oXJ8hkOosOrLoBLsqdTy4lFwP6iQdPS9uSYOA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.9",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "resolved": "10.0.11",
+        "contentHash": "PSmotV19c7E3lKed++uYo1kSiXFI+uTl37CBSrhq+CfLC3FCHjG7R91+xPnNehQfHS1b0Tzo/CCLPWH3qaEheg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+        "resolved": "10.0.11",
+        "contentHash": "/a1aJz4m7ylhEDf25ugQChLQoN5XwoGjWw/BoR/ZWWKsO1v4DdJElS1uyngahz4B/eOzjFk1KNTkarRLE5wsIg=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -293,35 +287,35 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "resolved": "10.0.11",
+        "contentHash": "nUOJwgFkSiLHiVGFpU22pIJtuWYewuSYQ3JVuP/gdK8ASMT807Px+TYQiRWs6uSsOmoyFTaVCwKXTasczV6BpA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "resolved": "10.0.11",
+        "contentHash": "Ljd0Uxoq5XpScD2Bg0nM/r3mwx7Ao5Uq24eo2ARxbGvqJ7Zht6rt2cJtwVRH4Cv+1ZVMdXz6TB43KbpmsxRrvQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "resolved": "10.0.11",
+        "contentHash": "eY1GAKcTfD2maP27J84X9IovT3yjHJ2dVDzPmDg6/XqYvt3jMzJhtfQCLjG9pVsZGAd+8DQ2QrjaDcs2+VQLGw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+        "resolved": "10.0.11",
+        "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -478,8 +472,8 @@
         "type": "Project",
         "dependencies": {
           "Duende.IdentityModel.OidcClient": "[7.1.0, )",
-          "Jellyfin.Controller": "[12.0.0-rc2, )",
-          "Jellyfin.Model": "[12.0.0-rc2, )",
+          "Jellyfin.Controller": "[12.0.0, )",
+          "Jellyfin.Model": "[12.0.0, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[8.19.1, )",
           "Newtonsoft.Json": "[13.0.4, )"
         }

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -31,7 +31,7 @@
          build.yaml targetAbi floor to prove the used API surface also exists on the oldest claimed
          server (#142). The committed lockfile pins the default, so a locked-mode restore is unaffected. -->
     <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net9.0'">10.11.11</JellyfinVersion>
-    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0-rc2</JellyfinVersion>
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == '' and '$(TargetFramework)' == 'net10.0'">12.0.0</JellyfinVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SSO-Auth/packages.lock.json
+++ b/SSO-Auth/packages.lock.json
@@ -13,25 +13,24 @@
       },
       "Jellyfin.Controller": {
         "type": "Direct",
-        "requested": "[12.0.0-rc2, )",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "tLsNj8ecS+QscBT8mvCzhmIjfV987JXJEdqeEyuMmZuO41JKzmYQi8Z1DqN06hnMV9nCNOlbSsXDOnE5Xh92wA==",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "CtqEPr2+oXjtHnlk2ZcavhTLLwaSLPa4DNu1qK8tv9S+qrz4PABYqEElO7NWkfPwGVcfaA+XD5mziHmZokAFHw==",
         "dependencies": {
-          "BitFaster.Caching": "2.6.0",
-          "Jellyfin.Common": "12.0.0-rc2",
-          "Jellyfin.MediaEncoding.Keyframes": "12.0.0-rc2",
-          "Jellyfin.Model": "12.0.0-rc2",
-          "Jellyfin.Naming": "12.0.0-rc2"
+          "Jellyfin.Common": "12.0.0",
+          "Jellyfin.MediaEncoding.Keyframes": "12.0.0",
+          "Jellyfin.Model": "12.0.0",
+          "Jellyfin.Naming": "12.0.0"
         }
       },
       "Jellyfin.Model": {
         "type": "Direct",
-        "requested": "[12.0.0-rc2, )",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "QrDTDrkoYMps5y9pZXFvWfCcBzOYVODcu3MRFgOsQZBQgZi/m4U5lVX1T+s1Tky3IbRnlACuk/2BJfQS4+vQtA==",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "tunpZL+hOVh2CveVwBmGqMLC48ozlDsVbCLK/Xf3HBV0F1iIyeVMsxHahin7AMgYwCjbURfsov/ZA8ZO6CgYTQ==",
         "dependencies": {
-          "Jellyfin.Data": "12.0.0-rc2",
-          "Jellyfin.Extensions": "12.0.0-rc2"
+          "Jellyfin.Data": "12.0.0",
+          "Jellyfin.Extensions": "12.0.0"
         }
       },
       "Meziantou.Analyzer": {
@@ -91,11 +90,6 @@
           "System.Security.Cryptography.Pkcs": "10.0.10"
         }
       },
-      "BitFaster.Caching": {
-        "type": "Transitive",
-        "resolved": "2.6.0",
-        "contentHash": "iF2dMiGpaya8Umwi0OfsGKtq3aMVgHVsBChwQL+NhShEsRorcoTinGf9FFNBnBMwJW2Vm0FqhtOaEBY0+74p6g=="
-      },
       "Diacritics": {
         "type": "Transitive",
         "resolved": "4.1.8",
@@ -129,33 +123,33 @@
       },
       "Jellyfin.Common": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "h96ohfL+W9XOkVA5UXOyXOjjccuwq2LaqzvFgrbcuR4BQL4QqvDKRGhR7ZnX1WH/RuY52QNOsotD5SZL6S0/Qw==",
+        "resolved": "12.0.0",
+        "contentHash": "U0XY7mKv1FSc0Dv10GOB+XDoiafTKnPe8zR/e8N/Cy1CMGKpbrRoAGUv7CwkJWBzk8vridlE5rP2L2Xow3QUrA==",
         "dependencies": {
-          "Jellyfin.Model": "12.0.0-rc2"
+          "Jellyfin.Model": "12.0.0"
         }
       },
       "Jellyfin.Data": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "6umXPZDpJw76vE3dMU1sT75gWwSVtw2tIog+mbDVfzTdZ1KZjksH5A1bKL39I4zo4yBKt9J2Xen1xj8eZ5wM5w==",
+        "resolved": "12.0.0",
+        "contentHash": "ogSgr4rjssk6vwAPgSTWrQOb8vj1XWQmROf64FKqq19AWUykGTHcaJiQWRkYiZFruOCXJQeNGOWv8IwCtfagBA==",
         "dependencies": {
-          "Jellyfin.Database.Implementations": "12.0.0-rc2"
+          "Jellyfin.Database.Implementations": "12.0.0"
         }
       },
       "Jellyfin.Database.Implementations": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "XsnP+6Bx1CjrozNWA0ArrolJaJ1nzIksopURK6zz0J0kEZmu2l6unq3hiJ6wlAuxwZctf6YNYwGTM8zgLwY7sA==",
+        "resolved": "12.0.0",
+        "contentHash": "9MPKdD1MymXICBOjnt96YooZz1oI4lsL34sV+4iaG0kx4Jmm2qfA2/9uZbb3Y7+ZSWSA1Fa+21SJtyQ3fakboQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.11",
           "Polly": "8.7.0"
         }
       },
       "Jellyfin.Extensions": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "ap/d3fEPZTpK1ihIE4jknKYkCdReab3fUh+cakvpewOdFUoTE11Y+e30GLdUJDjlOf0wYa2Ee/h1X5Q9VvIbGQ==",
+        "resolved": "12.0.0",
+        "contentHash": "p6XEGIE46Fn2SqZlPAlkeaP45SpPPtJ3fJPeNHXoGwOx83d09QENGrs4Ie8rTrWuoPoGvn/7g40d8eBrDzgADA==",
         "dependencies": {
           "Diacritics": "4.1.8",
           "ICU4N.Transliterator": "60.1.0-alpha.356"
@@ -163,19 +157,19 @@
       },
       "Jellyfin.MediaEncoding.Keyframes": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "bUmjVzvL7gxkEpvgsB0bTX3/vrTARrYkZ3A1LRlVytnMZE8UWS63HE7Ml5fH3mBNUUMgHtQxWbVdjd+qWoipUQ==",
+        "resolved": "12.0.0",
+        "contentHash": "RRyxFLr6JNDTatPPsn1xvQ1mhIUvwm7iWjEyh2Lt8FhLbEETsNaWSZKvfQxY2Gm5pMPRjlv0dH3tNUguyk6ZtQ==",
         "dependencies": {
           "NEbml": "1.1.0.5"
         }
       },
       "Jellyfin.Naming": {
         "type": "Transitive",
-        "resolved": "12.0.0-rc2",
-        "contentHash": "r+G0RDbH0wXlElhM8dxX1g0HX4Lmu3efOh9JIlGtyG3EEEte4oIEOz5nMoItq6P0IOdgDASXTSPUVdeYV+b8Ow==",
+        "resolved": "12.0.0",
+        "contentHash": "lHf27aSFmzYQoQ8ggY/7gst2LnjywW7xN6mRkScMzBmH5STvD+kfepGT38Ee4xDM1Fe17yxCiRWJKsKaFwVIcg==",
         "dependencies": {
-          "Jellyfin.Common": "12.0.0-rc2",
-          "Jellyfin.Model": "12.0.0-rc2"
+          "Jellyfin.Common": "12.0.0",
+          "Jellyfin.Model": "12.0.0"
         }
       },
       "Microsoft.Bcl.Cryptography": {
@@ -185,29 +179,29 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "resolved": "10.0.11",
+        "contentHash": "VOSGU8en6HZJs8t7UMFN+9vGcRgVOOn6fA44Ngcg2NyvJ3P1KE94iAb0XzaVaGhXGtt+qaM/VtEn0/hzluQJeg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.11",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+        "resolved": "10.0.11",
+        "contentHash": "6auJR+9+9VunznKfH7WGrHMrnrmA0F7JZ22EXzwXvVhjfnbu9Xq7NSIWaOf3KJsOanM2qf5ajJ2JR5TlcPZTLA=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+        "resolved": "10.0.11",
+        "contentHash": "Bv7X4wSSnzCQED9WYXKJ8fwgyvKwf0xZM1GO8xkf6CF9zl+UBnvjxmcPnokJRy0JKjc1SlHSzzhx1HcL4jitTQ=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "resolved": "10.0.11",
+        "contentHash": "grznnTJgEYxaWpdKAsTzg6j+89jHgCXWYp+QGtlX5O92+w/VuhWM6JLPYb+uw8M9VhGUvOTsO76dYOy9vNPd5Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.11"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -7,7 +7,7 @@ guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/main/img/logo.png"
 # The JF12 (5.0) line's target version. The beta workflow overrides this to 5.0.0.<run> at build time;
 # a 5.0.0-JF12-stable tag releases 5.0.0. Bump per change class exactly like build.yaml's version.
-version: "5.0.0"
+version: "6.0.0"
 # Jellyfin 12.0 moves the server to .NET 10; a 10.11-ABI plugin will not load there. This is the 12.0
 # line's ABI floor.
 targetAbi: "12.0.0.0"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -255,13 +255,15 @@ chmod -R 0777 test/e2e/jellyfin
 
 # 3. Boot the same stack against a 12.0 server. Every compose file in this directory takes the tag
 #    from this variable and defaults to the 10.11 server when it is unset, so nothing above changes.
-JELLYFIN_IMAGE_TAG=12.0-rc2 docker compose -f test/e2e/docker-compose.yml up \
+JELLYFIN_IMAGE_TAG=12.0 docker compose -f test/e2e/docker-compose.yml up \
   --abort-on-container-exit --exit-code-from harness
 ```
 
-The tag is **12.0-rc2 rather than the newest 12.0 image**, because it has to match the Jellyfin
-version the plugin compiles against - .NET will not bind an assembly reference down, so a server
-older than the referenced assemblies refuses to load the plugin. The pin lives in one place:
+The tag is **whatever the plugin compiles against, not whatever is newest**, because .NET will not
+bind an assembly reference down: a server older than the referenced assemblies refuses to load the
+plugin. Since 12.0 went GA on 2026-09-07 the two coincide, and that is a coincidence rather than a
+rule - the day a 12.1 image appears this tag stays at 12.0 until the pin moves. The pin lives in one
+place:
 
 ```sh
 git grep -n "JellyfinVersion Condition" -- SSO-Auth/SSO-Auth.csproj

--- a/test/e2e/pairwise/run-pairwise.sh
+++ b/test/e2e/pairwise/run-pairwise.sh
@@ -37,7 +37,7 @@ GENERATION="${SERVER_GENERATION:-jf10.11}"
 # sibling would make an empty run look like a clean one.
 if [ "$GENERATION" = "jf12" ]; then
   ABI_PREFIX="12."
-  DEFAULT_IMAGE="12.0-rc2"
+  DEFAULT_IMAGE="12.0"
 else
   ABI_PREFIX="10.11"
   DEFAULT_IMAGE="10.11.11"


### PR DESCRIPTION
# What & why

Jellyfin 12.0 went GA on 2026-09-07. The net10.0 leg compiled against
`12.0.0-rc2` while `build-jf12.yaml` already advertised `targetAbi 12.0.0.0`, so
the 5.0 artifact was built against a release candidate and offered as compatible
with the release. Closes #1579.

The same change numbers the JF12 line: `4.3` is the last release for Jellyfin
10.11 and `5.0` is the JF12 generation, so the next JF12 number is `6.0`. It
lives in `build-jf12.yaml` and NOWHERE else. `AssemblyVersion` and `build.yaml`
stay paired on the 10.11 generation's number, which `check-jellyfin-compat.sh`
enforces and which `main` already shows: assembly 4.3.0, `build.yaml` 4.3.0,
`build-jf12.yaml` 5.0.0 on its own. This supersedes #1580, which put the number
in the assembly and was refused by that check.

Five pins move together, for the reason the e2e server pin already states in the
tree: .NET will not bind an assembly reference down, so a server older than the
referenced assemblies refuses to load the plugin.

```
SSO-Auth/SSO-Auth.csproj            net10.0 JellyfinVersion   12.0.0-rc2 -> 12.0.0
SSO-Auth/packages.lock.json         8 Jellyfin.* under net10.0
SSO-Auth.Tests/packages.lock.json   the same eight
.github/workflows/e2e-login.yml     server image  12.0-rc2 -> 12.0
test/e2e/pairwise/run-pairwise.sh   DEFAULT_IMAGE 12.0-rc2 -> 12.0
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches no login logic, no crypto and no config persistence. It moves the
version of the server packages the net10.0 leg compiles against and the server
image the harness boots, and it renumbers a line.

- [x] Fail-closed preserved: no validation branch is added, removed or reached
      differently. The gates are the same code, now compiled against the GA
      packages, and the harness asserts each of them against a GA server (below).
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run. Not a SAML/OIDC validation,
      config-persistence or release-pipeline change.
- [x] Review record: no lens gate applies. What stands in its place is a live
      run against a real GA server, which is stronger evidence than a reading
      for this particular class of change.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: no logic changed.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the prose that explained the old pin was rewritten
      rather than left to rot, see Notes.
- [x] Architecture-conformance tests pass, in the harness run below.
- [x] Docs impact: `test/e2e/README.md` and the scope note in
      `publish-jf12-beta.yml` are updated in this pull request.

## Verification

**Build against the GA package, `--warnaserror`:**

```
0 Warnung(en)
0 Fehler
```

So the plugin interfaces the upstream announcement says changed do not reach
this plugin's surface. That is a measurement rather than a reading.

**The harness against a real GA server.** The 5.0 scope note names its own gate:

> The 5.0 line clears its own live-validation gate when a Jellyfin 12.0 GA build
> exists and the manual checklist has been run against it.

The first half became true on 2026-09-07. Run locally on 2026-09-09 with
`JELLYFIN_IMAGE_TAG=12.0` against `jellyfin/jellyfin:12.0`
(`sha256:baba6304...`), server reporting `Jellyfin version: 12.0.0`, with the
packaged net10.0 artifact `community-sso-for-jellyfin_6.0.0.0.zip` at
`targetAbi 12.0.0.0`:

```
PASS: plugin loaded and provider 'keycloak' is listed by GetNames
PASS: the authorize request binds the code with code_challenge_method=S256
PASS: alice: Jellyfin session token minted (user='alice')
PASS: alice: minted policy carries IsAdministrator=true from the IdP role claim
PASS: bob: callback refused the role-less user at the plugin (HTTP 401, role gate holds)
PASS: replayed state refused (HTTP 400, one-time-use holds)
PASS: SSO-only: non-exempt password login refused (HTTP 401)
PASS: SSO-only: the break-glass admin's password door survives
PASS: SSO-only: disable restores the password user's native login (no hash was reset)
PASS: carol: Jellyfin session token minted via SAML (user='carol')
PASS: dave: SAML ACS refused the role-less user at the plugin (HTTP 401, no token minted)
PASS: SAML: replayed login-outcome token refused (HTTP 400, one-time-use holds)
ALL E2E CHECKS PASSED
```

26 assertions, exit 0. Recorded in `docs/E2E-RUNS.md`.

- [x] `dotnet build --no-restore --warnaserror` is green (net10.0).
- [x] `dotnet test`: run as the manual prescribes, through the built MTP
      executable rather than `dotnet test` (which starts no tests here):
      **Total: 3828, Errors: 0, Failed: 0, Skipped: 4**. The local host has no
      .NET 9 runtime, so
      the net9.0 leg was not built or tested here; that leg is untouched by this
      change, since both `JellyfinVersion` lines are conditioned per target
      framework and only the net10.0 one moves.
- [x] Prettier: the only `.md` change is `test/e2e/README.md`.

## Notes

**Two things are deliberately NOT rewritten.**

The comment in `test/e2e/phases/passwordless-account-sweep.sh` records server
behaviour measured on 12.0-rc2, with its run number beside it. Moving that
figure to 12.0 would claim a measurement nobody took.

The paragraph in `test/e2e/README.md` that explained the old pin said the tag is
"12.0-rc2 rather than the newest 12.0 image". A blind substitution turned it
into "12.0 rather than the newest 12.0 image", which says nothing. It now says
the tag follows the pin rather than the newest image, and that the two coincide
today by coincidence rather than by rule.

**`build.yaml` keeps its 10.11 metadata and its number.** Retiring the net9.0
half removes a target framework, the 10.11-only package pins and the ABI-floor
job, and it re-opens the shipped-artifact closure question. None of that belongs
in a retarget, and 4.3 still has a soak to finish.
