### PR TITLE
Number the Jellyfin 12.0 line 5.0 rather than 6.0 [#1582]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,24 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Changed
 
+- **This line is 5.0, because the Jellyfin generation under it changed
+  (#1579).** Jellyfin 12.0 went GA on 2026-09-07 and its announcement is
+  explicit that plugins built for 10.11 will not load on it: the server targets
+  .NET 10 and several plugin interfaces changed. The scheme at the top of this
+  file reserves **X** for exactly that, a breaking or Jellyfin-ABI change, so
+  what was numbered 4.4 is 5.0 in all three places that carry the number: the
+  assembly, `build.yaml` and `build-jf12.yaml`.
+
+  **4.3 stays the last release for Jellyfin 10.11.** It is finishing its soak
+  and ships as the stable for that generation; nothing on this line is offered
+  to a 10.11 server. The net9.0 half of the build is not removed here, because
+  taking a target framework out also takes the 10.11-only package pins and the
+  ABI-floor job with it and re-opens which assemblies the package must carry.
+  That is its own change.
+
+  The number is the only thing this entry is about. What the line compiles
+  against moved in the same delivery and is recorded above.
+
 - **The settings page is five pages (#1527).** One 222 KB page carrying all 123
   controls became five, joined by the dashboard's own tab strip: **Overview**,
   **Providers**, **Accounts**, **Policies** and **Server**. Nothing was added to

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -8,8 +8,8 @@
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>4.4.0</AssemblyVersion>
-    <FileVersion>4.4.0</FileVersion>
+    <AssemblyVersion>5.0.0</AssemblyVersion>
+    <FileVersion>5.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -7,7 +7,7 @@ guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/main/img/logo.png"
 # The JF12 (5.0) line's target version. The beta workflow overrides this to 5.0.0.<run> at build time;
 # a 5.0.0-JF12-stable tag releases 5.0.0. Bump per change class exactly like build.yaml's version.
-version: "6.0.0"
+version: "5.0.0"
 # Jellyfin 12.0 moves the server to .NET 10; a 10.11-ABI plugin will not load there. This is the 12.0
 # line's ABI floor.
 targetAbi: "12.0.0.0"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "Community SSO for Jellyfin"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.4.0"
+version: "5.0.0"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here - otherwise a newer member would throw MissingMethodException at


### PR DESCRIPTION
# What & why

The line that was numbered `4.4` carries the Jellyfin 12.0 generation, so it is
`5.0`. #1579 numbered it `6.0`, which skipped a number for no stated reason.
Closes #1582.

The scheme is already written at the top of `CHANGELOG.md`:

> Versions are three-part `X.Y.Z` ... **X** a breaking / Jellyfin-ABI change

Jellyfin 12.0 went GA on 2026-09-07 and its announcement says plugins built for
10.11 will not load on it. That is an X bump, and the X after 4 is 5.
`build-jf12.yaml` had been carrying `5.0.0` for this generation all along.

```
SSO-Auth/SSO-Auth.csproj   AssemblyVersion / FileVersion   4.4.0 -> 5.0.0
build.yaml                 version                         4.4.0 -> 5.0.0
build-jf12.yaml            version                         6.0.0 -> 5.0.0
CHANGELOG.md               why the X moved
```

All three files move together because `scripts/check-jellyfin-compat.sh` refuses
a disagreement between the assembly and `build.yaml`.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

No code changed. This moves four version strings and adds a changelog entry.

- [x] Fail-closed preserved: no branch added, removed or reached differently.
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run, and not applicable to a version
      string.
- [x] Review record: no lens gate applies.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: no logic.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the changelog entry says WHY the X moved, not only that
      it did, so the next reader does not have to re-derive it from the scheme.
- [x] Architecture-conformance tests pass.
- [x] Docs impact: `CHANGELOG.md` is in this pull request. The pr-hygiene gate
      requires it on a `build.yaml` version change, and it would have blocked
      this merge without it.

## Verification

```
$ bash scripts/check-jellyfin-compat.sh
ok: plugin version (build.yaml vs AssemblyVersion) = 5.0.0
ok: FileVersion vs AssemblyVersion = 5.0.0
Jellyfin compatibility metadata is consistent.

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
0 Warnung(en)
0 Fehler
```

- [x] `dotnet build --no-restore --warnaserror` is green (net10.0).
- [x] `dotnet test`: the suite was run through the built MTP executable on the
      parent commit of this branch, **Total: 3828, Errors: 0, Failed: 0,
      Skipped: 4**. This change touches no code, only version strings and a
      document.
- [x] Prettier: clean for `CHANGELOG.md`.

## Notes

**Two things are deliberately out of scope, each for its own reason.**

The `net9.0` half stays. Removing a target framework takes the 10.11-only
package pins and the ABI-floor job with it and re-opens which assemblies the
package must carry. `4.3` is still finishing its soak as the last release for
Jellyfin 10.11.

The publish plumbing stays. Both nightly legs still dispatch from `main`:

```
gh workflow run publish-beta.yml      --ref main
gh workflow run publish-jf12-beta.yml --ref main
```

So a 5.0 beta cut from THIS line, rather than from the frozen `main`, needs that
JF12 dispatch moved. That changes what real users are offered nightly, so it is
filed on its own rather than riding a renumbering.
