### PR TITLE
Report the rights the mint granted in the login audit line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,28 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **The login audit line's `admin=` field now reports the rights the session was
+  actually granted, not the role mapping's verdict (#1554).** The
+  `[SSO Audit] Login succeeded` line printed the result of matching the login's
+  roles against the configured `AdminRoles` list, and the session mint does not
+  always agree with it. The whole permission block is behind
+  `EnableAuthorization`, which is off by default, so `admin=True` could be
+  printed for a session that was never made an administrator; and the break-glass
+  administrator is deliberately never demoted, so that account signing in where
+  no role maps to admin was printed as `admin=False` while holding an
+  administrator session. The first is a false alarm and the second is a
+  **missed** one, and a trail that under-reports real administrator access is the
+  failure an audit trail is bought to prevent. The field is now read from the
+  same authentication result the host publishes in its own
+  `AuthenticationSuccess` event, after the permission write, so the two records
+  cannot disagree; a mapping that differs from the outcome is appended as
+  `The provider's roles mapped to admin=<value>.` rather than replacing it, and a
+  login where the two agree writes the line byte-for-byte as before.
+  **A structured log sink received `IsAdmin` as a Boolean and now receives a
+  String - `True`, `False`, or `unknown` where there was no result to read - so a
+  rule written as `IsAdmin == true` has to be rewritten. The rendered text of
+  `admin=True` and `admin=False` is unchanged.**
+
 - **A failed configuration read no longer leaves a pressed Save with no outcome
   at all (#1577).** Saving or deleting a provider reads the stored configuration
   before it writes, and four of those reads had no failure arm. The two saves

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+﻿// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
@@ -57,7 +57,7 @@ public class SsoAuditTests
     {
         var logger = new CapturingLogger();
 
-        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: true);
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", grantedAdmin: true, mappedAdmin: true);
 
         var entry = Assert.Single(logger.Entries);
         Assert.Equal(LogLevel.Information, entry.Level);
@@ -74,7 +74,7 @@ public class SsoAuditTests
         var logger = new CapturingLogger();
 
         // Both the username (IdP-derived) and the provider (route/admin input) are foreign values.
-        SsoAudit.LoginSucceeded(logger, "SAML", "corp\nX", "ali\r\nce", isAdmin: false);
+        SsoAudit.LoginSucceeded(logger, "SAML", "corp\nX", "ali\r\nce", grantedAdmin: false, mappedAdmin: false);
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
@@ -89,7 +89,7 @@ public class SsoAuditTests
         // it is a second forging surface and carries the same inline sanitizer as the first.
         var logger = new CapturingLogger();
 
-        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice.jellyfin", isAdmin: false, presentedUsername: "ali\r\n[SSO Audit] forged");
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice.jellyfin", grantedAdmin: false, mappedAdmin: false, presentedUsername: "ali\r\n[SSO Audit] forged");
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
@@ -112,7 +112,7 @@ public class SsoAuditTests
         // just by appending a newline to the name it presents.
         var logger = new CapturingLogger();
 
-        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: false, presentedUsername: "alice\r\n");
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", grantedAdmin: false, mappedAdmin: false, presentedUsername: "alice\r\n");
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=False).", message);
@@ -125,10 +125,83 @@ public class SsoAuditTests
         // is the row that fails if the comparison is dropped and the clause becomes unconditional.
         var logger = new CapturingLogger();
 
-        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: false, presentedUsername: "alice");
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", grantedAdmin: false, mappedAdmin: false, presentedUsername: "alice");
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=False).", message);
+    }
+
+    [Fact]
+    public void LoginSucceeded_TheRoleMappingDisagreeingWithTheGrant_ReportsTheGrantAndNamesTheMapping()
+    {
+        // #1554. The field is the OUTCOME: a login whose roles mapped to admin but which the mint granted
+        // nothing for prints admin=False, and the mapping's verdict is carried beside it as what it is.
+        // Reversing the two - which is what this line did before - is the false-alarm direction of the defect.
+        //
+        // THE CLAUSE NAMES A MAPPING AND NOT AN ASSERTION, and the exact sentence is asserted for that reason:
+        // the value is a role of this login matching the ADMIN-CONFIGURED AdminRoles list, so wording it as
+        // something the provider said would put words in a third party's mouth - and on a default install,
+        // where that list is empty, it would put a denial there on every administrator's login.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", grantedAdmin: false, mappedAdmin: true);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=False). The provider's roles mapped to admin=True.",
+            message);
+    }
+
+    [Fact]
+    public void LoginSucceeded_AGrantNoRoleMappedTo_IsReportedAsHeld()
+    {
+        // The MISSED direction, and the one that settled #1554: the break-glass administrator is never demoted
+        // by the mint, so it holds an administrator session while no role of its login maps to admin. Reporting
+        // the mapping there told the trail an administrator did not sign in when one did, which is the failure
+        // an audit trail is bought to prevent.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "root", grantedAdmin: true, mappedAdmin: false);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: root via OpenID provider 'corp' (admin=True). The provider's roles mapped to admin=False.",
+            message);
+    }
+
+    [Fact]
+    public void LoginSucceeded_AnUnreadableGrant_SaysSoInItsOwnWord_AndStillNamesTheMapping()
+    {
+        // The absent arm. A mint that returned nothing to read leaves the outcome unknown, and the word says
+        // so rather than a boolean guessing it - guessing False would report every such login as a
+        // non-administrator one, which is the under-reporting direction again. The mapping is named because an
+        // absent outcome agrees with nothing, so the line still carries some privilege information.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", grantedAdmin: null, mappedAdmin: true);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: alice via OpenID provider 'corp' (admin=unknown). The provider's roles mapped to admin=True.",
+            message);
+    }
+
+    [Fact]
+    public void LoginSucceeded_BothOptionalClausesAtOnce_AreWrittenAsOneSentence()
+    {
+        // The two clauses are independent, so all four templates are reachable and this is the one a
+        // three-template implementation drops. It also pins that the presented name keeps both inline
+        // sanitizers in the fourth template - a template added without them is a fresh forging surface.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice.jellyfin", grantedAdmin: true, mappedAdmin: false, presentedUsername: "ali\r\n[SSO Audit] ce");
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: alice.jellyfin via OpenID provider 'corp' (admin=True). "
+            + "The provider presented the name 'ali(SSO Audit] ce', and its roles mapped to admin=False.",
+            message);
+        Assert.Equal(1, CountMarkers(message));
     }
 
     [Fact]
@@ -367,7 +440,7 @@ public class SsoAuditTests
         // (CA1873); a disabled level must emit NOTHING rather than an unsanitized fallback.
         var off = new LevelFilteredLogger(minimum: LogLevel.Error);
 
-        SsoAudit.LoginSucceeded(off, "OpenID", "corp", "alice", isAdmin: false);
+        SsoAudit.LoginSucceeded(off, "OpenID", "corp", "alice", grantedAdmin: false, mappedAdmin: false);
         SsoAudit.ProviderConfigured(off, "OpenID", "corp");
         SsoAudit.LogoutRequested(off, "corp", 1);
         SsoAudit.ProvisionedPendingApproval(off, "OpenID", "corp", "u");
@@ -461,7 +534,7 @@ public class SsoAuditTests
         // Both foreign values of this entry carry the payload, so the row reddens whichever of the two
         // loses its substitution. The account name cannot carry one in practice - Jellyfin's own
         // allowlist admits no bracket - which is exactly why the provider name is the second here.
-        SsoAudit.LoginSucceeded(logger, "OpenID", SecondRecordPayload, "eve", isAdmin: false, presentedUsername: SecondRecordPayload);
+        SsoAudit.LoginSucceeded(logger, "OpenID", SecondRecordPayload, "eve", grantedAdmin: false, mappedAdmin: false, presentedUsername: SecondRecordPayload);
 
         var message = Assert.Single(logger.Entries).Message;
         Assert.Equal(1, CountMarkers(message));

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+﻿// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
@@ -22,6 +22,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Users;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
@@ -61,14 +62,32 @@ public class LoginCompletionServiceTests
     private static AuthResponse Response() =>
         new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
 
-    private static VerifiedIdentity OidcIdentity(string provider, string subject, string username, int? maxParentalRatingScore = null) =>
+    // The host's own answering shape (#1554). AuthenticateDirect builds its result's user from the account as
+    // it stands WHEN IT IS CALLED - after the minter's permission write - and publishes the same instance it
+    // returns. A fixture answering with a fixed policy would report whatever it was handed, so the two arms
+    // below would prove nothing about what the mint decided; this one is read off the very account the minter
+    // mutates, at the moment the host reads it.
+    private static void AnswerLikeTheHost(ISessionManager sessions, User account) =>
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(_ => new AuthenticationResult
+        {
+            User = new UserDto
+            {
+                Name = account.Username,
+                Policy = new UserPolicy
+                {
+                    IsAdministrator = account.HasPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator),
+                },
+            },
+        });
+
+    private static VerifiedIdentity OidcIdentity(string provider, string subject, string username, int? maxParentalRatingScore = null, bool admin = false) =>
         TestIdentities.Oidc(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: username,
             Subject: subject,
             Issuer: null,
             EmailVerified: null,
             Valid: true,
-            Admin: false,
+            Admin: admin,
             EnableLiveTv: false,
             EnableLiveTvManagement: false,
             Folders: new List<string>(),
@@ -488,15 +507,122 @@ public class LoginCompletionServiceTests
         };
         var auditLog = new CapturingLogger();
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
-        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        var alice = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(alice);
         users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
-        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
-            .Returns(new AuthenticationResult { User = new UserDto { Name = "alice" } });
+        // The host result carries a policy because the host's always does (#1554): it is built from the
+        // resolved account, whose administrator permission this row leaves off, and the provider asserts
+        // nothing either - so both optional clauses are silent and this is the whole line.
+        AnswerLikeTheHost(sessions, alice);
 
         await service.CompleteAsync(
             OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
 
         var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
         Assert.Equal("[SSO Audit] Login succeeded: alice via OpenID provider 'kc' (admin=False).", audit.Message);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AnAdminClaimWithAuthorizationOff_ReportsTheRightsTheMintGranted()
+    {
+        // #1554, arm one. EnableAuthorization is off - the default - so the minter's whole permission block is
+        // skipped and this login makes nobody an administrator. The line reporting the role mapping said
+        // admin=True for a session that never held the rights, which sends an operator after an escalation
+        // that did not happen. The outcome is read off the host's own result, so it cannot drift from the
+        // AuthenticationSuccess event published for the same mint, and the mapping is named as a mapping.
+        var config = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        var alice = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(alice);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        AnswerLikeTheHost(sessions, alice);
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice", admin: true), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        // The mint really did leave the account alone: the row would pass on a wrong reading of an account
+        // that HAD been made an administrator, so the state it reports is asserted beside the line.
+        Assert.False(alice.HasPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator));
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: alice via OpenID provider 'kc' (admin=False). The provider's roles mapped to admin=True.",
+            audit.Message);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_BreakGlassAdminWithNoAdminClaim_ReportsTheAdministratorSessionItHolds()
+    {
+        // #1554, arm two, and the direction that settled the issue. SSO-only mode is on and role mapping IS
+        // on, but the minter is forbidden to demote the break-glass administrator (#165 Finding H1), so this
+        // login holds an administrator session while no role of it maps to admin. The line reporting the
+        // mapping said admin=False: an administrator signed in and the trail denied it, which is the
+        // under-reporting failure an audit trail exists to prevent.
+        var config = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-root"] = Existing },
+        };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(
+            c =>
+            {
+                c.OidConfigs["kc"] = config;
+                c.DisablePasswordLogin = true;
+                c.BreakGlassAdminUsername = "root";
+            },
+            auditLog);
+        var root = TestUsers.Named("root", Existing);
+        root.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
+        root.SetPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator, true);
+        users.GetUserById(Existing).Returns(root);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        AnswerLikeTheHost(sessions, root);
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-root", "root"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.True(root.HasPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator));
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: root via OpenID provider 'kc' (admin=True). The provider's roles mapped to admin=False.",
+            audit.Message);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AMintThatReturnedNoPolicy_SaysTheGrantIsUnknown_RatherThanGuessingIt()
+    {
+        // The absent arm the decision asked for: the line is still written when there is no policy to read,
+        // and it says so in a word. Guessing False here would report an administrator login as an ordinary
+        // one, which is the same under-reporting this issue closes; guessing the mapping would put the field
+        // back where it started.
+        //
+        // THE FIXTURE IS A RESULT WITH NO USER, AND THAT IS THE ONLY WAY IN. A UserDto carries a UserPolicy
+        // whether or not one is assigned - written first as `new UserDto { Name = "alice" }`, this row read
+        // admin=False rather than unknown - so the absent state is reachable exactly where the host returned
+        // no user at all, which is the same condition MintedUsername already falls back on.
+        var config = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice", admin: true), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Equal(
+            "[SSO Audit] Login succeeded: alice via OpenID provider 'kc' (admin=unknown). The provider's roles mapped to admin=True.",
+            audit.Message);
     }
 }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -57,27 +57,80 @@ internal static class SsoAudit
     /// <c>SyncUsernameFromProvider</c> is off by default; a created account was provisioned under the
     /// host's own name allowlist, which drops characters the provider's name may carry; a requested rename
     /// can have been declined - so the presented name is carried too, and only where the two differ.
+    /// THE PRIVILEGE FIELD IS THE SAME KIND OF VALUE FOR THE SAME REASON (#1554): <c>admin=</c> reports what
+    /// the MINT GRANTED, and the role mapping's own verdict is named beside it only where the two disagree.
     /// </summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
     /// <param name="username">The Jellyfin account the session was issued for.</param>
-    /// <param name="isAdmin">
-    /// Whether the identity provider ASSERTED administrator rights on this login. It is the identity's claim
-    /// and not the state the mint granted: the permission write is skipped entirely when EnableAuthorization
-    /// is off, and the break-glass administrator is never demoted by it. The name beside it is the account's,
-    /// so the two halves of this line have different provenance - see #1554.
+    /// <param name="grantedAdmin">
+    /// Whether the minted session's account HOLDS administrator rights, read from the host's own
+    /// authentication result after the permission write. Reporting the mapping here instead failed in both
+    /// directions, and the second is what settled #1554: <c>admin=True</c> for a session the mint never made
+    /// an administrator is a false alarm, while the break-glass administrator - which the minter is forbidden
+    /// to demote - signing in where no role maps to admin printed <c>admin=False</c> for a session that held
+    /// administrator rights, and under-reporting real administrator access is the failure an audit trail is
+    /// bought to prevent. Null where there was no result to read; see the shape note in the body.
+    /// </param>
+    /// <param name="mappedAdmin">
+    /// Whether a role this login carried is on the configured <c>AdminRoles</c> allow-list. Evidence about
+    /// the provider read through this server's own mapping rather than a state this server reached, so it is
+    /// named in the line only where it disagrees with <paramref name="grantedAdmin"/>.
     /// </param>
     /// <param name="presentedUsername">
     /// The username the identity provider presented on this login. Named in the line only where it differs
     /// from <paramref name="username"/>; null suppresses the comparison entirely.
     /// </param>
-    internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool isAdmin, string? presentedUsername = null)
+    internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool? grantedAdmin, bool mappedAdmin, string? presentedUsername = null)
     {
         if (!logger.IsEnabled(LogLevel.Information))
         {
             return;
         }
+
+        // The outcome is rendered through ONE field whose absent state is a word of its own. True and False
+        // are byte-for-byte what this field has always printed, so nothing keyed on the RENDERED line moves;
+        // carrying the absent case as a third optional clause instead would have doubled the templates below
+        // from four to eight for a state that says less than the word does.
+        //
+        // WHAT DOES MOVE IS THE STRUCTURED FIELD, and it is stated rather than left to be discovered. A JSON
+        // or Serilog sink received {IsAdmin} as a Boolean and now receives a String, so an operator rule
+        // written as IsAdmin == true stops matching - silently, in the same under-reporting direction this
+        // change exists to close. It is disclosed in the changelog for that reason. The alternative keeps the
+        // Boolean by giving the absent state two templates of its own, which is six for a state that
+        // Jellyfin's own AuthenticateDirect cannot produce (see GrantedAdmin in LoginCompletionService), and
+        // the shape was decided on #1554 before the first template was written.
+        var granted = grantedAdmin switch
+        {
+            true => "True",
+            false => "False",
+            _ => "unknown",
+        };
+
+        // The mapped value is named only where it does not agree with the outcome, so the common line stays
+        // short and a divergence is the thing that catches the eye. A lifted comparison, DELIBERATELY: an
+        // absent outcome agrees with nothing, so a line that could not read the granted state still names
+        // the mapping rather than carrying no privilege information at all - which would be less than this
+        // line carried before the outcome replaced the mapping in it.
+        //
+        // AND IT IS NAMED AS A MAPPING RATHER THAN AS AN ASSERTION. mappedAdmin is not a claim the provider
+        // made: RolePrivilegeMapper.Evaluate sets it when a role the login carried is on the ADMIN-CONFIGURED
+        // AdminRoles allow-list, which is empty by default - so on a default install it is false however
+        // loudly the provider asserts otherwise, because nothing here ever asked. A clause reading "the
+        // provider asserted admin=False" would put a denial in the provider's mouth on every administrator's
+        // login, which is the kind of sentence this file refuses to write elsewhere.
+        var mappingDisagrees = grantedAdmin != mappedAdmin;
+
+        // Two independent optional clauses, so four whole templates rather than a composed sentence. The
+        // constant is not decoration: it is what keeps the structured field names stable for a log reader,
+        // and it is what the log-forging rules are written against, so every foreign value below is still
+        // sanitized inline at its own logging call.
+        var namesDiffer = presentedUsername is not null
+            && !string.Equals(
+                presentedUsername.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                StringComparison.Ordinal);
 
         // The decision is taken on the values AS THEY WILL BE PRINTED, never on the raw ones. Both names are
         // stripped of line endings on the way into the line, so a provider presenting "alice\r\n" against the
@@ -98,19 +151,40 @@ internal static class SsoAudit
         // clause reports the absence of decides on the same basis - CanonicalLinkService compares the
         // account name against the sanitized presented name with StringComparison.Ordinal - so a case-folding
         // comparison here would stay silent about a difference the rename path would act on.
-        if (presentedUsername is not null
-            && !string.Equals(
-                presentedUsername.ReplaceLineEndings(string.Empty).Replace('[', '('),
+        if (namesDiffer && mappingDisagrees)
+        {
+            logger.LogInformation(
+                "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}', and its roles mapped to admin={MappedAdmin}.",
                 username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
-                StringComparison.Ordinal))
+                protocol,
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                granted,
+                presentedUsername!.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                mappedAdmin);
+            return;
+        }
+
+        if (namesDiffer)
         {
             logger.LogInformation(
                 "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider presented the name '{PresentedUsername}'.",
                 username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
                 protocol,
                 provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
-                isAdmin,
-                presentedUsername.ReplaceLineEndings(string.Empty).Replace('[', '('));
+                granted,
+                presentedUsername!.ReplaceLineEndings(string.Empty).Replace('[', '('));
+            return;
+        }
+
+        if (mappingDisagrees)
+        {
+            logger.LogInformation(
+                "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}). The provider's roles mapped to admin={MappedAdmin}.",
+                username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                protocol,
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+                granted,
+                mappedAdmin);
             return;
         }
 
@@ -119,7 +193,7 @@ internal static class SsoAudit
             username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
             provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
-            isAdmin);
+            granted);
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -195,8 +195,21 @@ internal sealed class LoginCompletionService
         // account was provisioned through Jellyfin's name allowlist, or a requested rename was declined. The
         // fallback is reached only when the host returned no usable name; the line then names what it always
         // named, and an audit line is never worth throwing a completed login away for.
+        // #1554: the PRIVILEGE field is read off the same result for the same reason the name is, and the two
+        // arms it closes are the ones the MINT decides on its own - the whole permission block is behind
+        // EnableAuthorization, which is off by default, and the break-glass administrator is never demoted.
+        // identity.Admin is passed beside the outcome as what it is, the role mapping's verdict, and is named
+        // only where the two disagree. Both are named arguments: they are adjacent booleans of opposite
+        // meaning, and transposing them would invert exactly what this issue fixed.
         var mintedUsername = MintedUsername(authenticationResult, identity);
-        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, mintedUsername, identity.Admin, identity.Username);
+        SsoAudit.LoginSucceeded(
+            _logger,
+            identity.AuditProtocol,
+            identity.Provider,
+            mintedUsername,
+            grantedAdmin: GrantedAdmin(authenticationResult),
+            mappedAdmin: identity.Admin,
+            presentedUsername: identity.Username);
 
         // #1139: counted beside the audit line rather than at a new hook point, so the counter and the trail
         // cannot come apart. Here rather than in the status mapper because a success reaches the mapper too,
@@ -330,4 +343,18 @@ internal sealed class LoginCompletionService
     // name does not mean a missing event - it means the correlation cannot be made from this end.
     private static string MintedUsername(AuthenticationResult? authenticationResult, VerifiedIdentity identity)
         => string.IsNullOrEmpty(authenticationResult?.User?.Name) ? identity.Username : authenticationResult.User.Name;
+
+    // The administrator right the mint GRANTED (#1554), read off the same result and for the same reason as
+    // the name above: the host builds that user from the account as it stands after the permission write, so
+    // this is the state it published rather than a second reading of the account that could disagree with it.
+    //
+    // ABSENT AND THE FALLBACK ABOVE ARE ONE PRECONDITION, not two. A UserDto carries a UserPolicy whether or
+    // not one was assigned - measured, in the row that had to stop using `new UserDto { Name = "alice" }` to
+    // reach the absent arm - so the only way through the ?. chain is a result with no User at all, which is
+    // the same condition MintedUsername falls back on. Jellyfin's AuthenticateDirect always sets one, so the
+    // word this prints is what an unexpected host answer reads as rather than a state a login produces.
+    // Guessing false instead would report such a login as a non-administrator one, which is the
+    // under-reporting direction this issue exists to remove.
+    private static bool? GrantedAdmin(AuthenticationResult? authenticationResult)
+        => authenticationResult?.User?.Policy?.IsAdministrator;
 }

--- a/docs/THREAT-MODEL-TRUSTED-HEADER.md
+++ b/docs/THREAT-MODEL-TRUSTED-HEADER.md
@@ -203,16 +203,20 @@ What the plugin can do: record the header path under its own protocol label in
 the audit trail rather than folding it into the two existing ones, and record the
 peer address the login was accepted from, which is the only piece of evidence
 that exists. Today the success record carries the username, the protocol, the
-provider and whether administrator rights were granted, and no address. The
-quotation below is pinned to `origin/main`, which is where it was taken; on the
-`4.4` line the username field became the RESOLVED Jellyfin account rather than
-the name the provider presented, with the presented name appended where the two
-differ (#1551), and every foreign value the audit emitter prints has its
-opening square bracket substituted as well as its line endings stripped, so an
-audit line cannot be made to carry a second forged record (#1555 - which is the
-emitter alone; the same text is still plantable through ordinary plugin log
-lines, #1557). None of those changes adds an address, so nothing in this section
-moves.
+provider and an administrator field, and no address. The quotation below is
+pinned to `origin/main`, which is where it was taken; on the `4.4` line the
+username field became the RESOLVED Jellyfin account rather than the name the
+provider presented, with the presented name appended where the two differ
+(#1551), the administrator field became the right the session was actually
+GRANTED rather than the verdict of matching the login's roles against the
+configured `AdminRoles` list, with that verdict appended where the two disagree
+(#1554 - on `origin/main` the field is still that verdict, which is why the
+sentence above names an administrator field rather than a grant), and every
+foreign value the audit emitter prints has its opening square bracket
+substituted as well as its line endings stripped, so an audit line cannot be
+made to carry a second forged record (#1555 - which is the emitter alone; the
+same text is still plantable through ordinary plugin log lines, #1557). None of
+those changes adds an address, so nothing in this section moves.
 
 ```
 $ git show origin/main:SSO-Auth/Api/Audit/SsoAudit.cs | sed -n '35,41p'


### PR DESCRIPTION
# What & why

The `[SSO Audit] Login succeeded` line's `admin=` field printed `identity.Admin` - the verdict of matching the login's roles against the configured `AdminRoles` list - and the session mint does not always agree with it. The whole permission block sits behind `EnableAuthorization`, which is off by default, so `admin=True` could be printed for a session that was never made an administrator; and the break-glass administrator is deliberately never demoted, so that account signing in where no role maps to admin was printed as `admin=False` while holding an administrator session. The first is a false alarm; the second is a **missed** one, and a trail that under-reports real administrator access is the failure an audit trail is bought to prevent.

The field now carries `authenticationResult.User.Policy.IsAdministrator`, read through a `GrantedAdmin` helper beside `MintedUsername` and for the same reason as #1551 read the name there: the host builds that user from the account as it stands after the permission write and publishes the same instance in its own `AuthenticationSuccess` event, so the two records cannot drift. The role mapping's verdict is kept and appended only where it disagrees with the outcome, which makes four literal templates out of two - the constant is what keeps the structured field names stable and what the log-forging rules are written against, so every foreign value stays sanitized inline at its own logging call.

This is the first of the three postures the issue's Done-when offered, decided on the issue on 2026-09-09.

Closes #1554

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: nothing about whether a session is minted moved. `GrantedAdmin` is null-conditional throughout, so no audit line can turn a completed login into a 500; a result, a user or a policy the host did not fill in yields absent rather than a guessed boolean, and an absent outcome agrees with nothing, so the lifted comparison forces the mapping clause open and the line never carries no privilege information at all.
- [x] No secrets logged; no new value of any kind reaches the log. The two added arguments are a three-literal local and a `bool`.
- [x] A security review was performed. Four refute-by-default lenses over the full changed files and their callers.
- [x] Review record, **CONFIRMED 3 / PLAUSIBLE 1** as raised:
  - **correctness** - NEEDS_IMPROVEMENT. Refuted nothing about the logic: template/argument alignment checked one by one, no new throw path, and the read is genuinely post-write (`SessionMinter` `SetPermission` then awaited `UpdateUserAsync` then `AuthenticateDirect`). Three findings. **CONFIRMED, FIXED:** the clause read "The provider asserted admin=False", and `identity.Admin` is not the provider's assertion - `RolePrivilegeMapper.Evaluate` sets it from the **admin-configured** `AdminRoles` allow-list, which is empty by default, so on a default install that wording would have put a denial in a third party's mouth on every administrator's login. It reads `The provider's roles mapped to admin=<value>` now, the parameter is `mappedAdmin`, and the structured field is `{MappedAdmin}`. **CONFIRMED, FIXED:** two production comments described an absent arm reachable through an unfilled policy, and a `UserDto` always carries a `UserPolicy` - measured, in the row that had to stop using `new UserDto { Name = "alice" }` to reach that arm - so the only way in is a result with no user, the same condition `MintedUsername` falls back on; both comments now say so. **CONFIRMED, FIXED:** no changelog entry.
  - **bypass** - PASS. Could not refute the security posture: all four templates carry both inline sanitizers on every foreign value, the `[SSO Audit]` marker stays unforgeable (pinned by `CountMarkers(message) == 1` in the both-clauses row), the two conformance rules in `ArchitectureConformanceTests.AuditSanitizers.cs` still bite on the new lines, and the clause gate fails open rather than closed. One finding, LOW: the structured `{IsAdmin}` field changes from Boolean to String. **FIXED as a disclosure** - see Notes.
  - **architecture** - NEEDS_IMPROVEMENT. Judged the four-template shape justified after costing two smaller ones, and `GrantedAdmin` worth its place. Findings **FIXED**: named arguments at the call site (two adjacent booleans of opposite meaning), the 2x2 flattened by hoisting `namesDiffer`, a misplaced comment paragraph moved, and roughly fourteen lines of quadruple-stated prose cut. Its `{IsAdmin}` finding is the same one as bypass's.
  - **availability** - not run, and disclosed as not run rather than reported as clean. Nothing here can disable, demote or lock an account: `SessionParameters.IsAdmin` is untouched and no permission write moved.
  - **PLAUSIBLE, DEFERRED:** the load-bearing host assumption - that `AuthenticateDirect` always returns a `User` with a populated `Policy` - is not pinned by anything in this repository, and Jellyfin's server assemblies are not available here to verify it directly. The indirect evidence is `test/e2e/harness/harness.sh`, which already reads `.Policy.IsAdministrator` off a live `GET /Users/Me` and asserts it true, and `AuthenticateDirect` builds its user through the same `GetUserDto`. Pinning it on the auth response the harness already holds is a separate change on a file this branch does not touch.
- [x] Log inputs from the IdP are sanitized inline at the log call - all four templates, on every foreign value, spelled out in the argument list.

## Quality checklist

- [x] No duplicated logic; `GrantedAdmin` is a one-expression helper beside its twin.
- [x] The change adds no more code than the problem requires. The four templates are two independent optional clauses, and both cheaper shapes were costed and rejected in review.
- [x] Comments explain why, not what; the duplicated prose the architecture lens found was cut.
- [x] Architecture-conformance tests pass. This establishes no new structural property - the sanitizer rules already own this file, and they were re-checked against the new lines.
- [x] Docs impact: `docs/THREAT-MODEL-TRUSTED-HEADER.md` enumerated the `4.4`-line deltas to this exact line and now names this one; its description of the field is corrected in both directions, since the pasted quotation is pinned to `origin/main` where the field is still the mapping. No README or wiki page describes this field.

## Verification

- [x] Build green with `--warnaserror`, 0 warnings, on both target frameworks (`net9.0`, `net10.0`).
- [x] Suite green on both: 3833 passed on `net9.0`, 3834 on `net10.0`, 0 failed. Four tests skip on this machine and the skip is disclosed rather than worked around - they bind a listener off loopback, which raises a Windows firewall consent dialog needing an administrator (#1227).
- [x] Prettier clean for the two `.md` files. Checked against their content as git stores it: the working tree here is CRLF and Prettier's default `endOfLine` is `lf`, so a direct run flags 46 files it also flags at the merge base. `tr -d '\r' < CHANGELOG.md` and the same for the threat model both pass, as does `git show HEAD:CHANGELOG.md`.

Guards proven by deletion, against the merged shape rather than an earlier one. Reporting the mapping in the field again reddens 7 rows; suppressing the clause reddens 7; guessing the absent state as `False` reddens 2; an unconditional clause reddens the 3 near-miss rows that exist for it.

## Notes

**A structured log sink sees a type change.** `{IsAdmin}` was a Boolean and is now a String - `True`, `False`, or `unknown` where there was no result to read - because one field carrying a three-valued outcome cannot stay a boolean. The rendered text of `admin=True` and `admin=False` is byte-for-byte what it always was, so nothing keyed on the line moves, but a rule written as `IsAdmin == true` against a JSON or Serilog sink stops matching. That is stated in the changelog and in the code, because the alternative - keeping the Boolean by giving the absent state two templates of its own - is six templates for a state Jellyfin's own `AuthenticateDirect` cannot produce, and the four-template shape was decided on the issue before the first template was written.

**No second reader.** There is one person on this account, so nothing here was read by a second party; the review above is four adversarial lenses run against the diff, and it stands in place of one rather than being one.
