### PR TITLE
Cut the nightly JF12 beta from the 5.0 line, not the frozen main [#1585]

### DIFF
--- a/.github/workflows/nightly-betas.yml
+++ b/.github/workflows/nightly-betas.yml
@@ -1,10 +1,19 @@
 name: Nightly betas
 
 # Publish betas on a daily cadence instead of on every push (#632). GitHub `schedule` events only run
-# a workflow from the DEFAULT branch, so this single scheduler lives on main and dispatches both beta
-# legs: publish-beta.yml (JF10.11) and publish-jf12-beta.yml (JF12) - both from main since #954
-# consolidated the JF12/5.0 line onto the one multi-target codebase (the 4.2 branch is retired).
-# Each dispatched workflow has its own gate job that skips the build unless main has advanced since
+# a workflow from the DEFAULT branch, so this single scheduler lives on the default branch and
+# dispatches both beta legs: publish-beta.yml (JF10.11) and publish-jf12-beta.yml (JF12).
+#
+# THE TWO LEGS TAKE DIFFERENT REFS, and that is the whole point of this file (#1585). `main` is frozen
+# on the 4.3 stable candidate for its soak, and 4.3 is the LAST release for Jellyfin 10.11 - so the
+# JF10.11 leg keeps building from `main`, which is exactly the artifact the soak is about. The JF12
+# leg does not: the 5.0 line is developed here, and while this leg pointed at the frozen `main` it
+# published the same code every night with a rising build number while the work sat unreleased.
+#
+# So the JF12 ref is the DEVELOPMENT branch and the JF10.11 ref is `main`. If the development branch
+# is ever renamed, this line is the one that has to follow it, and nothing else here does.
+#
+# Each dispatched workflow has its own gate job that skips the build unless its ref has advanced since
 # that lineage's last beta, so an unchanged day mints nothing.
 on:
   schedule:
@@ -29,17 +38,23 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Trigger the JF10.11 beta (main)
+      - name: Trigger the JF10.11 beta (the frozen 4.3 candidate on main)
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: gh workflow run publish-beta.yml --repo "$REPO" --ref main
-      - name: Trigger the JF12 beta (main)
+      - name: Trigger the JF12 beta (the 5.0 development branch)
         # Dispatch the JF12 leg even if the JF10.11 dispatch above failed, so one API hiccup cannot
         # silently take out both generations' nightly build. The job still fails if either dispatch
         # failed, and "Publish failure alert" watches this workflow, so the failure is surfaced (#982).
+        #
+        # The ref is the development branch rather than `main`, for the reason in the header. The
+        # first run after this lands publishes: that leg's gate compares its ref's HEAD to the commit
+        # the newest 5.0.0-JF12-beta tag points at, they differ, and the gate's fail-open default is
+        # to build. That is the same shape as the #954 move off the 4.2 branch, which its own comment
+        # records.
         if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref main
+        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref 4.4

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -2,8 +2,10 @@ name: Publish JF12 Beta
 
 # The Jellyfin 12.0 (.NET 10) BETA channel - the 5.0 line (#135). Jellyfin 12.0 moves the server to
 # .NET 10 and a 10.11-ABI plugin will not load there, so upgraders need a 12-targeted build. Since
-# #954 the one multi-target codebase (net9.0;net10.0) lives on `main` and BOTH betas publish from it:
-# this leg builds the net10 target and publishes an installable prerelease into the SHARED
+# #954 put both generations on ONE multi-target codebase (net9.0;net10.0). Since #1585 the two legs
+# publish from DIFFERENT refs of it: the JF10.11 leg from `main`, frozen on the 4.3 candidate for its
+# soak, and this leg from the 5.0 development branch. This leg builds the net10 target and publishes
+# an installable prerelease into the SHARED
 # `manifest-beta` branch. Jellyfin filters plugin versions client-side by targetAbi, so one beta
 # manifest carries BOTH generations (4.x at targetAbi 10.11, 5.0 at 12.0) and each server installs only
 # its compatible build - no separate JF12 manifest is needed. (The JF10.11 beta is published by
@@ -14,7 +16,8 @@ name: Publish JF12 Beta
 # committed build.yaml stays the JF10.11 metadata.
 # No push trigger: a beta is no longer minted on every merge (that spammed one release per PR).
 # nightly-betas.yml (the scheduler on the default branch) dispatches this workflow once a day; the gate
-# job below then skips the build unless main has advanced since the last JF12 beta. Still manually
+# job below then skips the build unless the dispatched ref has advanced since the last JF12 beta.
+# Still manually
 # runnable via workflow_dispatch.
 on:
   workflow_dispatch:
@@ -32,21 +35,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Publish only when main has advanced since the last JF12 beta, so a scheduled daily run on an
-  # unchanged branch does not mint a duplicate release. Compares the current main HEAD (github.sha) to
+  # Publish only when the dispatched ref has advanced since the last JF12 beta, so a scheduled daily
+  # run on an unchanged branch does not mint a duplicate release. Since #1585 that ref is the 5.0
+  # development branch rather than `main`, which is frozen on the 4.3 candidate; the comparison is
+  # written against whatever ref dispatched this run. Compares the current ref HEAD (github.sha) to
   # the commit the newest 5.0.0-JF12-beta.<n> tag points at. If the base version is ever bumped (the
   # JF12 line is 5.0 for now) no tag matches, last_sha is empty, and the build proceeds - the safe
   # default is to publish, never to silently skip a real change. (The first run after #954 moved this
-  # leg from the retired 4.2 branch always builds: the last tag points at a 4.2 commit, not main HEAD.)
+  # leg from the retired 4.2 branch always builds: the last tag points at a 4.2 commit, not this
+  # ref's HEAD. #1585 moved it again, off the frozen `main`, and it built for the same reason.)
   gate:
-    name: Gate on new main commits
+    name: Gate on new commits in the dispatched ref
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
-    - name: Compare main HEAD to the last JF12 beta
+    - name: Compare the dispatched ref HEAD to the last JF12 beta
       id: check
       env:
         GH_TOKEN: ${{ github.token }}
@@ -69,7 +75,7 @@ jobs:
         if [ -n "$last_tag" ]; then
           last_sha=$(gh api "repos/${REPO}/git/refs/tags/${last_tag}" --jq '.object.sha' 2>/dev/null || echo "")
         fi
-        echo "current main HEAD: ${CUR}"
+        echo "current ref HEAD: ${CUR}"
         echo "last JF12 beta:   ${last_tag:-<none>} -> ${last_sha:-<none>}"
         if [ -n "$last_sha" ] && [ "$last_sha" = "$CUR" ]; then
           echo "No new commits since the last JF12 beta; skipping the build."
@@ -103,7 +109,7 @@ jobs:
   # the residual it leaves rather than as one it closed.
   #
   # AHEAD of the build job, so a red stack stops the publish instead of documenting it afterwards, and
-  # gated on the same output as the build, so an unchanged main still costs nothing.
+  # gated on the same output as the build, so an unchanged ref still costs nothing.
   provider-matrix:
     name: Provider matrix (net10.0 into a Jellyfin 12 server)
     needs: gate


### PR DESCRIPTION
# What & why

Both nightly beta legs dispatched against `main`, which is frozen on the 4.3
stable candidate for its soak. So the JF12 leg published that frozen commit
every night with a rising build number while the 5.0 line's work sat unreleased.
Closes #1585.

The releases show it plainly: `5.0.0-JF12-beta.73`, `.74` and `.75` on three
consecutive days all point at `cfee8680`, 100 commits behind the development
branch.

**The JF10.11 leg keeps its ref, and that is the point rather than an
oversight.** 4.3 is the last release for Jellyfin 10.11 and the artifact its
soak is about is exactly what `main` builds. The two legs want different refs.

```
publish-beta.yml      (JF10.11)  --ref main   unchanged
publish-jf12-beta.yml (JF12)     --ref main -> --ref 4.4
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

No plugin code changed. This changes which commit a nightly prerelease is cut
from, and corrects comments.

- [x] Fail-closed preserved: the gate's fail-open-to-publish default is
      untouched, and it is deliberate there for the reason its own comment
      gives: skipping a real change is worse than an occasional duplicate beta.
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run. Release plumbing rather than
      the login path or crypto, and it publishes into the existing prerelease
      channel with no change to what is signed or checksummed.
- [x] Review record: no lens gate applies.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: no logic. One `--ref` value.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the header now says WHY the two legs take different
      refs, so the next reader does not restore the symmetry and silently
      re-freeze the 5.0 line.
- [x] Architecture-conformance tests pass: unaffected, no code changed.
- [x] Docs impact: the comments in both workflows are corrected in this pull
      request. Three mentions of `main` in the publish leg were display text
      (a job name, a step name, an `echo`) and now name the dispatched ref; the
      header that said both betas publish from `main` no longer says so.

## Verification

Both files parse:

```
$ python -c "import yaml; yaml.safe_load(open(f))"
YAML gueltig  (nightly-betas.yml, publish-jf12-beta.yml)
```

The publish leg needed no rewiring, which was checked rather than assumed:

```
$ grep -nE "ref:|main|github\.ref" .github/workflows/publish-jf12-beta.yml | grep -v '^\s*[0-9]+:\s*#'
42:    name: Gate on new main commits
49:    - name: Compare main HEAD to the last JF12 beta
72:        echo "current main HEAD: ${CUR}"
```

Three hits, all display text. The gate reads `github.sha`, which is the
dispatched ref's HEAD, so the leg was already ref-agnostic in behaviour.

- [x] `dotnet build --no-restore --warnaserror`: not applicable, no code
      changed. The branch's parent commit built clean.
- [x] `dotnet test`: not applicable for the same reason.
- [x] Prettier: no `.md`, `.js`, `.html` or `.css` change.

## Notes

**The first run after this lands will publish, and that is designed.** The
gate compares the dispatched ref's HEAD to the commit the newest
`5.0.0-JF12-beta` tag points at, finds they differ, and its documented
fail-open default is to build. The leg's own comment records the same shape
from the last time it was moved:

> The first run after #954 moved this leg from the retired 4.2 branch always
> builds: the last tag points at a 4.2 commit, not main HEAD.

**This promotes nothing to `latest`** and does not touch the frozen `main`.

**One coupling to know about.** The ref is a branch NAME. If the development
branch is renamed, this line has to follow it, and the header says so at the
one place that would need editing.
