### PR TITLE
Re-read a settings tab on return, and refuse where work would be lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -735,6 +735,29 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A settings tab returned to now shows what the server holds, instead of what
+  it last loaded (#1576, #1572).** The Jellyfin dashboard keeps three views
+  alive and hands a cached one back without re-running its controller, so a
+  settings tab left and returned to went on showing the configuration as it was
+  when the page was built - a provider added, renamed or deleted from another
+  window, or by a declarative source, was simply not there. Only the Overview
+  tab re-read itself, because it holds no control to overwrite.
+  The other four re-read on every return now, and they refuse to when the page
+  holds work: a re-read is skipped outright while a provider editor is open, and
+  skipped while the page holds anything the last read did not put there - which
+  includes a permission or role-mapping row removed by a click, because the
+  comparison is recomputed from the controls rather than read off a flag
+  something has to set. The same two questions are asked a second time,
+  immediately before anything is written, so an edit made while the
+  configuration was in flight is not overwritten by it; and the library
+  checklists are never rebuilt by a return, which is what would otherwise have
+  persisted an empty Enabled Folders set and cost every user of that provider
+  their library access at the next sign-in. When a return is refused, the page
+  raises its unsaved-changes notice rather than refreshing silently.
+  A media library added while the dashboard has been left open on one of those
+  tabs is not picked up by a return; the checklist is the one the page loaded,
+  until the next save, import, or reload of the dashboard.
+
 - **A failed configuration read no longer leaves a pressed Save with no outcome
   at all (#1577).** Saving or deleting a provider reads the stored configuration
   before it writes, and four of those reads had no failure arm. The two saves

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -16,6 +16,11 @@ function tr(key, englishDefault, params) {
 // this module's bookkeeping and not a fact about the page.
 const pageBaselines = new WeakMap();
 
+// Settles a promise without deciding anything about it. Used where a load has to WAIT for a request
+// whose failure it deliberately does not act on - the checklist fills the baseline waits for, and the
+// configuration read of a refresh, which leaves the page showing what it last read.
+const noop = () => {};
+
 // The Jellyfin account routing that a revoke restores (#1121). The Unregister endpoint PERSISTS
 // whatever the caller sends here onto the account, so a wrong string does not fail the request: it routes
 // that account to core's InvalidAuthenticationProvider, which refuses every password, and nothing on this
@@ -448,7 +453,16 @@ const ssoConfigurationPage = {
   // this function does not have to learn the new arrangement. What it must never become is a load that
   // SKIPS a section the page does have - so each test names the exact control the branch below writes
   // to, not a container that could survive the control being dropped.
-  loadConfiguration: (page) => {
+  //
+  // `options.refreshing` marks the ONE caller that is re-running this against a page an administrator is
+  // already looking at - the return to a tab, #1576 - and it changes two things and nothing else. The
+  // library checklists are not repopulated, because only `loadProvider` ticks them and nothing here would
+  // put the ticks back; and the write is re-gated on the page still being replaceable, because the
+  // decision to refresh was taken before this fetch went out. Every other caller is a save, a delete or
+  // an import that has just changed the stored configuration and is reading it back, and those replace
+  // the page unconditionally as they always have.
+  loadConfiguration: (page, options) => {
+    const refreshing = Boolean(options && options.refreshing);
     // Refreshed with the configuration itself: a provider that stopped being declaratively managed between
     // two loads must not keep a frozen form, and one that started being managed must not keep an open one.
     ssoConfigurationPage.loadManagedProviders();
@@ -456,67 +470,117 @@ const ssoConfigurationPage = {
     // re-asked rather than left standing from the load that found it. It is on every page, because the
     // statement it makes - that the settings in front of you are not this server's - is true of all five.
     ssoConfigurationPage.showUnreadableConfigurationNotice(page);
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
-      (config) => {
-        // The two provider workspaces (Providers). Both or neither: they are one tab.
-        if (page.querySelector("#selectProvider")) {
-          ssoConfigurationPage.populateProviders(page, config.OidConfigs);
-          // Refresh the SAML workspace from the same configuration load (#725), so a SAML save/delete/import
-          // reloads its provider list exactly as the OpenID one does.
-          ssoConfigurationPage.populateSamlProviders(
-            page,
-            config.SamlConfigs || {},
-          );
-        }
-        // The GLOBAL login-page buttons opt-in (#722) rides the same configuration load. It is a root
-        // PluginConfiguration flag, not a provider field, so it has the Server page's save path (saveServerSettings)
-        // and no sso-* marker class. On the Server tab since #1527.
-        const manage_buttons = page.querySelector("#ManageLoginPageButtons");
-        if (manage_buttons) {
-          manage_buttons.checked = Boolean(config.ManageLoginPageButtons);
-          // What this switch was FILLED with, so the save can tell a switch the administrator moved from
-          // one they never touched (#1572). See saveServerSettings for why that distinction is the whole
-          // difference between one Save and one lost update.
-          manage_buttons.dataset.ssoLoaded = String(manage_buttons.checked);
-        }
 
-        // The GLOBAL Single Logout opt-in (#727) rides the same configuration load. Like
-        // ManageLoginPageButtons it is a root PluginConfiguration flag, not a provider field, so it has its
-        // own save path (saveServerSettings, together with the flag above) and no sso-* marker class.
-        const single_logout = page.querySelector("#EnableSingleLogout");
-        if (single_logout) {
-          single_logout.checked = Boolean(config.EnableSingleLogout);
-          single_logout.dataset.ssoLoaded = String(single_logout.checked);
-        }
+    // NOT ON A REFRESH, and this is the guard that keeps a returning tab from costing users their
+    // libraries (#1576). populateFolders rebuilds the checklist from Library/MediaFolders with nothing
+    // ticked; loadProvider is what ticks it, and a refresh does not run loadProvider. Skipping it is
+    // safe because both checklists live inside an editor, a refresh only happens with every editor
+    // closed, and opening one runs loadProvider - which is where the ticks come from either way. What
+    // it costs is a media library added while the dashboard has been left open on this tab: the
+    // checklist is the one this load put there, until the next save, import or reload of the page.
+    //
+    // Issued BEFORE the configuration request rather than after it, because the baseline below waits on
+    // all three and the order they go out in is the order they tend to come back in.
+    const folderFills = [];
+    if (!refreshing) {
+      const folder_container = page.querySelector("#EnabledFolders");
+      if (folder_container) {
+        folderFills.push(
+          ssoConfigurationPage.populateFolders(folder_container),
+        );
+      }
 
-        // The GLOBAL provisioning profile set (#1105) rides the same configuration load, for the
-        // reason the two flags above do: it is a root PluginConfiguration member with its own save
-        // path. Doing it here means every existing save, delete and import route refreshes the
-        // editor and both provider-form selectors without knowing that they exist. Since #1527 the
-        // editor is on Policies and the two provider-form selectors are on Providers, so this runs on
-        // both tabs and fills whichever half is there.
-        ssoConfigurationPage.populateProvisioningProfiles(page, config);
-
-        // The Overview tab reads the same configuration rather than a second endpoint, so what it says
-        // about a provider and what the editor shows for it cannot come apart.
-        ssoConfigurationPage.renderOverviewFrom(page, config);
-
-        // What the page now shows IS the stored configuration, so it is clean (#1572). This is the one
-        // place that has to say so, because every save, delete and import path ends here - and it is
-        // what re-runs the Save gate against the values that were just filled in.
-        ssoConfigurationPage.markPageClean(page);
-      },
-    );
-
-    const folder_container = page.querySelector("#EnabledFolders");
-    if (folder_container) {
-      ssoConfigurationPage.populateFolders(folder_container);
+      // The SAML editor has its own available-folders checklist; populate it too (#725).
+      const saml_folder_container = page.querySelector("#saml-EnabledFolders");
+      if (saml_folder_container) {
+        folderFills.push(
+          ssoConfigurationPage.populateFolders(saml_folder_container),
+        );
+      }
     }
 
-    // The SAML editor has its own available-folders checklist; populate it too (#725).
-    const saml_folder_container = page.querySelector("#saml-EnabledFolders");
-    if (saml_folder_container) {
-      ssoConfigurationPage.populateFolders(saml_folder_container);
+    const load = ApiClient.getPluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+    ).then((config) => {
+      // THE SECOND ASKING, and the whole answer to the check-then-act the review refused (#1576). The
+      // refresh decided to run before this request went out; an administrator can open an editor or
+      // type into a control while it is in flight, and every line below writes a control. So the
+      // question is put again HERE, at the last moment before the first write, and a refresh that has
+      // been overtaken does nothing at all rather than overwriting what arrived.
+      if (refreshing && !ssoConfigurationPage.mayReplacePageContents(page)) {
+        return;
+      }
+      // The two provider workspaces (Providers). Both or neither: they are one tab.
+      if (page.querySelector("#selectProvider")) {
+        ssoConfigurationPage.populateProviders(page, config.OidConfigs);
+        // Refresh the SAML workspace from the same configuration load (#725), so a SAML save/delete/import
+        // reloads its provider list exactly as the OpenID one does.
+        ssoConfigurationPage.populateSamlProviders(
+          page,
+          config.SamlConfigs || {},
+        );
+      }
+      // The GLOBAL login-page buttons opt-in (#722) rides the same configuration load. It is a root
+      // PluginConfiguration flag, not a provider field, so it has the Server page's save path (saveServerSettings)
+      // and no sso-* marker class. On the Server tab since #1527.
+      const manage_buttons = page.querySelector("#ManageLoginPageButtons");
+      if (manage_buttons) {
+        manage_buttons.checked = Boolean(config.ManageLoginPageButtons);
+        // What this switch was FILLED with, so the save can tell a switch the administrator moved from
+        // one they never touched (#1572). See saveServerSettings for why that distinction is the whole
+        // difference between one Save and one lost update.
+        manage_buttons.dataset.ssoLoaded = String(manage_buttons.checked);
+      }
+
+      // The GLOBAL Single Logout opt-in (#727) rides the same configuration load. Like
+      // ManageLoginPageButtons it is a root PluginConfiguration flag, not a provider field, so it has its
+      // own save path (saveServerSettings, together with the flag above) and no sso-* marker class.
+      const single_logout = page.querySelector("#EnableSingleLogout");
+      if (single_logout) {
+        single_logout.checked = Boolean(config.EnableSingleLogout);
+        single_logout.dataset.ssoLoaded = String(single_logout.checked);
+      }
+
+      // The GLOBAL provisioning profile set (#1105) rides the same configuration load, for the
+      // reason the two flags above do: it is a root PluginConfiguration member with its own save
+      // path. Doing it here means every existing save, delete and import route refreshes the
+      // editor and both provider-form selectors without knowing that they exist. Since #1527 the
+      // editor is on Policies and the two provider-form selectors are on Providers, so this runs on
+      // both tabs and fills whichever half is there.
+      ssoConfigurationPage.populateProvisioningProfiles(page, config);
+
+      // The Overview tab reads the same configuration rather than a second endpoint, so what it says
+      // about a provider and what the editor shows for it cannot come apart.
+      ssoConfigurationPage.renderOverviewFrom(page, config);
+
+      // The Save gate is re-run against the values just filled in. The BASELINE is taken below rather
+      // than here, because this is one of the load's three requests and not the whole of it.
+      ssoConfigurationPage.updateSaveAvailability(page);
+
+      // THE BASELINE COVERS THE WHOLE LOAD, AND TAKING IT HERE ALONE WAS A DEFECT THE REVIEW
+      // REPRODUCED AGAINST THE SHIPPED FILE (#1576). A load is three requests: the two checklists are
+      // filled by their own, and each appends one ID-LESS checkbox per media library that
+      // controlSignature counts. Whenever the configuration answered first, the baseline was taken
+      // before those controls existed and nothing corrected it, so the Providers page differed from
+      // its own baseline for the life of the view. Under #1572 that was invisible, because only a user
+      // event consulted the comparison. Under the refresh it decides everything: the tab would have
+      // refused to re-read for good, and would have asserted unsaved changes on a page nobody had
+      // touched - training away the one indicator that says a real edit is about to be lost.
+      //
+      // A rejected checklist read settles here too, so a failed fill cannot leave the page with no
+      // baseline at all - which pageDiffersFromBaseline reads as edited, and which would refuse every
+      // refresh from then on. What that read leaves behind is a checklist with no rows, and what a
+      // save then writes for it is its own defect on a different path; it is #1587 rather than this.
+      return Promise.all(folderFills.map((fill) => fill.then(noop, noop))).then(
+        () => ssoConfigurationPage.markPageClean(page),
+      );
+    });
+
+    // A refresh that could not read the configuration leaves the page showing what it last read, which
+    // is what a failed refresh should leave. Attached ONLY for the refresh: every other caller has just
+    // written something and is reading it back, and its failure is not this function's to swallow.
+    if (refreshing) {
+      load.then(noop, noop);
     }
   },
   populateProviders: (page, providers) => {
@@ -1012,6 +1076,13 @@ const ssoConfigurationPage = {
   // `checked` and everything else from `value`, and the id rides along so a control appearing or
   // disappearing - a permission row, a folder checklist filled from the server - is a difference rather
   // than something two lengths could cancel out.
+  //
+  // SEPARATED, AND THE EMPTY JOIN IT REPLACED WAS A COLLISION (#1576). The rows a page renders from a
+  // server list carry no id, so two of them contribute "=a" and "=b=c" where two others contribute
+  // "=a=b" and "=c" - the same string, a different page. Under #1572 that could only miss an edit; under
+  // the refresh, "the same signature" is the permission to REPLACE what is on the page, so a collision
+  // is a discarded edit rather than an unmarked one. A separator no value can contain removes the class
+  // for one character, which is cheaper than reasoning about which pairs are reachable.
   controlSignature: (page) =>
     ssoConfigurationPage
       .editableControls(page)
@@ -1023,7 +1094,7 @@ const ssoConfigurationPage = {
             ? String(element.checked)
             : String(element.value)),
       )
-      .join(""),
+      .join("\n"),
   isPageDirty: (page) => page.classList.contains("sso-page-dirty"),
   markPageDirty: (page) => {
     page.classList.add("sso-page-dirty");
@@ -1186,6 +1257,76 @@ const ssoConfigurationPage = {
     };
     page.addEventListener("input", observe, true);
     page.addEventListener("change", observe, true);
+  },
+  // ---- The refresh on return to a tab (#1576) ----
+  //
+  // WHAT WAS REFUSED AND WHY IT IS NOT THE DIRTY STATE'S FAULT. #1572 built the state so a clean tab
+  // could re-read the server on `viewshow`, and the review took the re-read out again: the danger was
+  // never in the state, it was in what `loadConfiguration` does when it runs a SECOND time, having been
+  // written to run once at construction while the editors are still hidden. Three ways, and each of the
+  // three has its own guard below rather than one guard credited with all of them.
+  //
+  // ONE. `loadConfiguration` re-populates both library checklists from `Library/MediaFolders` with
+  // nothing ticked, and it does not re-run `loadProvider`, which is what ticks them. A return to
+  // Providers with an editor open therefore emptied the checklist while the editor still showed its
+  // provider, and the next save serialises that checklist unconditionally and persists
+  // `EnabledFolders: []` - after which `SessionMinter` writes that empty set on every login while
+  // `EnableAllFolders` is off, and every user of that provider loses library access at their next
+  // sign-in. That is the worst outcome on this surface and it needed no race and no typing.
+  //
+  // TWO. Removing a permission row or a role-mapping row is a button click: `row.remove()`, no `input`,
+  // no `change`. So the tracking never runs and the page is never MARKED dirty, while holding a real
+  // edit that the Policies re-read would render straight back out of storage.
+  //
+  // THREE. The check was check-then-act: the dirty test ran first and the fill landed at the end of an
+  // asynchronous chain, so an edit made inside that window was overwritten and the page then reported
+  // itself clean.
+  //
+  // THE THREE GUARDS, IN THE ORDER THEY BITE.
+  //
+  //   - An OPEN EDITOR refuses the refresh outright, which is what answers ONE. Nothing is re-read while
+  //     an editor is on screen: not the checklists, not the hidden `#selectProvider` the save path reads
+  //     its target from - `populateProviders` clears that selector's options, and clearing them drops
+  //     its value - and not the profile selectors inside the two provider forms. An open editor is work
+  //     in progress, and the cost of refusing is staleness behind a panel the administrator is looking
+  //     through anyway.
+  //   - The decision reads `pageDiffersFromBaseline`, which recomputes the SIGNATURE from the live
+  //     controls, and NOT `isPageDirty`, which reads a class something has to have set. That is what
+  //     answers TWO without the tracking having to see a click: the signature carries each control's id,
+  //     so a row that is no longer in the page is a difference by construction. The marked state is
+  //     brought into line at the same moment, so the indicator says why the tab did not refresh.
+  //   - The same two questions are asked AGAIN inside the fill, immediately before anything is written,
+  //     which answers THREE: an edit made while the configuration was in flight leaves the fill with
+  //     nothing to do rather than being overwritten by it.
+  //
+  // WHAT THIS SETTLES ABOUT THE INDICATOR'S GRANULARITY, which #1576 asks for as its own condition. The
+  // indicator is page-wide and the Providers page carries two editors, so opening one still clears the
+  // other's state - unchanged, and it does not matter here: the refresh does not depend on the state
+  // being per-editor, because ANY open editor refuses it wholesale. The granularity question is about
+  // what the indicator promises, and it promises the same thing it did before this.
+  editorRegionIds: ["sso-editor", "saml-editor"],
+  anyEditorOpen: (page) =>
+    ssoConfigurationPage.editorRegionIds.some((id) => {
+      const region = page.querySelector("#" + id);
+      return region !== null && region.hidden !== true;
+    }),
+  // Whether the page may have its contents replaced by a fresh read. Asked twice per refresh, before the
+  // fetch and again before the write, because the answer can change in between.
+  mayReplacePageContents: (page) =>
+    !ssoConfigurationPage.anyEditorOpen(page) &&
+    !ssoConfigurationPage.pageDiffersFromBaseline(page),
+  refreshOnShow: (page) => {
+    if (ssoConfigurationPage.anyEditorOpen(page)) {
+      return;
+    }
+    if (ssoConfigurationPage.pageDiffersFromBaseline(page)) {
+      // The tab holds something the last read did not put there - possibly a removed row nothing
+      // dispatched an event for. Say so where it is read, which is the same notice an ordinary edit
+      // raises, and leave the page exactly as the administrator left it.
+      ssoConfigurationPage.markPageDirty(page);
+      return;
+    }
+    ssoConfigurationPage.loadConfiguration(page, { refreshing: true });
   },
   renderSaveStatus: (page, message, ok) => {
     const box = page.querySelector("#sso-save-status");
@@ -4977,27 +5118,23 @@ const ssoConfigurationPage = {
 // page in front of it actually has and skips the rest, so one load path serves five pages.
 
 /**
- * The calls every page with controls makes: the stylesheet, the configuration, the localized labels, and
- * the unsaved-changes tracking.
+ * The calls every page with controls makes: the stylesheet, the configuration, the localized labels, the
+ * unsaved-changes tracking, and the re-read on return to the tab.
  *
- * WHY THERE IS NO RE-READ ON `viewshow` HERE, WHICH #1572 SET OUT TO ADD. The dirty state was built so a
- * tab returned to could re-read the server when it held no unsaved edit. It was built, reviewed, and
- * taken out again, because the review showed the re-read destroys work the dirty state cannot see:
+ * THE RE-READ ON `viewshow` IS HERE NOW (#1576), AND IT IS THE LOAD PATH THAT CHANGED RATHER THAN THE
+ * DIRTY STATE. #1572 built the state for exactly this and the review refused the re-read, because
+ * `loadConfiguration` was written to run once at construction, while the editors are still hidden, and
+ * running it again emptied both library checklists, rendered a removed row back out of storage, and
+ * decided on a dirty test that ran before an asynchronous fill. Each of those three now has its own
+ * guard, and all three live at `refreshOnShow` and in `loadConfiguration`'s `refreshing` arm rather than
+ * being restated here.
  *
- *   - `loadConfiguration` re-populates both library checklists from the server with NOTHING ticked and
- *     does not re-run `loadProvider`, so a clean return to Providers with an editor open empties the
- *     ticks; the next save then persists an empty EnabledFolders and every user of that provider loses
- *     library access at their next sign-in.
- *   - Removing a permission row or a role-mapping row is a button click. It fires no `input` and no
- *     `change`, so the page stays clean while holding a real edit, and the Policies re-read renders the
- *     removed row straight back out of storage.
- *   - The dirty test happens before an asynchronous fill that lands after it, so an edit made inside
- *     that window is overwritten and the page then reports itself clean.
- *
- * None of the three is a defect in the dirty state; all three are what `loadConfiguration` does, which
- * was written to run once, at construction, while the editor is still hidden. Making it safe to run
- * again is its own piece of work and its own issue. What #1572 keeps is the state itself, the indicator
- * and the Save gate - and the fourth done-condition it was asked for is the one deliberately not met.
+ * THE LISTENER IS REGISTERED AFTER THE FIRST LOAD AND NOT INSTEAD OF IT, for the reason `initOverviewPage`
+ * measured: jellyfin-web constructs the controller inside `loadView`'s own chain and dispatches
+ * `viewshow` one microtask after that chain resolves, and this controller is reached through a dynamic
+ * import, so the first `viewshow` is always missed. The init call covers the show that has already
+ * happened; the listener covers every later show of the same cached view, when the controller does not
+ * run at all.
  *
  * @param {Element} view The page element Jellyfin hands the controller.
  */
@@ -5007,6 +5144,9 @@ function initSharedPage(view) {
   ssoConfigurationPage.localize(view);
   ssoConfigurationPage.bindUnsavedChangeTracking(view);
   ssoConfigurationPage.markPageClean(view);
+  view.addEventListener("viewshow", () =>
+    ssoConfigurationPage.refreshOnShow(view),
+  );
 }
 
 // One registration per template-control prefix that this page actually carries, derived from the
@@ -5053,15 +5193,11 @@ function bindTemplatePermissionAdders(view) {
  * not run at all. In the ordering where both fire, the page loads twice, which costs one read of a
  * read-only report and paints the same thing.
  *
- * WHY THE OTHER FOUR DO NOT DO THIS. Re-reading the configuration re-fills form controls, and those four
- * pages hold controls an administrator may have typed into and not yet saved, so a reload on every show
- * would silently discard an edit made before a glance at another tab. Overview has no control at all -
- * none of the page's 123 - so re-reading it can lose nothing. What that leaves is a Providers, Policies
- * or Server tab returned to after a change made elsewhere still showing the older list until it is
- * reloaded. #1572 tried to close that and was refused: re-reading a page with an open editor empties both
- * library checklists without refilling them, and renders a removed permission row back out of storage, so
- * the refresh needs the load path to be safe to run twice rather than the tab to be told to run it. That
- * is #1576, and this paragraph names it rather than a pull request a later reader cannot find.
+ * WHY THIS ONE READS UNCONDITIONALLY AND THE OTHER FOUR ASK FIRST. Re-reading the configuration re-fills
+ * form controls, and those four pages hold controls an administrator may have typed into and not yet
+ * saved. Overview has no control at all - none of the page's 123 - so re-reading it can lose nothing and
+ * it needs no guard. The other four go through `refreshOnShow`, which refuses while an editor is open or
+ * while the page holds anything the last read did not put there (#1576).
  */
 function initOverviewPage(view) {
   ssoConfigurationPage.addTextAreaStyle(view);
@@ -5516,6 +5652,14 @@ function initAccountsPage(view) {
     });
 
   ssoConfigurationPage.loadLinkedAccounts(view);
+
+  // The roster is the one thing on this tab that a change made elsewhere - a revoke, a link import, a
+  // first sign-in - moves, and `loadConfiguration` does not fetch it (#1576). Unconditional, like
+  // Overview's read and for the same reason: it renders a read-only list and writes no control, so a
+  // re-read here can discard nothing. `refreshOnShow` still runs beside it from initSharedPage.
+  view.addEventListener("viewshow", () =>
+    ssoConfigurationPage.loadLinkedAccounts(view),
+  );
 }
 
 /** The Policies tab: the named provisioning-profile editor. */

--- a/tools/ui-unsaved-state.js
+++ b/tools/ui-unsaved-state.js
@@ -58,6 +58,7 @@ const root = path.resolve(__dirname, "..");
 const CORE = path.join(root, "SSO-Auth", "Web", "sso-core.js");
 const SERVER_PAGE = path.join(root, "SSO-Auth", "Web", "serverPage.html");
 const POLICIES_PAGE = path.join(root, "SSO-Auth", "Web", "policiesPage.html");
+const PROVIDERS_PAGE = path.join(root, "SSO-Auth", "Web", "providersPage.html");
 
 /** Replaces every HTML comment with spaces, so a documented control is not a real one. */
 function withoutComments(html) {
@@ -164,6 +165,21 @@ function policiesPageFixture() {
   return pageFixture(POLICIES_PAGE, ["sso-unsaved", "SaveProvisioningProfile"]);
 }
 
+/**
+ * The Providers page, which is the only one that carries an editor - two of them - and the two library
+ * checklists a re-read used to empty (#1576). The regions are asserted against the markup like every
+ * other fixture's, so a renamed editor or checklist container fails here rather than passing silently.
+ */
+function providersPageFixture() {
+  return pageFixture(PROVIDERS_PAGE, [
+    "sso-unsaved",
+    "sso-editor",
+    "saml-editor",
+    "EnabledFolders",
+    "saml-EnabledFolders",
+  ]);
+}
+
 function pageFixture(file, regionIds) {
   const html = withoutComments(fs.readFileSync(file, "utf8"));
   const controls = [
@@ -192,6 +208,20 @@ function pageFixture(file, regionIds) {
           ", so the state would render into nothing",
       );
     }
+  });
+
+  // The editors ship `hidden` in the markup, and a fixture that started them open would make the
+  // refresh refuse for a reason the arm did not set up. Read off the tag rather than assumed, so a
+  // region that stops shipping hidden fails an arm here instead of quietly changing what it proves.
+  regions.forEach((region) => {
+    // Read by cutting the tag out around the id rather than by matching one, because an opening tag in
+    // this markup runs over several lines and a pattern for it is a second thing to get wrong.
+    const at = html.indexOf('id="' + region.id + '"');
+    const tag =
+      at === -1
+        ? ""
+        : html.slice(html.lastIndexOf("<", at), html.indexOf(">", at) + 1);
+    region.hidden = tag.split(/[\s>]+/).includes("hidden");
   });
 
   return new Page([...controls, ...regions]);
@@ -489,6 +519,332 @@ async function main() {
     }
   }
 
+  // ---- The refresh on return to a tab (#1576) ----
+  //
+  // WHAT THESE FIVE ARMS CAN AND CANNOT SAY. The subject is the DECISION - whether the refresh runs at
+  // all, and whether the fill it triggers writes anything - so the fills themselves are substituted and
+  // counted rather than executed. That is the honest bound: an arm below reddens when a guard is taken
+  // off, and none of them says the fills are correct, which is what every other route over this file
+  // already asks. The configuration fetch is substituted for the same reason, and because the stub is
+  // node and `ApiClient` is the dashboard's.
+  //
+  // The order is the issue's: the library-checklist case first, because it is the one that costs users
+  // their libraries.
+  const refreshHarness = (page) => {
+    const original = {
+      loadManagedProviders: core.loadManagedProviders,
+      showUnreadableConfigurationNotice: core.showUnreadableConfigurationNotice,
+      populateProviders: core.populateProviders,
+      populateSamlProviders: core.populateSamlProviders,
+      populateProvisioningProfiles: core.populateProvisioningProfiles,
+      renderOverviewFrom: core.renderOverviewFrom,
+      populateFolders: core.populateFolders,
+      apiClient: globalThis.ApiClient,
+    };
+    const seen = { folders: 0, fills: 0 };
+    let settle = null;
+    core.loadManagedProviders = () => {};
+    core.showUnreadableConfigurationNotice = () => Promise.resolve();
+    core.populateProviders = () => {};
+    core.populateSamlProviders = () => {};
+    // The checklist fill is a REQUEST OF ITS OWN and it appends id-less checkboxes the signature counts,
+    // so the substitute has to do both of those things or the arms cannot see the ordering that broke
+    // the baseline. It settles when the arm says so, not when it is called.
+    let releaseFolders = null;
+    core.populateFolders = (container) => {
+      seen.folders += 1;
+      return new Promise((resolve) => {
+        const previous = releaseFolders;
+        releaseFolders = () => {
+          if (previous) {
+            previous();
+          }
+          const box = new Element("input", "", "checkbox");
+          page.elements.push(box);
+          container.appended = (container.appended || 0) + 1;
+          resolve();
+        };
+      });
+    };
+    // The fill counter is on the ONE call the `.then` makes unconditionally. Counting on
+    // populateProviders instead reads zero on the Server page, which has no #selectProvider - so the
+    // in-flight arm's first assertion would have been vacuous there.
+    core.populateProvisioningProfiles = () => {
+      seen.fills += 1;
+    };
+    core.renderOverviewFrom = () => {};
+    globalThis.ApiClient = {
+      getUrl: (u) => u,
+      getJSON: () => Promise.resolve({}),
+      getPluginConfiguration: () =>
+        new Promise((resolve) => {
+          settle = () => resolve({ OidConfigs: {}, SamlConfigs: {} });
+        }),
+    };
+    // Enough turns to drain the chain the load builds: the configuration `.then`, the Promise.all over
+    // the checklist fills, and the `.then` that takes the baseline. Counted generously rather than
+    // exactly, because an arm that under-drains passes by not looking.
+    const drain = async () => {
+      for (let turn = 0; turn < 12; turn += 1) {
+        await Promise.resolve();
+      }
+    };
+    return {
+      seen,
+      drain,
+      // Answers the CONFIGURATION request. The checklist fills stay outstanding, which is the ordering
+      // that broke the baseline and the one an arm has to be able to produce.
+      deliver: async () => {
+        settle();
+        await drain();
+      },
+      // Answers the checklist fills, appending their controls, after the configuration has landed.
+      deliverFolders: async () => {
+        if (releaseFolders) {
+          releaseFolders();
+          releaseFolders = null;
+        }
+        await drain();
+      },
+      restore: () => {
+        Object.keys(original).forEach((key) => {
+          if (key !== "apiClient") {
+            core[key] = original[key];
+          }
+        });
+        globalThis.ApiClient = original.apiClient;
+      },
+      page,
+    };
+  };
+
+  // ---- Arm: the library checklists are not rebuilt by a refresh ----
+  {
+    const page = providersPageFixture();
+    wire(core, page);
+    const h = refreshHarness(page);
+    core.loadConfiguration(page, { refreshing: true });
+    await h.deliver();
+    if (h.seen.folders !== 0) {
+      refuse(
+        "refresh-folders",
+        "a refresh repopulated a library checklist, which rebuilds it with nothing ticked and does not run loadProvider - the next save then persists an empty EnabledFolders and every user of that provider loses library access",
+      );
+    }
+    // The near-miss: an ordinary load - a save, a delete, an import reading itself back - must still
+    // fill them. A guard that skipped the checklists for every caller would pass the arm above.
+    core.loadConfiguration(page);
+    await h.deliver();
+    h.restore();
+    if (h.seen.folders === 0) {
+      refuse(
+        "refresh-folders",
+        "an ordinary load stopped filling the library checklists, so an editor opened after a save shows none",
+      );
+    }
+  }
+
+  // ---- Arm: the baseline covers the checklist fills, not just the configuration ----
+  {
+    // The ordering that broke this, reproduced: a load is THREE requests, and the configuration answers
+    // before the two checklist reads. Each of those appends id-less checkboxes the signature counts, so
+    // a baseline taken in the configuration `.then` alone left the Providers page differing from its own
+    // baseline for the life of the view - the refresh then refused forever AND the page asserted unsaved
+    // changes on a tab nobody had touched, which is the indicator that says a real edit is at risk.
+    const page = providersPageFixture();
+    wire(core, page);
+    const h = refreshHarness(page);
+    core.loadConfiguration(page);
+    await h.deliver();
+    if (h.seen.folders !== 2) {
+      refuse(
+        "refresh-baseline",
+        "the fixture issued no checklist fill, so this arm cannot produce the ordering it is about",
+      );
+    }
+    await h.deliverFolders();
+    const differs = core.pageDiffersFromBaseline(page);
+
+    const loads = [];
+    const real = core.loadConfiguration;
+    core.loadConfiguration = (_, options) => loads.push(options);
+    core.refreshOnShow(page);
+    core.loadConfiguration = real;
+    h.restore();
+
+    if (differs) {
+      refuse(
+        "refresh-baseline",
+        "a page nobody touched differed from its own baseline once the library checklists landed, so the baseline does not cover the whole load",
+      );
+    }
+    if (loads.length !== 1) {
+      refuse(
+        "refresh-baseline",
+        "the tab refused to re-read on a page nobody had touched, so the refresh never runs on Providers at all",
+      );
+    }
+    if (core.isPageDirty(page)) {
+      refuse(
+        "refresh-baseline",
+        "the page asserted unsaved changes with nothing typed and no editor open, which trains away the indicator that says a real edit is at risk",
+      );
+    }
+  }
+
+  // ---- Arm: an open editor refuses the refresh outright ----
+  {
+    const page = providersPageFixture();
+    wire(core, page);
+    const editor = page.querySelector("#sso-editor");
+    if (editor.hidden !== true) {
+      refuse(
+        "refresh-editor",
+        "the fixture starts with the editor open, so this arm proves nothing",
+      );
+    }
+    const loads = [];
+    const real = core.loadConfiguration;
+    core.loadConfiguration = (_, options) => loads.push(options);
+
+    editor.hidden = false;
+    core.refreshOnShow(page);
+    if (loads.length !== 0) {
+      refuse(
+        "refresh-editor",
+        "a tab returned to with the editor open re-read the server, which clears the hidden selector the save reads its target from and empties the checklists",
+      );
+    }
+
+    editor.hidden = true;
+    core.refreshOnShow(page);
+    core.loadConfiguration = real;
+    if (loads.length !== 1) {
+      refuse(
+        "refresh-editor",
+        "a clean tab with every editor closed did not re-read, so it goes on showing whatever it last loaded",
+      );
+    }
+  }
+
+  // ---- Arm: a removed row is an unsaved edit, and nothing dispatched an event for it ----
+  {
+    const page = policiesPageFixture();
+    wire(core, page);
+    const notice = page.querySelector("#sso-unsaved");
+    // Removing a permission row is `row.remove()`: no input, no change, so the tracking never runs and
+    // the page is never MARKED dirty. The decision must read the controls, not the mark.
+    // A control the state actually tracks, taken from the page's own list rather than guessed: the first
+    // control on this page is the profile SELECTOR, which is excluded as a navigation control, so
+    // removing that one would change no signature and the arm would prove nothing.
+    const removed = core.editableControls(page)[0];
+    page.elements.splice(page.elements.indexOf(removed), 1);
+    page.byId.delete(removed.id);
+    if (core.isPageDirty(page)) {
+      refuse(
+        "refresh-removed-row",
+        "the fixture was already marked dirty, so this arm cannot tell the mark from the signature",
+      );
+    }
+    const loads = [];
+    const real = core.loadConfiguration;
+    core.loadConfiguration = () => loads.push(1);
+    core.refreshOnShow(page);
+    core.loadConfiguration = real;
+    if (loads.length !== 0) {
+      refuse(
+        "refresh-removed-row",
+        "a page holding a removed row re-read the server, which renders the removed row straight back out of storage",
+      );
+    }
+    if (!core.isPageDirty(page) || notice.hidden) {
+      refuse(
+        "refresh-removed-row",
+        "the tab refused to refresh and said nothing about why",
+      );
+    }
+  }
+
+  // ---- Arm: an edit made while the configuration is in flight is not overwritten ----
+  {
+    const page = serverPageFixture();
+    wire(core, page);
+    const h = refreshHarness(page);
+    const toggle = page.querySelector("#ManageLoginPageButtons");
+
+    core.loadConfiguration(page, { refreshing: true });
+    // The decision has been taken and the request is out. Now an administrator types.
+    toggle.checked = true;
+    page.dispatch("change", toggle, true);
+    await h.deliver();
+    h.restore();
+
+    if (h.seen.fills !== 0) {
+      refuse(
+        "refresh-in-flight",
+        "a refresh overtaken by an edit went on filling the page, which is the check-then-act the review refused",
+      );
+    }
+    if (!toggle.checked || !core.isPageDirty(page)) {
+      refuse(
+        "refresh-in-flight",
+        "an edit made while the configuration was in flight was reverted and the page then read as clean",
+      );
+    }
+  }
+
+  // ---- Arm: an editor opened while the refresh is in flight also stops the fill ----
+  {
+    // `mayReplacePageContents` is a conjunction and the arm above only exercises the dirty half. This is
+    // the other one, and it is the half with the worse outcome: `populateProviders` clears the hidden
+    // #selectProvider, whose value is the provider a save writes to, so a fill landing into a freshly
+    // opened editor writes the wrong provider or none at all. It has to be on the Providers page,
+    // because the Server page declares no editor and could never reach this.
+    const page = providersPageFixture();
+    wire(core, page);
+    const h = refreshHarness(page);
+
+    core.loadConfiguration(page, { refreshing: true });
+    // The decision has been taken and the request is out. Now an administrator clicks a provider card.
+    page.querySelector("#sso-editor").hidden = false;
+    await h.deliver();
+    h.restore();
+
+    if (h.seen.fills !== 0) {
+      refuse(
+        "refresh-in-flight-editor",
+        "a refresh overtaken by an opened editor went on filling the page, which clears the hidden selector the save reads its target from",
+      );
+    }
+  }
+
+  // ---- Arm: an ordinary load still replaces the page, whatever state it is in ----
+  {
+    // The near-miss for the two guards above. A save, a delete or an import has just changed the stored
+    // configuration and is reading it back; it must write the page even with an editor open and the page
+    // dirty, or every one of those paths stops showing its own result.
+    const page = providersPageFixture();
+    wire(core, page);
+    const h = refreshHarness(page);
+    page.querySelector("#sso-editor").hidden = false;
+    const toggle = page.querySelector("#OidEnabled");
+    if (toggle) {
+      toggle.checked = !toggle.checked;
+      page.dispatch("change", toggle, true);
+    }
+
+    core.loadConfiguration(page);
+    await h.deliver();
+    h.restore();
+
+    if (h.seen.fills !== 1) {
+      refuse(
+        "refresh-ordinary-load",
+        "an ordinary load refused to write the page, so a save no longer shows what it saved",
+      );
+    }
+  }
+
   if (faults.length) {
     faults.forEach((fault) => console.error(fault));
     console.error(
@@ -498,7 +854,7 @@ async function main() {
   }
 
   console.log(
-    "unsaved state:     eight arms run against the shipped sso-core.js and the pages it serves",
+    "unsaved state:     fifteen arms run against the shipped sso-core.js and the pages it serves",
   );
   console.log(
     "  untouched        a page nobody typed into is clean, shows nothing, and its Save is open",
@@ -526,6 +882,27 @@ async function main() {
   );
   console.log(
     "  hidden-region    a gate whose editor is off screen is left alone",
+  );
+  console.log(
+    "  refresh-folders  a refresh leaves the library checklists alone, and an ordinary load fills them",
+  );
+  console.log(
+    "  refresh-baseline the baseline covers the checklist fills, so an untouched tab re-reads and stays quiet",
+  );
+  console.log(
+    "  refresh-editor   an open editor refuses the refresh, a closed one lets it run",
+  );
+  console.log(
+    "  refresh-removed  a removed row refuses the refresh and the page says so",
+  );
+  console.log(
+    "  refresh-in-flight an edit made while the configuration was in flight is not overwritten,",
+  );
+  console.log(
+    "                   and neither is an editor opened inside the same window",
+  );
+  console.log(
+    "  refresh-ordinary a save, delete or import still replaces the page whatever state it is in",
   );
 }
 


### PR DESCRIPTION
# What & why

The Jellyfin dashboard keeps three views alive and hands a cached one back without re-running its controller, so a settings tab left and returned to went on showing the configuration as it was when the page was built - a provider added, renamed or deleted from another window, or by a declarative source, was simply not there. #1527 made Overview re-read on every show and left the four pages that hold controls alone; #1572 built the unsaved-changes state so those four could re-read safely, and the review refused the re-read, because the danger was never in that state but in what `loadConfiguration` does when it runs a second time, having been written to run once at construction while the editors are still hidden.

Each of the three refusals has its own guard now, rather than one guard credited with all of them:

- **An open editor refuses the refresh outright.** That is what keeps a return from emptying both library checklists - `populateFolders` rebuilds them with nothing ticked and only `loadProvider` ticks them, so the next save would persist an empty `EnabledFolders` and every user of that provider would lose library access at their next sign-in - and it is also what keeps `populateProviders` from clearing the hidden `#selectProvider` whose value is the provider a save writes to. On top of that, the refresh does not repopulate the checklists at all, so the worst outcome does not depend on the other two guards holding.
- **The decision reads the controls, not a flag.** `pageDiffersFromBaseline` recomputes the signature from the live page; `isPageDirty` reads a class something has to set. Removing a permission or role-mapping row is `row.remove()` - no `input`, no `change` - so nothing marks the page, but the signature carries each control's id and a row that is no longer there is a difference by construction. A refused return raises the unsaved-changes notice, so the tab says why it did not refresh.
- **Both questions are asked again inside the fill,** immediately before the first write, so a refresh overtaken by an edit or by a newly opened editor does nothing rather than overwriting what arrived.

The granularity condition is settled rather than answered: the indicator is still page-wide, and the refresh does not depend on it being per-editor, because any open editor refuses it wholesale.

The Accounts tab also re-reads its roster unconditionally beside the refresh - that list writes no control, and it is the one thing on the page a revoke or a link import elsewhere moves.

Closes #1576
Closes #1572

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This touches no login path, no crypto and no release pipeline, and it writes no configuration - it decides whether the admin page re-reads one. The availability lens ran anyway, because the failure it prevents is a mass one.

- [x] Fail-closed preserved: every new decision refuses rather than proceeds when it cannot answer. A page whose baseline was never taken reads as edited; an absent editor region is treated as closed only because `querySelector` returning null means the page declares none; a refresh that cannot read the configuration leaves the page showing what it last read.
- [x] No secrets logged; nothing is logged and no value is transported.
- [x] A security review was performed. Two refute-by-default lenses over the full changed files and their callers.
- [x] Review record, **CONFIRMED 3 / PLAUSIBLE 0** as raised. All three CONFIRMED findings are reproductions against the shipped file, and all three are FIXED here:
  - **availability** - NEEDS_IMPROVEMENT. Could not refute the three guards: it traced the checklist nesting (both containers really are inside their editors), the save serialisation, `SessionMinter.SetPreference(PreferenceKind.EnabledFolders, ...)`, and the Policies fill window, and could construct no path where the refresh empties a folder set, a grant set or a role mapping. **CONFIRMED, FIXED:** on Providers the baseline was taken in the configuration `.then` while the two checklist fills were still outstanding, so a page nobody had touched differed from its own baseline for the life of the view - the refresh would never have run there, and the tab would have asserted unsaved changes on arrival. Two further findings are filed rather than fixed: #1587 and #1589.
  - **correctness** - NEEDS_IMPROVEMENT. Confirmed `viewshow` delivery, one listener per view with no leak, `anyEditorOpen` correct on the three pages that declare no editor, and that the `refreshing` early exit skips nothing but the checklists. **CONFIRMED (same defect as above), FIXED.** **CONFIRMED, FIXED:** the editor half of the second asking was untested - deleting it left all thirteen arms green, because the in-flight arm ran on a page that declares no editor; there is an arm for it now, on Providers. **CONFIRMED, FIXED:** the signature joined on `""`, so two id-less rows could collide, and under this change "signature equal" is permission to replace the page - it joins on a separator no value can contain now. One finding filed rather than fixed: #1588.
  - **saml / oidc / bypass** - not run, and disclosed as not run rather than reported as clean. No file under `SSO-Auth/Api` is touched and no request this change makes is authenticated differently from the one beside it.
- [x] Log inputs from the IdP are sanitized inline at the log call - not applicable; no logging call is added or moved.

## Quality checklist

- [x] No duplicated logic. `refreshOnShow` is three lines of decision over two predicates that already existed; the load gained one option and one promise.
- [x] The change adds no more code than the problem requires. The prose is the larger half on purpose: the three defects it guards against are the ones a later reader would otherwise re-introduce, and each is written at its guard rather than in one block.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. No new structural property: `tools/ui-unsaved-state.js` is the running proof this surface already had, and it grew from eight arms to fifteen. The `.NET` workflow runs it, so it is a gate rather than a command somebody remembers.
- [x] Docs impact: no README or wiki page describes the tab-refresh behaviour, and #1574 already carries the wiki's settings-page rewrite for the whole 4.4 surface. The changelog entry states what a return now does and what it still does not pick up.

## Verification

- [x] Build green with `--warnaserror`, 0 warnings, on both target frameworks.
- [x] Suite green on both: 3826 passed on `net9.0`, 3827 on `net10.0`, 0 failed. Four tests skip on this machine and the skip is disclosed rather than worked around - they bind a listener off loopback, which raises a Windows firewall consent dialog needing an administrator (#1227).
  Two earlier full-suite runs on this branch failed six `SSOControllerAuthorizationTests` on a connect timeout to `127.0.0.1:29999`, and I did not take that at face value in either direction: a clean checkout of the merge base showed the same six under the same conditions and none when run alone, the same six pass alone on this branch, and the failing runs took 600 seconds against 37 for the passing ones. It is contention for that port between two suites on this machine, not this change, which touches no C# at all.
- [x] Prettier clean for both `.js` files. Checked against their content as git stores it: the working tree here is CRLF and Prettier's default `endOfLine` is `lf`, so a direct run flags files it also flags at the merge base.
- [x] `node tools/ui-mock-fields.js` green: 123 controls, five controllers, fourteen page names.
- [x] `node tools/ui-unsaved-state.js` green: fifteen arms, six of them new.

**Guards proven by deletion, against the merged shape rather than an earlier one.** Seven mutations, each reddening the arm that names it: repopulating the checklists on a refresh (1 refusal), dropping the open-editor guard (2), deciding on the marked class instead of the signature (2), dropping the dirty half of the second asking (3), dropping its editor half (1), never refreshing at all (2), and taking the baseline in the configuration `.then` alone (3).

## Notes

**A media library added while the dashboard is left open on one of these tabs is not picked up by a return.** The checklist is the one the page loaded, until the next save, import or reload of the dashboard. That is the price of not rebuilding it, and it is stated in the changelog.

**Three findings are filed rather than fixed,** because each belongs to a path this change does not take: #1587 (a media-library read that failed leaves an empty checklist, and the next save writes no libraries at all - the save route to the same mass failure this change closes on the refresh route), #1588 (an editor has no close control, so the tab stops refreshing once one is opened), #1589 (a managed-provider read that failed unfreezes a declaratively-owned form, which this change retries more often).

**What the running proof cannot say.** Its DOM is a stub with no tree, so it has no propagation and no phases, and the fills are substituted and counted rather than executed - the arms judge the DECISION, not the fills. The file states that bound at the top and the new block restates it for its own arms. CI cannot exercise browser JS at all, so this review is the primary verification for this change.

**No second reader.** There is one person on this account, so nothing here was read by a second party; the review above is two adversarial lenses run against the diff, and it stands in place of one rather than being one.
