### PR TITLE
Point the nightly JF12 dispatch at the renamed branch [#1592]

### DIFF
--- a/.github/workflows/nightly-betas.yml
+++ b/.github/workflows/nightly-betas.yml
@@ -11,7 +11,8 @@ name: Nightly betas
 # published the same code every night with a rising build number while the work sat unreleased.
 #
 # So the JF12 ref is the DEVELOPMENT branch and the JF10.11 ref is `main`. If the development branch
-# is ever renamed, this line is the one that has to follow it, and nothing else here does.
+# is ever renamed, this line is the one that has to follow it, and nothing else here does. It was
+# renamed from `4.4` to `5.0` on 2026-09-09 and this line followed one merge too late (#1592).
 #
 # Each dispatched workflow has its own gate job that skips the build unless its ref has advanced since
 # that lineage's last beta, so an unchanged day mints nothing.
@@ -57,4 +58,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref 4.4
+        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref 5.0


### PR DESCRIPTION
# What & why

The development branch was renamed `4.4` to `5.0` today. The nightly dispatcher still names the old one, so the 04:00 UTC JF12 leg would dispatch against a ref that no longer exists. Closes #1592.

```
publish-beta.yml      (JF10.11)  --ref main            unchanged
publish-jf12-beta.yml (JF12)     --ref 4.4 -> --ref 5.0
```

#1586 introduced the ref and was written before the rename. Its Notes named this exact coupling; the two simply landed in the wrong order. The header now records that it bit once, rather than only that it could.

## Type of change

- [x] Bug fix
- [ ] Security hardening / vulnerability fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

No plugin code. One branch name in a dispatch step.

- [x] Fail-closed preserved: untouched.
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run, release plumbing.
- [x] Review record: no lens gate applies.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: no logic.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the header says the rename happened and that this line followed late.
- [x] Architecture-conformance tests pass: unaffected.
- [x] Docs impact: the comment is in this pull request.

## Verification

```
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/nightly-betas.yml'))"
YAML gueltig

$ grep -n -- '--ref' .github/workflows/nightly-betas.yml
46:        run: gh workflow run publish-beta.yml --repo "\" --ref main
61:        run: gh workflow run publish-jf12-beta.yml --repo "\" --ref 5.0
```

- [x] `dotnet build` / `dotnet test`: not applicable, no code changed.
- [x] Prettier: no gated file changed.

## Notes

**What would prevent the next one is not in here.** Nothing verifies that a dispatched `--ref` names a branch that exists. A check reading every `--ref` in `.github/workflows/` and refusing a name with no branch behind it would have caught this at the pull request rather than at 04:00 UTC. That half stays open on #1592.