### PR TITLE
Warm the two time-budget rows before they start their clocks [#1591]

### DIFF
--- a/SSO-Auth.Tests/Events/SsoLoginEventsTests.cs
+++ b/SSO-Auth.Tests/Events/SsoLoginEventsTests.cs
@@ -102,6 +102,19 @@ public class SsoLoginEventsTests
         // operator-configured destination on a client the host gives no timeout, and PublishAsync awaits
         // every consumer in turn - so a black-holed destination would hold a refusal that was already
         // decided. The budget is what keeps the 401 prompt; without it this test never returns.
+        //
+        // THE PATH IS WALKED ONCE BEFORE THE CLOCK STARTS AND THE WARM-UP IS NOT TIMED (#1591). The clock
+        // reads wall time, so whatever the first call in a process touches for the first time - the event
+        // argument types, the substituted bus, the logger's formatter - is charged to the budget under
+        // assertion. On a cold process here that first touch reached 25.7 seconds against a 50 ms budget,
+        // and the row failed on the first invocation and passed on the next one with nothing else changed.
+        // The warm-up spends it outside the measurement. The five-second bound stays where it was, because
+        // a row that answered a cold process by widening its own bound would stop proving what it names.
+        var warmUpBus = Substitute.For<IEventManager>();
+        warmUpBus.PublishAsync(Arg.Any<AuthenticationRequestEventArgs>()).Returns(new TaskCompletionSource().Task);
+        await new SsoLoginEvents(warmUpBus, new CapturingLogger(), TimeSpan.FromMilliseconds(50)).PublishRoleDeniedAsync("keycloak", "203.0.113.9");
+
+
         var log = new CapturingLogger();
         var bus = Substitute.For<IEventManager>();
         var neverCompletes = new TaskCompletionSource();
@@ -111,6 +124,7 @@ public class SsoLoginEventsTests
         var clock = Stopwatch.StartNew();
         await events.PublishRoleDeniedAsync("keycloak", "203.0.113.9");
         clock.Stop();
+
 
         Assert.True(clock.Elapsed < TimeSpan.FromSeconds(5), $"the publish held the refusal for {clock.Elapsed}");
         Assert.Contains(log.Entries, e => e.Message.Contains("Could not publish", StringComparison.Ordinal));

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -337,10 +337,24 @@ public class OidcDiscoveryReaderTests
         // the read closed, and no screen refusal is recorded for it. The day the read stops being pre-buffered
         // this row goes red: the two arms become reachable, the screen starts refusing here, and their
         // retention becomes checkable instead of decorative.
+        //
+        // THE READ IS MADE TWICE AND ONLY THE SECOND IS ASSERTED (#1591). Which failure arrives is a race
+        // the reader itself starts: it gives a fetch FetchTimeout to complete, and the first read a process
+        // makes pays the first touch of the whole fetch graph inside that budget. On a cold process here
+        // that first touch has outlasted the budget, the timeout won the race, and the row read a timeout
+        // error rather than the copy failure it is named for - so it said different things on a cold process
+        // and a warm one. The warm-up spends the first touch outside the read under assertion. Widening
+        // FetchTimeout would do the same thing by moving a production bound this row does not own.
+        var warmUp = new CountingFactory(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UncopyableContent() });
+        await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", warmUp.Factory, Logger(), cancellationToken: TestContext.Current.CancellationToken);
+
+
         var http = new CountingFactory(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UncopyableContent() });
+
         var logger = new CapturingLogger();
 
         var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger, cancellationToken: TestContext.Current.CancellationToken);
+
 
         Assert.False(result.Available);
         Assert.DoesNotContain(logger.Entries, e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));


### PR DESCRIPTION
# What & why

Two rows read wall time and charged the first touch of their own dependency
graph to the budget they assert against, so they said different things on a
cold test process than on a warm one. On this machine a full local run is the
gate before every merge handover, and the two honest responses to a red row
that is not about your change - re-run it, or read past it - are the two that
erode a gate. Closes #1591.

`PublishRoleDenied_WhenTheBusNeverReturns_GivesUpWithinItsBudget` asserts the
publish returns inside 5s against a 50 ms budget; the issue measured 25.7s on
a cold process. `ABodyThatCannotBeCopied_ReachesNeitherTheHttpRequestException
NorTheIOExceptionArm` asserts the fail-closed line names the copy failure, and
the reader gives a fetch `FetchTimeout` (10s) to arrive at all: on a cold
process the first read spent more than that, the timeout won the race, and the
row read a timeout error instead.

Each row now walks its path once before the measurement starts and asserts
nothing about that walk. **Neither bound moved.** A row that answered a cold
process by widening its own bound would stop proving what it names, and the 10s
`FetchTimeout` is a production bound this row does not own. Both rows say so at
the row, which is the issue's second done-condition.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

No product code changed - the diff is two test files, 28 added lines and no
deletions.

- [x] Fail-closed preserved: untouched. Both rows keep the bound they had, and
      the second one still asserts the read fails closed.
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run. Two test-local warm-up calls
      against substituted buses and a stub transport; no login path, no crypto,
      no config persistence, no release pipeline.
- [x] Review record: no lens gate applies.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: each warm-up is three lines at the row it warms, and
      a shared helper would put the reason a row is slow somewhere other than
      the row it is about.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: each row states which of the two remedies it took and
      why the other was refused.
- [x] Architecture-conformance tests pass (both TFMs, full suite below).
- [x] Docs impact: none. Nothing user-visible changes.

## Verification

Both target frameworks, `--warnaserror` on the test project, which is the
analyzer gate `dotnet test` alone does not promote:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3834, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 80,206s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3835, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 601,311s
```

The four skips are the loopback-binding rows that need a Windows firewall
consent dialog (#1227); they are skipped on this machine by design and that is
disclosed here rather than counted as green.

- [x] `--warnaserror` build green on both TFMs.
- [x] Full suite green on both TFMs.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

### That the change bites

The warm-up was timed separately on a fresh process, and the numbers are what
the assertions were previously being charged:

```
warmup=00:00:04.7000781  measured=00:00:00.0565942   (50 ms budget, 5s bound)
warmup=00:00:02.5261611  measured=00:00:00.0036746   (10s FetchTimeout)
```

4.70s of the 5s bound and 2.53s of the 10s timeout were first-touch cost inside
the assertion. The instrumentation that produced those two lines was temporary
and is not in the diff.

## Notes

**The third done-condition is only partly discharged, and this stays negative.**
It asks for one run of the full suite on a cold process after `dotnet nuget
locals` has been cleared or a fresh restore. The suite above ran on a freshly
rebuilt binary, but not after a cache clear: clearing the shared NuGet cache
would pull the restore out from under every other build running on this machine
tonight. The failure itself did not reproduce here either - a rebuild plus a
fresh process ran the two rows in 2,506s and both passed - so this machine is
currently too warm to show the red state the issue measured. What is verified is
the mechanism and its removal, in the numbers above; what is NOT verified is a
run from a cleared cache.
