### PR TITLE
Read a 200 that is not the managed report as a read that failed [#1597]

### DIFF
--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -305,18 +305,29 @@ const ssoConfigurationPage = {
       ApiClient.getUrl("sso/Config/Managed"),
     ).then(
       (report) => {
+        // AN EMPTY REPORT AND SOMETHING THAT IS NOT THE REPORT ARE NOT THE SAME ANSWER (#1597). Each member
+        // is kept as `null` until it is seen to be a list, so the arm can tell the two apart; a report
+        // naming any one of the three is the report, whatever the other two are, because a server with no
+        // SAML provider legitimately sends an empty list for that member.
+        const listOrNothing = (member) =>
+          Array.isArray(member) ? member : null;
+        const oid = listOrNothing(report && report.OidConfigs);
+        const saml = listOrNothing(report && report.SamlConfigs);
+        const profiles = listOrNothing(report && report.ProvisioningProfiles);
+
+        if (oid === null && saml === null && profiles === null) {
+          // A 200 carrying none of the three is a body that reached this page instead of the report - a
+          // proxy's error page that happens to parse, a version-skewed endpoint, a truncated body. Reading
+          // it as "nothing is managed" is the #1589 fail-open arriving through the arm that believes it
+          // succeeded, and it is worse there, because that arm also clears the flag that would have said so.
+          ssoConfigurationPage.managedReportUnread = true;
+          return;
+        }
+
         ssoConfigurationPage.managedProviders = {
-          OidConfigs: Array.isArray(report && report.OidConfigs)
-            ? report.OidConfigs
-            : [],
-          SamlConfigs: Array.isArray(report && report.SamlConfigs)
-            ? report.SamlConfigs
-            : [],
-          ProvisioningProfiles: Array.isArray(
-            report && report.ProvisioningProfiles,
-          )
-            ? report.ProvisioningProfiles
-            : [],
+          OidConfigs: oid || [],
+          SamlConfigs: saml || [],
+          ProvisioningProfiles: profiles || [],
         };
         ssoConfigurationPage.managedReportUnread = false;
       },

--- a/tools/ui-unsaved-state.js
+++ b/tools/ui-unsaved-state.js
@@ -859,16 +859,17 @@ async function main() {
     const originalSet = core.managedProviders;
     const originalUnread = core.managedReportUnread;
     let rejecting = false;
+    let serving = {
+      OidConfigs: ["file-owned"],
+      SamlConfigs: [],
+      ProvisioningProfiles: ["file-profile"],
+    };
     globalThis.ApiClient = {
       getUrl: (url) => url,
       getJSON: () =>
         rejecting
           ? Promise.reject(new Error("sso/Config/Managed answered 500"))
-          : Promise.resolve({
-              OidConfigs: ["file-owned"],
-              SamlConfigs: [],
-              ProvisioningProfiles: ["file-profile"],
-            }),
+          : Promise.resolve(serving),
     };
 
     // The report arrives once, which is the state a transient failure then has to survive.
@@ -971,6 +972,74 @@ async function main() {
       refuse(
         "managed-report-failure",
         "an unfrozen editor went on warning about a report that is being read fine",
+      );
+    }
+
+    // A 200 that is not the report at all (#1597). The rejection arm above is careful; this one used to
+    // believe it had succeeded, so it emptied the set AND cleared the flag that would have said otherwise -
+    // the same fail-open through the door that reports nothing. Two bodies are served: one carrying none of
+    // the three members, and one carrying a single empty member, which IS the report and must still be read
+    // as one.
+    serving = { detail: "502 Bad Gateway" };
+    await core.loadManagedProviders();
+    if (!core.isManagedProvider("oid", "file-owned")) {
+      refuse(
+        "managed-report-failure",
+        "a body that is not the report unfroze a provider a configuration file owns",
+      );
+    }
+    if (!core.managedReportUnread) {
+      refuse(
+        "managed-report-failure",
+        "a body that is not the report was counted as having read the set",
+      );
+    }
+
+    serving = null;
+    await core.loadManagedProviders();
+    if (
+      !core.isManagedProvider("oid", "file-owned") ||
+      !core.managedReportUnread
+    ) {
+      refuse(
+        "managed-report-failure",
+        "a body of null was read as a report saying nothing is managed",
+      );
+    }
+
+    // The other direction of the same boundary, and the one that costs availability if it is wrong: an
+    // ordinary server with nothing managed sends three empty lists, and that IS the report. Read as "not
+    // the report" it would warn on every editor forever on the commonest installation there is.
+    serving = { OidConfigs: [], SamlConfigs: [], ProvisioningProfiles: [] };
+    await core.loadManagedProviders();
+    if (core.managedReportUnread) {
+      refuse(
+        "managed-report-failure",
+        "a server with nothing managed was treated as one whose report could not be read",
+      );
+    }
+    if (core.isManagedProvider("oid", "file-owned")) {
+      refuse(
+        "managed-report-failure",
+        "an empty report left a provider frozen from the set before it",
+      );
+    }
+
+    // And a report naming ONE member is still the report. The guard asks whether all three are missing
+    // rather than whether any one is, and this is the arm that says which: a server is free to answer with
+    // only the members it has, and a page that refused that would warn forever on a real installation.
+    serving = { SamlConfigs: ["saml-owned"] };
+    await core.loadManagedProviders();
+    if (!core.isManagedProvider("saml", "saml-owned")) {
+      refuse(
+        "managed-report-failure",
+        "a report naming one member was thrown away as though it were not the report",
+      );
+    }
+    if (core.managedReportUnread) {
+      refuse(
+        "managed-report-failure",
+        "a report naming one member was counted as a read that did not happen",
       );
     }
 


### PR DESCRIPTION
# What & why

#1589 made the REJECTION arm of the managed-set read keep the last set it read
and record that the read failed. The SUCCESS arm was left believing the
opposite: it mapped each of the three members through `Array.isArray` with an
empty list as the fallback, so a 200 carrying none of them — a proxy's error
page that happens to parse, a version-skewed endpoint, a truncated body — was
read as a successful read of a server that owns nothing. Every provider a
configuration file owns then rendered as an ordinary editable form, the
administrator edited it, pressed Save, was told "Settings saved.", and the
server kept the stored value and logged an ignored write. **That is the same
fail-open, arriving through the door that reports nothing, and it is worse
there, because that arm also clears the flag that would have said so.** Closes
#1597.

Each member is now kept as `null` until it is seen to be a list. A body carrying
none of the three leaves the set alone and sets the unread flag, exactly as a
rejection does. A body carrying any ONE of them is the report and is read as
one, because a server is free to answer with only the members it has and a page
that refused that would warn forever on an ordinary installation.

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved — this change is the fail-closed repair, on the one
      arm #1589 left open. Nothing new is frozen: on a first load whose body is
      not the report the set is still the empty default, so the change cannot
      lock an administrator out of a form.
- [x] No secrets logged: nothing logged, nothing exported, no new text.
- [x] A security review was performed: the bypass lens, refute-by-default, on
      the full files, their callers AND the server side.
- [x] Review record: **bypass lens — PASS. CONFIRMED 0 / PLAUSIBLE 0**, three
      residuals, all DECLINE with the reason.
      - The lens's main attack was that ASP.NET could put camelCase member
        names on the wire, which `Array.isArray` would then reject — making
        EVERY real report look like a not-report and the page permanently
        unread. It refuted its own attack by measurement rather than by
        reading: against the real `Jellyfin.Extensions` 10.11.11 package,
        `JsonDefaults.PascalCaseOptions` serializes
        `{"OidConfigs":[],"SamlConfigs":[],"ProvisioningProfiles":[]}`, and
        `WhenWritingNull` can never fire because `ManagedProviderSetDocument`
        defaults each member to an empty list and the controller fills all
        three. Residual stated: the host's MVC wiring is not a dependency of
        this repository, so the options object was proved and not the host's
        use of it — and the direction that would be wrong is loud (a permanent
        warning), not a bypass.
      - `oid || []` is byte-for-byte the old behaviour on every branch the new
        guard does not take (arrays are truthy, including empty ones; the
        empty array's identity is preserved).
      - Thirteen body shapes driven through the shipped module: `null`,
        `undefined`, `{}`, an array body, a string body, `0`, camelCase
        members, all-members-`null`, a string member, a `__proto__` payload —
        every one keeps the previous set and sets the flag. Only a real report
        is consumed.
      - DECLINE: a future server legitimately dropping one member would have
        that dimension emptied — gated today by the conformance rule pinning
        exactly those three names. DECLINE: an attacker who can forge a
        well-formed empty report can unfreeze the editors — pre-existing and
        inherent to a client-side advisory freeze, and the server refuses and
        audits the write. DECLINE: two arms the lens suggested — a `null` body
        and an all-empty report — were **taken** rather than declined and are
        in the diff.
- [x] Log inputs sanitized: nothing is logged by this path.

## Quality checklist

- [x] No duplicated logic: one `listOrNothing` helper asked three times.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the arm says why an empty report and something that is
      not the report are different answers, which is the distinction the whole
      change rests on.
- [x] Architecture-conformance tests pass (inside the suites below).
- [x] Docs impact: none beyond #1599, which is already filed and covers the
      unreadable-report state as a whole.

## Verification

```
$ npx prettier --check "SSO-Auth/Web/sso-core.js" "tools/ui-unsaved-state.js"
All matched files use Prettier code style!
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q   # 0 warnings, 0 errors
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q   # 0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3837, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 80,115s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3838, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 59,655s
$ node tools/ui-unsaved-state.js       # exit 0
```

The four skips are the loopback-binding rows that need a Windows firewall
consent dialog (#1227); they are skipped on this machine by design and that is
disclosed rather than counted as green.

### That the guard bites, from both sides

The boundary is "all three members missing", and a guard is only proved when
both sides of it are. Each mutation was applied to the shipped file and the
harness run:

| mutation | harness |
|---|---|
| the guard removed (`if (false)`) — the pre-#1597 behaviour | 3 refusals, exit 1 |
| the boundary widened, `&&` to `||` — "any one member missing" | 2 different refusals, exit 1 |
| guard restored (each time) | exit 0 |

The second row is the one that matters: without the arm that serves a report
naming a single member, the widened boundary survives, and the first version of
this change had exactly that hole until the mutation was run.

- [x] `--warnaserror` build green on both TFMs.
- [x] Full suite green on both TFMs.
- [x] Prettier clean on both changed `.js` files.

## Notes

**What the proof cannot say, and this stays negative.** The node stub has no
tree, so this arm judges the DATA the freeze is decided from and never the
rendered form; no route in this repository exercises the change in a browser.
That bound is the one the tool's own header states, and the review is the
primary verification here as it is for every browser-JS change.

**Where it came from:** the adversarial review of #1589 raised this as the one
finding out of that issue's scope, and it was filed rather than folded in. This
is that issue.
