### PR TITLE
Let the rail go first only where it earns it, and wrap the tab strip [#1527]

### DIFF
--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -124,7 +124,7 @@
             aria-live="polite"
           ></div>
 
-          <div class="sso-columns">
+          <div class="sso-columns sso-columns--rail-first">
             <div class="sso-column-main">
               <!--
             Configuration check (#1084): ONE action across every configured OpenID and SAML provider,

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -502,18 +502,48 @@
   min-width: 0;
 }
 
-/* THE RAIL COMES FIRST WHEN THE COLUMNS COLLAPSE, and that is the decision the stage-0 walk left to this
-   stage. Stacking in source order puts the readiness checklist and the field help BELOW the save button
-   at 375 wide - which is to say it puts the answer to "can I use this yet" behind every field and behind
-   the button that commits them. The order is reversed instead: at one column the rail is read first and
-   the form follows it, which is the order the two are actually used in. */
+/* WHICH COLUMN COMES FIRST WHEN THEY COLLAPSE DEPENDS ON WHAT THE RAIL IS, and one rule for all five
+   pages was wrong in both directions before it was right in one.
+
+   The stage-0 walk found that source order puts the readiness checklist BELOW the save button at 375 -
+   the answer to "can I use this yet" behind every field and behind the button that commits them. So the
+   rail was reversed for every page. The stage-1 walk on a live server then found what that costs on the
+   four pages whose rail is not a checklist: on Overview the rail is reference prose, and reversing it put
+   the page's own first question at y=832 on an 812-tall screen. One pixel below the fold, behind a wall
+   of documentation, on the page that exists to answer it.
+
+   Both walks were right about their own page. The rail is a readiness checklist tied to a form on
+   Providers, and reference prose everywhere else, so the reversal belongs to the page rather than to the
+   layout: source order by default, opted out of where the rail earns going first. */
 @media (max-width: 60em) {
   .sso-columns {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .sso-column-rail {
+  .sso-columns--rail-first .sso-column-rail {
     order: -1;
+  }
+}
+
+/* THE TAB STRIP WRAPS AT NARROW WIDTHS RATHER THAN SCROLLING, because scrolling here is invisible.
+   Measured on a live Jellyfin at 375: the five tabs need 539px and the strip has 346, so Policies and
+   Server sit past the right edge. They are reachable - the container is `overflow-x: auto` - but Jellyfin
+   puts `hiddenScrollX` on it, so there is no scrollbar, no arrow, no fade and no partial tab wide enough
+   to read as one. Two fifths of the surface is present and undiscoverable, and the two that fall off are
+   where the SSO-only switch lives.
+
+   An affordance would have been the smaller change and it would still ask the reader to find it. Wrapping
+   asks nothing: at 375 the strip becomes two rows, all five labels visible, overflow zero. It costs one
+   row of height, which the rail order above gives back many times over. */
+@media (max-width: 60em) {
+  .sso-tabs {
+    overflow-x: visible;
+  }
+
+  .sso-tabs .emby-tabs-slider {
+    display: flex;
+    flex-wrap: wrap;
+    white-space: normal;
   }
 }
 


### PR DESCRIPTION
# What & why

Two blockers the stage-1 walk found on a live Jellyfin 12.0.0 at 375 wide.
Refs #1527, which stays open until stage 1 is released on a fresh walk.

**The rail went first on every page.** The stage-0 walk found that source order
puts the readiness checklist below the save button, so the collapse was reversed
for all five. Four of them have no checklist: their rail is reference prose. On
Overview the reversal put the page's own first question at `y=832` on an 812-tall
screen. One pixel below the fold, behind a wall of documentation, on the page
that exists to answer it.

Both walks were right about their own page. The rail is a checklist tied to a
form on Providers and prose everywhere else, so the reversal belongs to the page
rather than to the layout.

**The tab strip overflowed silently.** Five tabs need 539px and the strip has
346, so Policies and Server sit past the right edge. Reachable, because the
container is `overflow-x: auto`; undiscoverable, because Jellyfin puts
`hiddenScrollX` on it and there is no arrow, no fade and no partial tab. The two
that fall off are where the SSO-only switch lives.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

CSS and one class attribute. No login path, no crypto, no config persistence.

- [x] Fail-closed preserved: untouched.
- [x] No secrets logged: untouched.
- [ ] A security review was performed: not run, not a sensitive surface.
- [x] Review record: no lens applies. A live walk stands in its place.
- [x] Log inputs sanitized: untouched.

## Quality checklist

- [x] No duplicated logic: one rule became one rule plus an opt-in.
- [x] Adds no more code than the problem requires.
- [x] Self-documenting: the comment carries BOTH walks, so the next reader sees
      why the reversal exists at all before removing it, and why it is not global.
- [x] Architecture-conformance tests pass.
- [x] Docs impact: none. No document describes the collapse order.

## Verification

Measured on a live server, same page, same width, before and after:

```
Inhalt (main)   y=832  ->  y=239
Hilfe  (rail)   y=178  ->  y=727
tab rows            1  ->      2
overflow        193px  ->    0px
```

All five tab labels are visible at 375; `Übersicht Anbieter Konten` on row one,
`Richtlinien Server` on row two.

- [x] `dotnet build --no-restore --warnaserror` green (net10.0), and the rebuilt
      assembly is what the figures above were read from - the web assets are
      `EmbeddedResource`, so a CSS change only reaches the page through a build.
- [x] `dotnet test`: no C# changed.
- [x] Prettier: clean for `style.css` and `providersPage.html`.

## Notes

**A correction on the method, because it nearly passed.** The first "after"
reading was green and wrong: it measured a CSS probe injected during the
investigation, not the change. A same-origin hash change does not reload the
document, so the probe survived into the verification. It showed up because
`order` still read `-1` while the new rule no longer sets it - the one figure
that did not fit the others. Probe removed, hard reload, then the numbers above.

**What stage 1 still owes** before release is another walk on this branch's
build, which is why #1527 is `Refs` rather than `Closes`.
