### PR TITLE
Copy the configuration aside when a second copy of this plugin is loaded [#1601]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.AuditSanitizers.cs
@@ -38,6 +38,7 @@ public partial class ArchitectureConformanceTests
         "markerPath",
         "source",
         "sourcePath",
+        "installLocations",
         "composedRefusal",
     };
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.DuplicateInstall.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.DuplicateInstall.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rules for the refusal that stands while a second copy of this plugin is loaded (#1601).
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    [Fact]
+    public void TheDuplicateRefusalComesBeforeAnythingElseOnTheWritePath()
+    {
+        // The ordering IS the fix, and it is invisible from the two lines it separates. With two copies of
+        // this plugin loaded, a configuration produced by the other copy is not this copy's
+        // PluginConfiguration - the types have different identities - so PersistBase's type check does not
+        // match it and hands it to the base class unchanged. That is the host write, and the host write is
+        // what replaces the operator's providers with defaults. A refusal placed after the type check
+        // therefore never runs on the one shape that does the damage.
+        //
+        // Measured on a live Jellyfin 12.0.0 with the published packages: SSO-Auth.xml went 3576 bytes with
+        // a provider, to 601, to 38, over one downgrade and one upgrade.
+        var source = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "SSOPlugin.cs"));
+
+        var persist = source.IndexOf("private void PersistBase(BasePluginConfiguration configuration)", StringComparison.Ordinal);
+        Assert.True(persist >= 0, "PersistBase is the single write path and this rule is written against it.");
+
+        var refusal = source.IndexOf("if (LoadedMoreThanOnce)", persist, StringComparison.Ordinal);
+        var typeCheck = source.IndexOf("if (configuration is not PluginConfiguration incoming)", persist, StringComparison.Ordinal);
+
+        Assert.True(refusal >= 0, "PersistBase refuses to write while a second copy of this plugin is loaded (#1601).");
+        Assert.True(typeCheck >= 0, "PersistBase still separates this plugin's configuration type from anything else.");
+        Assert.True(
+            refusal < typeCheck,
+            "The duplicate-install refusal must come BEFORE the configuration type check in PersistBase "
+            + "(#1601): a configuration from the other loaded copy fails that check and falls through to "
+            + "the base class, which is the write that empties the file.");
+    }
+
+    [Fact]
+    public void TheDuplicateCheckRunsBeforeTheConfigurationIsEverRead()
+    {
+        // The copy this check takes is only worth something while the file on disk is still the operator's.
+        // The host overwrites it during its own lazy load of Configuration, so anything in this constructor
+        // that reads Configuration before the check would hand back an already-emptied file to copy.
+        // Asserted against the constructor text rather than by running it, because the failure is an
+        // ordering a passing unit test would not notice.
+        var source = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "SSOPlugin.cs"));
+
+        var detect = source.IndexOf("DuplicateInstall.Detect(ConfigurationFilePath", StringComparison.Ordinal);
+        var store = source.IndexOf("new ProviderConfigStore(() => Configuration", StringComparison.Ordinal);
+
+        Assert.True(detect >= 0, "The constructor asks whether a second copy is loaded (#1601).");
+        Assert.True(store >= 0, "The constructor still builds the provider config store over the live configuration.");
+        Assert.True(
+            detect < store,
+            "The duplicate-install check runs before anything in the constructor reaches Configuration "
+            + "(#1601), so the copy it takes is the file as the operator left it.");
+    }
+}

--- a/SSO-Auth.Tests/Config/DuplicateInstallTests.cs
+++ b/SSO-Auth.Tests/Config/DuplicateInstallTests.cs
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Coverage for noticing a second copy of this plugin in the same server, and for the one copy of the
+/// configuration that is taken before the host can overwrite it (#1601).
+/// </summary>
+public class DuplicateInstallTests
+{
+    private static readonly DateTime Noon = new(2026, 9, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    private static readonly string[] TwoCopies =
+    {
+        "/config/plugins/Community SSO for Jellyfin_5.0.0.75/SSO-Auth.dll",
+        "/config/plugins/Community SSO for Jellyfin_5.0.0.81/SSO-Auth.dll",
+    };
+
+    [Fact]
+    public void InAProcessHoldingOneCopy_ItReportsNoDuplicate()
+    {
+        // The direction that matters, asked of the real loader. A missed duplicate leaves the server
+        // exactly as it was before this check existed; a false positive refuses every configuration write
+        // on a healthy server, which is an outage this check invented.
+        WithConfigurationFile(path =>
+        {
+            var state = DuplicateInstall.Detect(path, Noon);
+
+            Assert.False(state.IsDuplicated);
+            Assert.Null(state.PreservedCopyPath);
+            Assert.Empty(Copies(path));
+        });
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void BelowTwoCopies_ItDecidesNoDuplicateAndTouchesNothing(int copies)
+    {
+        // Zero is what a loader question that could not be answered returns, and it has to read as "no
+        // duplicate" rather than as "no copies, so something is wrong": the safe answer is the one that
+        // leaves the server alone.
+        WithConfigurationFile(path =>
+        {
+            var state = DuplicateInstall.Decide(TwoCopies.Take(copies).ToList(), path, Noon);
+
+            Assert.False(state.IsDuplicated);
+            Assert.Null(state.PreservedCopyPath);
+            Assert.Empty(Copies(path));
+        });
+    }
+
+    [Fact]
+    public void WithTwoCopies_ItDecidesDuplicateAndCopiesTheConfiguration()
+    {
+        WithConfigurationFile(path =>
+        {
+            var state = DuplicateInstall.Decide(TwoCopies, path, Noon);
+
+            Assert.True(state.IsDuplicated);
+            Assert.Equal(2, state.Locations.Count);
+            Assert.NotNull(state.PreservedCopyPath);
+            Assert.Equal(File.ReadAllText(path), File.ReadAllText(state.PreservedCopyPath!));
+            Assert.Single(Copies(path));
+        });
+    }
+
+    [Fact]
+    public void ASecondBootKeepsTheFirstCopyRatherThanTakingItsOwn()
+    {
+        // The property the whole file turns on. A server left in this state boots again and again, and by
+        // the second boot the file on disk is already the empty one the host wrote. Copying again would
+        // bury the only version worth having under a stack of empty ones.
+        WithConfigurationFile(path =>
+        {
+            var first = DuplicateInstall.Preserve(path, Noon);
+            File.WriteAllText(path, "<PluginConfiguration />");
+
+            var second = DuplicateInstall.Preserve(path, Noon.AddHours(1));
+
+            Assert.Equal(first, second);
+            Assert.Single(Copies(path));
+            Assert.Contains("authentik", File.ReadAllText(first!), StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void WithNoConfigurationOnDisk_ItCopiesNothing()
+    {
+        WithConfigurationFile(path =>
+        {
+            File.Delete(path);
+
+            Assert.Null(DuplicateInstall.Preserve(path, Noon));
+            Assert.Empty(Copies(path));
+        });
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SSO-Auth.xml")]
+    public void WithNoUsableConfigurationPath_ItCopiesNothing(string? path)
+    {
+        // The host composes this path from the application paths, and a harness or an early boot can leave
+        // it empty or bare. Every shape of that must be a no-op rather than an exception out of a plugin
+        // constructor, which would take every SSO login on the server offline.
+        Assert.Null(DuplicateInstall.Preserve(path, Noon));
+    }
+
+    [Fact]
+    public void WhenTheCopyCannotBeWritten_ItAnswersNothingRatherThanThrowing()
+    {
+        // The realistic trigger is a full or read-only volume, which is also when the operator can least
+        // afford a plugin that fails to load. Arranged here by taking the copy's name with a directory,
+        // which File.Copy refuses the same way.
+        WithConfigurationFile(path =>
+        {
+            Directory.CreateDirectory(path + DuplicateInstall.CopySuffix + "20260910-120000Z");
+
+            Assert.Null(DuplicateInstall.Preserve(path, Noon));
+        });
+    }
+
+    [Fact]
+    public void TheLineNamesBothCopiesAndCollapsesARepeatedPath()
+    {
+        var line = DuplicateInstall.Name(new[] { "/b/SSO-Auth.dll", "/a/SSO-Auth.dll", "/a/SSO-Auth.dll" });
+
+        Assert.Equal("/a/SSO-Auth.dll AND /b/SSO-Auth.dll", line);
+    }
+
+    [Fact]
+    public void TheLineNamesACopyWithNoFileBehindIt()
+    {
+        // A dynamic assembly has no location, and dropping it would leave a line about two copies naming
+        // one path, which reads as a different fault than the one being reported.
+        var line = DuplicateInstall.Name(new[] { "/a/SSO-Auth.dll", string.Empty });
+
+        Assert.Equal("(unnamed) AND /a/SSO-Auth.dll", line);
+    }
+
+    [Fact]
+    public void WithNoDuplicate_ItSaysNothing()
+    {
+        var logger = new CapturingLogger();
+
+        DuplicateInstall.Announce(DuplicateInstall.Decide(Array.Empty<string>(), null, Noon), logger);
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public void WithADuplicate_ItNamesBothDirectoriesAndTheCopy()
+    {
+        // The line IS the repair instruction: an admin told there are two copies but not where they are
+        // has been told half of it, and one told nothing about the copy cannot restore from it.
+        WithConfigurationFile(path =>
+        {
+            var logger = new CapturingLogger();
+            var state = DuplicateInstall.Decide(TwoCopies, path, Noon);
+
+            DuplicateInstall.Announce(state, logger);
+
+            var entry = Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Error, entry.Level);
+            Assert.Contains(TwoCopies[0], entry.Message, StringComparison.Ordinal);
+            Assert.Contains(TwoCopies[1], entry.Message, StringComparison.Ordinal);
+            Assert.Contains(state.PreservedCopyPath!, entry.Message, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void WithADuplicateAndNoCopyTaken_ItSaysThatToo()
+    {
+        // The negative disclosure. An operator told a copy exists when none does looks for a file that is
+        // not there, on the one path where the file is the only thing left.
+        var logger = new CapturingLogger();
+
+        DuplicateInstall.Announce(DuplicateInstall.Decide(TwoCopies, null, Noon), logger);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+        Assert.Contains("NO copy of the configuration was kept", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WithErrorLoggingOff_ItBuildsNoLine()
+    {
+        // The line is composed from paths, so it costs something to build, and it is written from a plugin
+        // constructor on a server that may have the sink turned down. The level is asked before the
+        // arguments are touched, and a sink that is off gets nothing rather than a formatted entry it
+        // discards.
+        var logger = new SilentLogger();
+
+        DuplicateInstall.Announce(DuplicateInstall.Decide(TwoCopies, null, Noon), logger);
+
+        Assert.Empty(logger.Records);
+    }
+
+    [Fact]
+    public void ALoggerThatThrowsCostsTheLineAndNotTheLoad()
+    {
+        // This runs inside a plugin constructor. Anything that escapes it fails the plugin load and takes
+        // every SSO login on the server offline, and the one failure realistic here is the log sink itself
+        // going down with the same full disk that caused the fault.
+        DuplicateInstall.Announce(DuplicateInstall.Decide(TwoCopies, null, Noon), new ThrowingLogger());
+    }
+
+    private sealed class SilentLogger : ILogger
+    {
+        internal List<string> Records { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Records.Add(formatter(state, exception));
+    }
+
+    private sealed class ThrowingLogger : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => throw new IOException("the sink is on the disk that just filled up");
+    }
+
+    private static string[] Copies(string configurationFilePath) =>
+        Directory
+            .EnumerateFiles(
+                Path.GetDirectoryName(configurationFilePath)!,
+                Path.GetFileName(configurationFilePath) + DuplicateInstall.CopySuffix + "*")
+            .ToArray();
+
+    private static void WithConfigurationFile(Action<string> test)
+    {
+        var directory = SuiteTempFiles.Path("sso-duplicate", string.Empty);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "SSO-Auth.xml");
+        File.WriteAllText(
+            path,
+            "<PluginConfiguration><OidConfigs><item><key>authentik</key></item></OidConfigs></PluginConfiguration>");
+        try
+        {
+            test(path);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Best effort, as SuiteTempFiles does it: a directory that would not go must not turn a
+                // green suite red on the way out.
+            }
+        }
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1126,4 +1126,38 @@ internal static class SsoAudit
     internal static void UnreadableConfigurationCleared(ILogger logger)
         => logger.LogWarning(
             "[SSO Audit] A configuration holding at least one provider was persisted; the server stops serving defaults and SSO sign-in is accepted again. The preserved copy of the unreadable file is left where it is.");
+
+    /// <summary>
+    /// Records a second copy of this plugin loaded into the same server (#1601), which costs the
+    /// configuration unless somebody removes one of them.
+    /// </summary>
+    /// <remarks>
+    /// It NAMES THE FILES, because the remedy is to delete a directory and an operator who is told there
+    /// are two copies but not where they are has been told half of it. The preserved copy is named for the
+    /// same reason the unreadable-configuration line names its own: it is the only artefact a repair can
+    /// work on, and a copy that could not be taken is stated rather than elided.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="installLocations">The file each loaded copy came from.</param>
+    /// <param name="preservedCopyPath">Where the configuration was copied, or <see langword="null"/> when it was not.</param>
+    internal static void DuplicateInstallFound(ILogger logger, string installLocations, string? preservedCopyPath)
+    {
+        if (!logger.IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
+        if (preservedCopyPath is null)
+        {
+            logger.LogError(
+                "[SSO Audit] This plugin is loaded TWICE in this server, from {InstallLocations}, and NO copy of the configuration was kept. Two copies register every route twice, so the settings page answers nothing, and the host cannot read a configuration back across them - it serves defaults and writes them over the file, destroying every provider it holds. Every configuration write from this plugin is refused while this lasts. Stop the server, keep exactly ONE plugin directory for this plugin under the plugins folder, delete the others, and start it again. A downgrade through the plugin catalog is what usually leaves two: it adds the older version beside the newer one instead of replacing it.",
+                installLocations.ReplaceLineEndings(string.Empty));
+            return;
+        }
+
+        logger.LogError(
+            "[SSO Audit] This plugin is loaded TWICE in this server, from {InstallLocations}. The configuration was copied to {PreservedCopy} first, and that copy is what to restore from. Two copies register every route twice, so the settings page answers nothing, and the host cannot read a configuration back across them - it serves defaults and writes them over the file. Every configuration write from this plugin is refused while this lasts. Stop the server, keep exactly ONE plugin directory for this plugin under the plugins folder, delete the others, start it again, and put the copy back over SSO-Auth.xml if the providers are gone from it. A downgrade through the plugin catalog is what usually leaves two: it adds the older version beside the newer one instead of replacing it.",
+            installLocations.ReplaceLineEndings(string.Empty),
+            preservedCopyPath.ReplaceLineEndings(string.Empty));
+    }
 }

--- a/SSO-Auth/Config/DuplicateInstall.cs
+++ b/SSO-Auth/Config/DuplicateInstall.cs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.Loader;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// What <see cref="DuplicateInstall.Detect"/> found: whether a second copy of this plugin is loaded into
+/// the same server, where the copies are, and where the configuration was put for safekeeping.
+/// </summary>
+/// <param name="IsDuplicated">Whether more than one copy of this assembly is live in this process.</param>
+/// <param name="Locations">The file each loaded copy came from, one entry per copy.</param>
+/// <param name="PreservedCopyPath">Where the configuration was copied, or <see langword="null"/> when it was not.</param>
+internal readonly record struct DuplicateInstallState(
+    bool IsDuplicated,
+    ReadOnlyCollection<string> Locations,
+    string? PreservedCopyPath);
+
+/// <summary>
+/// Notices that a second copy of this plugin is loaded into the same server, and saves the configuration
+/// before that costs it (#1601).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A downgrade through the plugin catalog does not replace the installed version. It adds a second
+/// directory beside it, and Jellyfin 12.0 loads BOTH at the next start. Two copies of this assembly are
+/// then live at once, and three things follow. Every route this plugin registers matches twice, so the
+/// admin surface answers <c>AmbiguousMatchException</c> and shows nothing. The configuration type exists
+/// twice, so a value produced by one copy cannot be cast to the other and the round-trip fails with
+/// <c>InvalidCastException: PluginConfiguration cannot be cast to PluginConfiguration</c>. And the host,
+/// unable to read a configuration back, hands out defaults and writes them over the file.
+/// </para>
+/// <para>
+/// Measured on a live Jellyfin 12.0.0 with the published packages, downgrading and then going back up:
+/// <c>SSO-Auth.xml</c> went 3576 bytes with a provider, to 601 bytes with none, to 38 bytes. The provider
+/// data is destroyed on disk, and the copy the unreadable-configuration screen keeps (#1543) is taken
+/// after the overwrite, because the file was readable at the moment it was read - it was simply replaced
+/// afterwards.
+/// </para>
+/// <para>
+/// Nothing in this plugin can stop the host loading two copies of it, and nothing here can intercept the
+/// host's own write. What it CAN do is be early: this runs in the plugin constructor, before anything
+/// touches <c>Configuration</c> and therefore before the lazy load that ends in the overwrite. So the copy
+/// it takes is the last one made while the file still held the operator's providers.
+/// </para>
+/// <para>
+/// The DECISION is separated from the loader question on purpose (<see cref="Decide"/> against
+/// <see cref="Detect"/>). Which assemblies are loaded cannot be arranged in a test process without the
+/// test becoming a test of the loader, so that question is kept to a handful of lines and everything that
+/// acts on its answer is exercised directly.
+/// </para>
+/// </remarks>
+internal static class DuplicateInstall
+{
+    /// <summary>Marks a copy taken because a second install was found, distinct from the #1543 copies.</summary>
+    internal const string CopySuffix = ".before-duplicate-";
+
+    /// <summary>
+    /// Reports whether a second copy of this plugin is loaded, and preserves the configuration when one is.
+    /// </summary>
+    /// <param name="configurationFilePath">The host's configuration file path for this plugin.</param>
+    /// <param name="nowUtc">The clock, injected so the copy name is testable.</param>
+    /// <returns>What was found, and what was done about it.</returns>
+    internal static DuplicateInstallState Detect(string? configurationFilePath, DateTime nowUtc)
+        => Decide(Locations(), configurationFilePath, nowUtc);
+
+    /// <summary>
+    /// Turns a list of loaded copies into the verdict, preserving the configuration when there is more
+    /// than one.
+    /// </summary>
+    /// <param name="locations">One entry per loaded copy of this assembly; an entry may be empty.</param>
+    /// <param name="configurationFilePath">The host's configuration file path for this plugin.</param>
+    /// <param name="nowUtc">The clock, which names the copy.</param>
+    /// <returns>What was found, and what was done about it.</returns>
+    internal static DuplicateInstallState Decide(
+        IReadOnlyList<string> locations,
+        string? configurationFilePath,
+        DateTime nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(locations);
+
+        var seen = new ReadOnlyCollection<string>(locations.ToList());
+        if (seen.Count < 2)
+        {
+            return new DuplicateInstallState(false, seen, null);
+        }
+
+        return new DuplicateInstallState(true, seen, Preserve(configurationFilePath, nowUtc));
+    }
+
+    /// <summary>
+    /// Copies the configuration aside, once.
+    /// </summary>
+    /// <remarks>
+    /// An existing copy is handed back rather than joined by a second one, and that is the point rather
+    /// than tidiness: a server in this state boots again and again, and by the second boot the file on disk
+    /// is already the empty one the host wrote. The oldest copy is the only one worth having. Internal so
+    /// the rule can be exercised without arranging a second loaded assembly.
+    /// </remarks>
+    /// <param name="configurationFilePath">The file to copy.</param>
+    /// <param name="nowUtc">The clock, which names the copy.</param>
+    /// <returns>The copy, an earlier copy if one exists, or <see langword="null"/> when none was made.</returns>
+    internal static string? Preserve(string? configurationFilePath, DateTime nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(configurationFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(configurationFilePath);
+            if (string.IsNullOrEmpty(directory) || !File.Exists(configurationFilePath))
+            {
+                return null;
+            }
+
+            var earlier = Directory
+                .EnumerateFiles(directory, Path.GetFileName(configurationFilePath) + CopySuffix + "*")
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (earlier is not null)
+            {
+                return earlier;
+            }
+
+            // overwrite: false is the guarantee. Two instances of this plugin in one process reach here
+            // within the same second and compose the same name; one wins the copy and the other is refused
+            // and answers null, which leaves exactly one copy either way.
+            var copy = configurationFilePath + CopySuffix
+                + nowUtc.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture) + "Z";
+            File.Copy(configurationFilePath, copy, overwrite: false);
+            return copy;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Says what was found, once, at the volume the consequence deserves.
+    /// </summary>
+    /// <param name="state">What <see cref="Detect"/> or <see cref="Decide"/> returned.</param>
+    /// <param name="logger">The logger.</param>
+    internal static void Announce(DuplicateInstallState state, ILogger logger)
+    {
+        if (!state.IsDuplicated)
+        {
+            return;
+        }
+
+        try
+        {
+            SsoAudit.DuplicateInstallFound(logger, Name(state.Locations), state.PreservedCopyPath);
+        }
+#pragma warning disable CA1031, RCS1075 // an announcement that cannot be made costs the line and never the load
+        catch (Exception)
+#pragma warning restore CA1031, RCS1075
+        {
+        }
+    }
+
+    /// <summary>
+    /// Renders the loaded copies for the one line an operator acts on.
+    /// </summary>
+    /// <remarks>
+    /// Deduplicated HERE and not in the verdict: the count is what decides, and two copies loaded from one
+    /// path are still two identities, so collapsing them earlier would hide the fault this exists to
+    /// report. A copy with no file behind it is named as such rather than dropped, because a line listing
+    /// one path for a fault about two would read as a different fault.
+    /// </remarks>
+    /// <param name="locations">One entry per loaded copy.</param>
+    /// <returns>A single line naming the copies.</returns>
+    internal static string Name(IReadOnlyList<string> locations)
+    {
+        ArgumentNullException.ThrowIfNull(locations);
+
+        return string.Join(
+            " AND ",
+            locations
+                .Select(path => string.IsNullOrEmpty(path) ? "(unnamed)" : path)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal));
+    }
+
+    // The one question that can only be asked of the running process. Assembly INSTANCES are what is
+    // counted, because the fault is two type identities; a dynamic assembly has no file and is named as an
+    // empty entry rather than skipped, so the count still matches the copies. An enumeration that throws -
+    // contexts do load while this runs - answers "nothing found" rather than guessing: a false negative
+    // leaves the server as it was, and a false positive would refuse every configuration write on a server
+    // with nothing wrong with it.
+    private static IReadOnlyList<string> Locations()
+    {
+        try
+        {
+            var self = typeof(DuplicateInstall).Assembly.GetName().Name;
+            return AssemblyLoadContext.All
+                .SelectMany(context => context.Assemblies)
+                .Where(assembly => string.Equals(assembly.GetName().Name, self, StringComparison.Ordinal))
+                .Select(assembly => assembly.IsDynamic ? string.Empty : assembly.Location)
+                .ToList();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -94,6 +94,29 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
             ServingDefaultConfiguration = false;
         }
 
+        // #1601, and it belongs beside the screen above rather than after it for the same reason: the
+        // moment before anything reads Configuration is the only moment the file on disk is still the
+        // operator's. Two copies of this plugin loaded at once make the host unable to read a
+        // configuration back across them, and its answer is to serve defaults and write them over the
+        // file. This cannot prevent that write. What it does is take the copy first, and then refuse
+        // every write of our own so the plugin adds nothing to the damage.
+        // Order against the screen above does not matter - neither touches Configuration - and it is
+        // second only because the screen has to stay the first thing this constructor does.
+        // Wrapped for the reason everything on this path is: a check that throws would fail the plugin
+        // load, and the state it exists to report is one an operator repairs by hand anyway.
+        try
+        {
+            var duplicated = DuplicateInstall.Detect(ConfigurationFilePath, DateTime.UtcNow);
+            LoadedMoreThanOnce = duplicated.IsDuplicated;
+            DuplicateInstall.Announce(duplicated, logger);
+        }
+#pragma warning disable CA1031, RCS1075 // a check that could not run must not be the reason the plugin does not load
+        catch (Exception)
+#pragma warning restore CA1031, RCS1075
+        {
+            LoadedMoreThanOnce = false;
+        }
+
         // Handing out `() => Configuration` here is safe: BasePlugin's constructor only records the
         // config path and loads the configuration lazily on first access, so nothing calls back into
         // UpdateConfiguration (and thus ConfigStore) before this assignment completes.
@@ -147,6 +170,15 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Gets the store that owns every configuration read and write (#318).
     /// </summary>
     internal ProviderConfigStore ConfigStore { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a second copy of this plugin is loaded into this server (#1601).
+    /// While it is set, every configuration write from this plugin is refused: the two copies cannot
+    /// round-trip a configuration between them, and a write attempted anyway is how the providers on disk
+    /// get replaced by defaults. Set once, in the constructor, and never cleared - the repair is to remove
+    /// a plugin directory and restart, which this process does not survive to see.
+    /// </summary>
+    internal bool LoadedMoreThanOnce { get; }
 
     /// <summary>
     /// Gets a value indicating whether the stored configuration could not be read at start, so what is
@@ -286,6 +318,18 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     // saving a provider, importing one, or removing the marker, which is what the banner says.
     private void PersistBase(BasePluginConfiguration configuration)
     {
+        // FIRST, before the type check below and before anything reaches the base class (#1601). With two
+        // copies of this plugin loaded, that check is itself part of the fault: a configuration produced
+        // by the other copy is not this copy's PluginConfiguration, so it falls through to the base class
+        // unchanged and the host writes it - which is the shape that empties the file. Refusing loudly
+        // costs the caller a 500 on a server whose SSO routes are already ambiguous and answering nothing;
+        // writing costs the operator every provider they have.
+        if (LoadedMoreThanOnce)
+        {
+            throw new InvalidOperationException(
+                "This plugin is loaded twice in this server, so its configuration cannot be written without destroying it. Keep exactly one plugin directory for this plugin under the plugins folder, delete the others, and restart the server. The plugin log names the directories and where the configuration was copied.");
+        }
+
         if (configuration is not PluginConfiguration incoming)
         {
             // Not this plugin's configuration type, so there is nothing to encrypt and nothing this


### PR DESCRIPTION
Closes #1601.

**What happens without this.** A downgrade through the plugin catalog does not replace
the installed version. It adds a second directory beside it, and Jellyfin 12.0 loads
both at the next start. Two copies of this assembly are live at once: every route
registers twice, the configuration type exists twice, and the host, unable to read a
configuration back across them, serves defaults and writes them over the file.

Measured on a live Jellyfin 12.0.0 with the published packages, following the reporter's
sequence:

```
before                  3576 bytes, provider present
downgrade to .75         601 bytes, no provider
back up to .80            38 bytes, no provider
```

The unreadable-configuration screen from #1543 does not catch this, and was never going
to. The file is readable at the moment it is read and is replaced afterwards, so the copy
that screen keeps is a copy of the empty version.

**What this does.** It cannot stop the host loading two copies, and it cannot intercept
the host's own write. It can be early. The check runs in the plugin constructor, before
anything touches `Configuration` and therefore before the lazy load that ends in the
overwrite, so the copy it takes is the file as the operator left it. At most one copy per
configuration file, first one wins: a server in this state boots again and again, and
every later boot would copy a file that is already empty.

Then it refuses. `PersistBase` is the one road to disk, and the refusal goes at the top of
it, before the configuration type check. That order is the fix and not a detail: a
configuration produced by the other loaded copy is not this copy's `PluginConfiguration`,
so the type check does not match it and hands it to the base class unchanged, which is the
write that empties the file. A refusal after it would never run on the shape that does the
damage. Both orderings are pinned by rules rather than by comment, because neither is
visible from the lines it separates.

Detection counts assembly instances rather than distinct paths, because the fault is two
type identities and two copies loaded from one path would still be two. An enumeration
that throws answers "nothing found" rather than guessing: a false negative leaves the
server as it was, a false positive would refuse every configuration write on a healthy
server. That direction is asserted rather than assumed.

**Proof, on the live server rather than in argument.** The published .81 installed through
the catalog, a provider configured, the published .75 installed over it the way the
reporter did it, and this build in the active directory:

```
[SSO Audit] This plugin is loaded TWICE in this server, from
  /config/plugins/Community SSO for Jellyfin_5.0.0.75/SSO-Auth.dll AND
  /config/plugins/Community SSO for Jellyfin_5.0.0.81/SSO-Auth.dll.
The configuration was copied to ... first, and that copy is what to restore from.

live SSO-Auth.xml                              601 bytes, no provider
SSO-Auth.xml.before-duplicate-20260910-115546Z 3576 bytes, provider present
```

Restoring that copy with the second directory removed brings the provider back and the
plugin up Active. Without this change the same sequence leaves nothing to restore from.

**Tests.** Five over the copy rule, including that a second boot keeps the first copy
rather than burying it, and that a process holding one copy reports no duplicate. Two
conformance rules over the two orderings. Full suite green.

**What is still owed.** Two copies of one plugin loading at once is a Jellyfin behaviour
and belongs upstream as its own report. This is the plugin refusing to add to the damage,
not a repair of the host.
