### PR TITLE
Draw the library checklists on Jellyfin 12, and stop a list that did not draw from clearing a restriction [#1607]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,6 +64,15 @@ jobs:
       # (#1572). This runs the shipped sso-core.js against the shipped serverPage.html and refuses each
       # arm by name. Same runtime and same absence of dependencies as the step above.
       run: node tools/ui-unsaved-state.js
+    - name: Library checklists on both client shapes
+      # The two steps above read the assets or drive the unsaved-changes state; neither can say whether a
+      # LIST DRAWS, and that is where #1607 sat. `createElement("input", { is: ... })` is correct on 10.11
+      # and throws on the Jellyfin 12 client, which registers no emby-* customized built-in and refuses the
+      # options argument outright, so the provider page's library checklists came up empty on a server with
+      # libraries and the next save wrote that emptiness over the provider's folder restriction. This runs
+      # the shipped sso-core.js against both client shapes and refuses each arm by name. Same runtime and
+      # same absence of dependencies as the two steps above.
+      run: node tools/ui-folder-checklist.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/SSO-Auth/Web/linking.js
+++ b/SSO-Auth/Web/linking.js
@@ -207,11 +207,17 @@ const ssoConfigLinking = {
 
       // The canonical name is identity-provider-controlled - assigning it via dataset/textContent
       // (never innerHTML) keeps a hostile linked-account name inert on this page.
-      // createElement's `is` option upgrades the customized built-in; the attribute is set as well
-      // so CSS attribute selectors and the web-components polyfill see it.
-      const checkbox = document.createElement("input", {
-        is: "emby-checkbox",
-      });
+      // The `is` option upgrades the customized built-in where the client accepts it. The Jellyfin 12
+      // client refuses that argument outright and throws for any value (#1607), which would take this
+      // list the way it took the provider page's library checklists, so the construction falls back to
+      // the attribute alone. The attribute is set either way, so CSS attribute selectors and the
+      // web-components polyfill see it.
+      let checkbox;
+      try {
+        checkbox = document.createElement("input", { is: "emby-checkbox" });
+      } catch {
+        checkbox = document.createElement("input");
+      }
       checkbox.setAttribute("is", "emby-checkbox");
       checkbox.classList.add("sso-link-checkbox");
       checkbox.type = "checkbox";

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -16,6 +16,22 @@ function tr(key, englishDefault, params) {
 // this module's bookkeeping and not a fact about the page.
 const pageBaselines = new WeakMap();
 
+// Builds a customized built-in the way BOTH clients accept (#1607). The options form is what upgrades
+// the element on 10.11, and the Jellyfin 12 client REFUSES that argument outright: createElement throws
+// `t.toLowerCase is not a function` for any `is` value, a registered name and an invented one alike, and
+// that client registers no emby-* element at all. The throw landed before the first row existed, so every
+// library checklist on the provider page came up empty and a save then wrote the empty set over the
+// provider's folder restriction. The fallback carries the `is` attribute, which both clients take and
+// which every call site sets on the next line anyway; what it gives up on 10.11 is nothing, because the
+// upgrading form is tried first and only a client that refuses it ever reaches the second line.
+function customizedBuiltIn(tag, is) {
+  try {
+    return document.createElement(tag, { is });
+  } catch {
+    return document.createElement(tag);
+  }
+}
+
 // Settles a promise without deciding anything about it. Used where a load has to WAIT for a request
 // whose failure it deliberately does not act on - the checklist fills the baseline waits for, and the
 // configuration read of a refresh, which leaves the page showing what it last read.
@@ -1422,12 +1438,20 @@ const ssoConfigurationPage = {
       e.checked = folder_list.includes(e.dataset.id);
     });
   },
+  // NO ROWS IS NOT AN EMPTY SELECTION (#1607). An administrator who clears the list leaves the rows on
+  // screen and unticked; a container holding no rows at all is one the fill never reached - the client
+  // refused the row construction, or Library/MediaFolders did not answer. Writing that as "no libraries"
+  // while EnableAllFolders is off is the save this file already names as the worst outcome on this
+  // surface, in the refresh guards above: SessionMinter then writes the empty set on every login and
+  // every user of the provider loses library access at their next sign-in. So the two cases are told
+  // apart here and the caller decides; null means the question could not be answered.
   serializeEnabledFolders: (container) => {
-    return [...container.querySelectorAll(".folder-checkbox")]
-      .filter((e) => e.checked)
-      .map((e) => {
-        return e.dataset.id;
-      });
+    const rows = [...container.querySelectorAll(".folder-checkbox")];
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return rows.filter((e) => e.checked).map((e) => e.dataset.id);
   },
   populateFolders: (container) => {
     return ApiClient.getJSON(
@@ -1457,9 +1481,10 @@ const ssoConfigurationPage = {
       // emby-checkbox upgrade to add it; otherwise folder IDs could be duplicated on re-populate.
       out.classList.add("emby-checkbox-label");
 
-      // createElement's `is` option upgrades the customized built-in; the attribute is set as well
-      // so CSS attribute selectors and the web-components polyfill see it.
-      const checkbox = document.createElement("input", { is: "emby-checkbox" });
+      // The `is` option upgrades the customized built-in where the client accepts it, and is refused
+      // outright on Jellyfin 12 (#1607) - see customizedBuiltIn. The attribute is set either way, so
+      // CSS attribute selectors and the web-components polyfill see it.
+      const checkbox = customizedBuiltIn("input", "emby-checkbox");
       checkbox.setAttribute("is", "emby-checkbox");
       checkbox.classList.add("folder-checkbox", "chkFolder");
       checkbox.type = "checkbox";
@@ -1543,9 +1568,14 @@ const ssoConfigurationPage = {
         const role = elem.querySelector(".sso-role-mapping-name").value;
         const checklist = elem.querySelector(".sso-folder-list");
 
+        // A row whose checklist never drew is written as the empty set rather than skipped (#1607).
+        // The two are different failures and the smaller one is chosen deliberately: an empty mapping
+        // grants that role no libraries, which the administrator sees on the row in front of them,
+        // while dropping the row would silently delete a mapping they never touched.
         out.push({
           Role: role,
-          Folders: ssoConfigurationPage.serializeEnabledFolders(checklist),
+          Folders:
+            ssoConfigurationPage.serializeEnabledFolders(checklist) || [],
         });
       },
     );
@@ -2955,8 +2985,13 @@ const ssoConfigurationPage = {
 
           form_elements.folder_list_fields.forEach((id) => {
             const elem = page.querySelector(`#${id}`);
-            current_config[id] =
-              ssoConfigurationPage.serializeEnabledFolders(elem);
+            const folders = ssoConfigurationPage.serializeEnabledFolders(elem);
+            // A checklist that never drew leaves the stored restriction alone rather than replacing it
+            // with nothing (#1607). The key is left off the object entirely, so the stored value is what
+            // the server keeps; assigning null here would be the same destructive write in another shape.
+            if (folders !== null) {
+              current_config[id] = folders;
+            }
           });
 
           form_elements.role_map_fields.forEach((id) => {

--- a/tools/ui-folder-checklist.js
+++ b/tools/ui-folder-checklist.js
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Refuses, by name, the two ways the provider page's library checklists have
+ * failed (#1607).
+ *
+ * WHY THIS RUNS THE SHIPPED FILE. Every C# rule over these assets reads their
+ * TEXT, so none of them can say what the checklist DOES, and the fault here was
+ * not visible in the text at all: `document.createElement("input", { is: ... })`
+ * is correct on Jellyfin 10.11 and throws on Jellyfin 12, whose client registers
+ * no emby-* customized built-in and whose createElement refuses the options
+ * argument outright - for a registered name and an invented one alike. The throw
+ * landed before the first row existed, so the checklist came up empty on a server
+ * with four libraries, and a save then wrote that emptiness over the provider's
+ * folder restriction. Nothing short of running the builder against a client that
+ * refuses the argument can tell the two clients apart.
+ *
+ * WHAT IT DOES NOT DO. It does not model a browser. The stub below is the
+ * smallest DOM the two functions under test touch: createElement in both client
+ * shapes, a class list, a dataset, textContent, append/appendChild, remove, and
+ * class-selector lookup. Everything under test is the shipped function.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-mock-fields.js and tools/ui-unsaved-state.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CORE = path.join(HERE, "..", "SSO-Auth", "Web", "sso-core.js");
+
+const FOLDERS = {
+  Items: [
+    { Id: "7a2175bccb1f1a94152cbd2b2bae8f6d", Name: "Filme" },
+    { Id: "8a05b0252259a1dbd62df97522638439", Name: "Musik" },
+    { Id: "9c3186ccd370b2ece73ef08633749540", Name: "Serien" },
+  ],
+};
+
+class Classes {
+  constructor(owner) {
+    this.owner = owner;
+    this.set = new Set();
+  }
+  add(...names) {
+    names.forEach((name) => this.set.add(name));
+  }
+  remove(...names) {
+    names.forEach((name) => this.set.delete(name));
+  }
+  contains(name) {
+    return this.set.has(name);
+  }
+}
+
+class Element {
+  constructor(tag) {
+    this.tag = tag;
+    this.type = "";
+    this.checked = false;
+    this.textContent = "";
+    this.dataset = {};
+    this.attributes = {};
+    this.children = [];
+    this.parent = null;
+    this.classList = new Classes(this);
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  append(...nodes) {
+    nodes.forEach((node) => this.appendChild(node));
+  }
+
+  appendChild(node) {
+    node.parent = this;
+    this.children.push(node);
+    return node;
+  }
+
+  remove() {
+    if (!this.parent) {
+      return;
+    }
+    const at = this.parent.children.indexOf(this);
+    if (at >= 0) {
+      this.parent.children.splice(at, 1);
+    }
+    this.parent = null;
+  }
+
+  /** Every descendant, this node excluded, in document order. */
+  descendants() {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+
+  querySelectorAll(selector) {
+    if (!selector.startsWith(".")) {
+      throw new Error("the stub resolves class selectors only: " + selector);
+    }
+    const wanted = selector.slice(1);
+    return this.descendants().filter((node) => node.classList.contains(wanted));
+  }
+}
+
+/**
+ * A `document` in one of the two client shapes.
+ *
+ * `refusesTheIsOption` is Jellyfin 12: createElement throws the moment a second
+ * argument is passed, whatever it names. The message is the one that client
+ * actually raises, so a reader who greps for it finds this file.
+ */
+function documentFor(refusesTheIsOption) {
+  let optionsSeen = 0;
+  return {
+    optionsAccepted: () => optionsSeen,
+    createElement(tag, options) {
+      if (options !== undefined) {
+        if (refusesTheIsOption) {
+          throw new TypeError("t.toLowerCase is not a function");
+        }
+        optionsSeen += 1;
+      }
+      return new Element(tag);
+    },
+  };
+}
+
+async function loadCore() {
+  const source = fs.readFileSync(CORE, "utf8");
+  const url =
+    "data:text/javascript;base64," +
+    Buffer.from(source, "utf8").toString("base64");
+  return (await import(url)).default;
+}
+
+function rowsOf(container) {
+  return container.querySelectorAll(".folder-checkbox");
+}
+
+async function main() {
+  const core = await loadCore();
+  const faults = [];
+  const refuse = (leg, detail) => faults.push(leg + ": " + detail);
+
+  // ---- The two client shapes draw the same three rows ----
+  for (const [name, refuses] of [
+    ["jellyfin-12", true],
+    ["jellyfin-10.11", false],
+  ]) {
+    const doc = documentFor(refuses);
+    globalThis.document = doc;
+    const container = new Element("div");
+
+    try {
+      core._populateFolders(container, FOLDERS);
+    } catch (error) {
+      refuse(
+        name,
+        "building the checklist threw, so the list stays empty on a server that has libraries: " +
+          String((error && error.message) || error),
+      );
+      continue;
+    }
+
+    const rows = rowsOf(container);
+    if (rows.length !== FOLDERS.Items.length) {
+      refuse(
+        name,
+        `the checklist drew ${rows.length} rows for ${FOLDERS.Items.length} libraries`,
+      );
+      continue;
+    }
+
+    const unmarked = rows.filter(
+      (row) => row.getAttribute("is") !== "emby-checkbox",
+    );
+    if (unmarked.length > 0) {
+      refuse(
+        name,
+        `${unmarked.length} rows carry no is="emby-checkbox", so the client cannot style or upgrade them`,
+      );
+    }
+
+    const ids = rows.map((row) => row.dataset.id);
+    if (ids.join(",") !== FOLDERS.Items.map((f) => f.Id).join(",")) {
+      refuse(
+        name,
+        "the rows do not carry the library ids they were built from",
+      );
+    }
+
+    if (!refuses && doc.optionsAccepted() === 0) {
+      refuse(
+        name,
+        "the upgrading form was never tried on a client that accepts it, so 10.11 loses the upgrade",
+      );
+    }
+  }
+
+  // Everything below presupposes a builder that returns rows. Reporting the shape faults and stopping
+  // here is what keeps the refusal readable: without it the first unguarded call throws again, and the
+  // message an operator reads is a stack trace through a base64 data URL rather than the sentence above.
+  if (faults.length > 0) {
+    faults.forEach((fault) => console.error("REFUSED  " + fault));
+    process.exit(1);
+  }
+
+  // ---- A second fill replaces the rows rather than doubling them ----
+  {
+    globalThis.document = documentFor(true);
+    const container = new Element("div");
+    core._populateFolders(container, FOLDERS);
+    core._populateFolders(container, FOLDERS);
+
+    if (rowsOf(container).length !== FOLDERS.Items.length) {
+      refuse(
+        "refill",
+        `a second fill left ${rowsOf(container).length} rows for ${FOLDERS.Items.length} libraries, so ids are duplicated`,
+      );
+    }
+  }
+
+  // ---- No rows is not an empty selection ----
+  {
+    globalThis.document = documentFor(true);
+
+    const empty = new Element("div");
+    if (core.serializeEnabledFolders(empty) !== null) {
+      refuse(
+        "never-drew",
+        "a checklist that never drew serialized as a library set, which is the write that " +
+          "clears a provider's folder restriction and costs its users their access at the next sign-in",
+      );
+    }
+
+    const drawn = new Element("div");
+    core._populateFolders(drawn, FOLDERS);
+    const none = core.serializeEnabledFolders(drawn);
+    if (none === null || none.length !== 0) {
+      refuse(
+        "cleared",
+        "a drawn checklist with nothing ticked did not serialize as an empty set, so an " +
+          "administrator cannot clear a restriction: " +
+          JSON.stringify(none),
+      );
+    }
+
+    rowsOf(drawn)[1].checked = true;
+    const one = core.serializeEnabledFolders(drawn);
+    if (!Array.isArray(one) || one.join(",") !== FOLDERS.Items[1].Id) {
+      refuse(
+        "ticked",
+        "a ticked row did not serialize as its library id: " +
+          JSON.stringify(one),
+      );
+    }
+  }
+
+  delete globalThis.document;
+
+  if (faults.length > 0) {
+    faults.forEach((fault) => console.error("REFUSED  " + fault));
+    process.exit(1);
+  }
+
+  console.log("The library checklist holds on both client shapes.");
+  console.log(
+    "  jellyfin-12      a client that refuses the createElement `is` option still gets its rows",
+  );
+  console.log(
+    "  jellyfin-10.11   a client that accepts it is still handed the upgrading form",
+  );
+  console.log(
+    "  refill           a second fill replaces the rows rather than doubling the ids",
+  );
+  console.log(
+    "  never-drew       a checklist that never drew is not serialized as an empty library set",
+  );
+  console.log(
+    "  cleared/ticked   a drawn checklist still says what the administrator ticked",
+  );
+}
+
+main().catch((error) => {
+  console.error(String((error && error.stack) || error));
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #1607, and it is the gap the reporter on #1601 ran into before the downgrade.

**What was broken.** Each library row is built with a customized built-in:

```js
document.createElement("input", { is: "emby-checkbox" })
```

Correct on Jellyfin 10.11. On the Jellyfin 12 client it throws, because that client
registers no `emby-*` customized built-in at all and refuses the options argument
outright:

```
customElements.get('emby-checkbox')                        false
document.createElement('input', {is: 'emby-checkbox'})     TypeError: t.toLowerCase is not a function
document.createElement('input', {is: 'anything-at-all'})   TypeError: t.toLowerCase is not a function
input.setAttribute('is', 'emby-checkbox')                  ok
```

The throw landed before the first row existed, so every library checklist came up
empty on a server that has libraries.

**What it cost.** Open a provider restricted to two libraries, press Save, change
nothing else:

```
before   EnabledFolders: 2 entries    EnableAllFolders: false
after    <EnabledFolders />           EnableAllFolders: false
```

That pairing is the one this file already calls the worst outcome on this surface:
the empty set is written on every login while all-folders is off, and every user of
the provider loses library access at their next sign-in. Adding a Folder Role Mapping
row had the same hole from the other side, with a Role field and no library to tick.

**Both halves, and neither is enough alone.** The construction tries the upgrading
form and falls back to the attribute, which both clients accept and which every call
site sets on the next line anyway. Nothing is given up on 10.11, because the options
form is tried first. The same construction on the account-linking page is carried the
same way.

And no rows is no longer read as an empty selection. An administrator who clears the
list leaves the rows on screen, unticked; a container with no rows at all is one the
fill never reached. The provider save path now leaves the stored restriction alone
instead of replacing it with nothing, and a role-mapping row whose checklist did not
draw is written as the empty set rather than skipped, which is stated where it is
chosen.

**Verification.** `tools/ui-folder-checklist.js` runs the shipped `sso-core.js`
against both client shapes and refuses each arm by name, dependency-free and gated in
CI beside the two harnesses it sits with. Both halves were checked against the
unfixed code before being trusted:

```
construction reverted   REFUSED  jellyfin-12: building the checklist threw, so the list stays empty
serializer reverted     REFUSED  never-drew: a checklist that never drew serialized as a library set
```

On the live Jellyfin 12.0 server with the built plugin in place: three rows drawn with
the two stored libraries ticked, a save that leaves both in the file, and a
role-mapping row offering all three libraries.
