### PR TITLE
Name the redirect URI in a refused authorization request [#1610]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ChallengeRefusal.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ChallengeRefusal.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rule for what a refused authorization request tells the administrator (#1610).
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    [Fact]
+    public void TheChallengeRefusalNamesTheRedirectUriItSent()
+    {
+        // The provider's answer to a redirect URI it does not have registered is a bare code and a message
+        // that names nothing: `invalid_request - Failed to push authorization parameters` is the whole of
+        // it. With pushed authorization on, that exchange is server to server, so the administrator never
+        // reaches the provider's own error page, which is the only place the URL would otherwise appear.
+        //
+        // Measured, on a live Pocket ID 2.14.0 reproducing #1608: the provider logged
+        // `fosite.MatchRedirectURIWithClientRedirectURIs` on its side and returned nothing but the code on
+        // ours, and the difference between the two URIs was one scheme. Registering the right callback
+        // turned the same login into 201 from the push and 302 from the plugin.
+        //
+        // A source rule rather than a behaviour test on purpose. Reaching this branch needs a provider whose
+        // discovery succeeds and whose authorize preparation then fails, which is a fake identity provider
+        // stood up for one log line. What the rule protects is the property that costs when it is absent -
+        // the string being in the message - and that is visible in the text.
+        var source = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Api", "Flows", "OidcLoginService.cs"));
+
+        var line = source
+            .Split('\n')
+            .Select(candidate => candidate.TrimEnd('\r'))
+            .FirstOrDefault(candidate =>
+                candidate.Contains("preparing the authorization request failed", StringComparison.Ordinal)
+                && candidate.Contains("LogWarning", StringComparison.Ordinal));
+
+        Assert.True(
+            line is not null,
+            "The challenge refusal is logged in OidcLoginService and this rule is written against it (#1610).");
+
+        Assert.True(
+            line!.Contains("{RedirectUri}", StringComparison.Ordinal),
+            "The refused-challenge line names the redirect URI it sent (#1610), because the provider's own "
+            + "answer names nothing and the administrator cannot reach the page that would. This line does "
+            + "not: " + line.Trim());
+
+        Assert.True(
+            line.Contains("redirectUri?.ReplaceLineEndings(string.Empty).Replace('[', '(')", StringComparison.Ordinal),
+            "The redirect URI is composed from the request's host header, so it carries both sanitizers "
+            + "inline at the call like every other foreign value this tree logs (#1557). This line does "
+            + "not: " + line.Trim());
+    }
+}

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -276,7 +276,17 @@ internal sealed class OidcLoginService
             // the user-facing error page. Sanitized against log forging. Fail-closed is unchanged (400).
             if (_logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: preparing the authorization request failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.Error?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.ErrorDescription?.ReplaceLineEndings(string.Empty).Replace('[', '('));
+                // IT NAMES THE REDIRECT URI (#1610). The provider's answer here is a bare code and a
+                // message that names nothing - `invalid_request - Failed to push authorization parameters`
+                // is the whole of it when the refusal is a URI the provider does not have registered - and
+                // with pushed authorization on, that exchange is server to server, so the administrator
+                // never reaches the provider's own error page where the URL WOULD be named. The plugin
+                // composed this string from the incoming request; withholding it here sent one reporter
+                // (#1608) through disabling pushed authorization, retrying, reading the provider's page and
+                // turning it back on, to learn a scheme this line already held.
+                // Sanitized both ways like everything beside it: the URI is composed from the request's
+                // host header, which is not this server's to vouch for.
+                _logger.LogWarning("OpenID login refused for provider {Provider}: preparing the authorization request failed ({Error} - {ErrorDescription}). The redirect URI sent was {RedirectUri}, which the provider must have registered exactly as written - scheme, host, port and path.", provider?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.Error?.ReplaceLineEndings(string.Empty).Replace('[', '('), state.ErrorDescription?.ReplaceLineEndings(string.Empty).Replace('[', '('), redirectUri?.ReplaceLineEndings(string.Empty).Replace('[', '('));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login.");


### PR DESCRIPTION
Closes #1610. Comes out of #1608, where a login failed for one character of scheme and
the plugin said nothing that could be compared against anything.

**What it looked like.** The provider refuses a redirect URI it does not have
registered, and what it returns is the code and nothing else:

```
[ERR] Duende.IdentityModel.OidcClient.AuthorizeClient: Failed to push authorization parameters
[WRN] SSOController: OpenID login refused for provider lea-id: preparing the authorization
      request failed (invalid_request - Failed to push authorization parameters).
```

The plugin composed the URI from the incoming request, so it holds the string the whole
time. With pushed authorization on the exchange is server to server, so the
administrator never reaches the provider's own error page, which is the only other
place the URL appears. Getting to it in #1608 meant disabling pushed authorization,
retrying, reading the provider's page and turning it back on.

**Reproduced** on a live Pocket ID 2.14.0 against a Jellyfin 12.0. The provider's side
of the same refusal:

```
ERR Failed to create pushed authorize request  error="invalid_request
  fosite.MatchRedirectURIWithClientRedirectURIs
  pocket-id/internal/oidc.matchRedirectURI (provider.go:131)
  fosite.(*Fosite).NewPushedAuthorizeRequest"
```

Registering the right callback turned the same login into `201` from the push and `302`
from the plugin.

**The change.** The line carries the URI and says what has to be true of it: registered
exactly as written, scheme, host, port and path. "It does not match" is the finding;
"which part" is the work, and the administrator is the only one who can do it. Both
sanitizers inline at the call, as for every foreign value here - the URI is composed
from the request's host header.

**SAML is not changed.** Its refusals at this tier are capacity refusals, not a provider
rejecting a composed address, so there is no sibling line to widen. A SAML consumer URL
that does not match is refused at the identity provider, where it can be read.

**A source rule rather than a behaviour test**, and the reason is in it: reaching this
branch needs a provider whose discovery succeeds and whose authorize preparation then
fails, which is a fake identity provider stood up for one log line. Checked against the
unfixed line before being trusted - removing the URI refuses, and so does removing
either sanitizer from its argument.
