### PR TITLE
Send each OpenID scope once instead of repeating the base [#1612]

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerScopeStringTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerScopeStringTests.cs
@@ -16,6 +16,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// challenge (<c>OidScopes.Prepend</c> on null) and null-padded the callback scope string
 /// (<c>new string[2]</c> → trailing separators). The builder normalizes null to empty so both sides
 /// emit the same clean, base-prefixed string.
+/// And #1612: the base is a UNION with what is configured, not a prefix in front of it. The cases below
+/// that carry <c>openid</c> or <c>profile</c> in the configuration are the ordinary ones - it is what every
+/// provider template here and the wiki tell an administrator to enter - and until #1612 they were the only
+/// shape this file did not cover, which is how every login on every installation came to ask twice.
 /// </summary>
 public class SSOControllerScopeStringTests
 {
@@ -65,5 +69,54 @@ public class SSOControllerScopeStringTests
         var config = new OidConfig { OidScopes = new[] { "", " ", null } };
 
         Assert.Equal("openid profile", OidcLoginService.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void TheConfiguredBase_IsNotRepeated()
+    {
+        // What every wiki page and every provider template in this repository tells an administrator to
+        // enter. Before #1612 this went out as "openid profile openid profile email".
+        var config = new OidConfig { OidScopes = new[] { "openid", "profile", "email" } };
+
+        Assert.Equal("openid profile email", OidcLoginService.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void AScopeRepeatedInTheConfiguration_IsCarriedOnce()
+    {
+        var config = new OidConfig { OidScopes = new[] { "email", "groups", "email" } };
+
+        Assert.Equal("openid profile email groups", OidcLoginService.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void TheBaseStillLeads_WhenTheConfigurationOrdersItLater()
+    {
+        // openid missing is not an OpenID request, so its position is the builder's to decide and not the
+        // stored order's. A configuration naming it last still gets it first, and only once.
+        var config = new OidConfig { OidScopes = new[] { "email", "openid" } };
+
+        Assert.Equal("openid profile email", OidcLoginService.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void SeveralScopesTypedIntoOneEntry_BecomeSeveralScopes()
+    {
+        // The field takes a list, and an administrator who pasted a space-delimited scope string into one
+        // row of it meant several scopes. Splitting is also what keeps that row from smuggling a repeat of
+        // the base past the union.
+        var config = new OidConfig { OidScopes = new[] { "openid profile email", "groups" } };
+
+        Assert.Equal("openid profile email groups", OidcLoginService.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void ScopeComparisonIsCaseSensitive()
+    {
+        // Scope values are case-sensitive in the specification, so these are two scopes. Collapsing them
+        // would be this builder deciding something about a provider it does not know.
+        var config = new OidConfig { OidScopes = new[] { "Email", "email" } };
+
+        Assert.Equal("openid profile Email email", OidcLoginService.BuildScopeString(config));
     }
 }

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -86,6 +86,11 @@ internal sealed class OidcLoginService
     // live inside; see OidcStateStore). One process-wide instance, like the SAML caches the controller keeps.
     private static readonly OidcStateStore StateStore = new();
 
+    // The two scopes every OpenID request carries whatever the provider is configured with. Separate
+    // tokens rather than one "openid profile" string, so the union below can see that a configured
+    // "openid" is the same scope and not a different one (#1612).
+    private static readonly string[] BaseScopes = { "openid", "profile" };
+
     // The shared login-completion tail (#160): resolve/adopt the link, build the session parameters, mint
     // under the revocation gate, audit, map to a LoginOutcome. Both protocols funnel their verified identity
     // into it, so it is a shared collaborator this service holds a reference to rather than owning.
@@ -662,16 +667,49 @@ internal sealed class OidcLoginService
     // doubled or trailing separator (#407). Shared by both sites.
 
     /// <summary>
-    /// Builds the space-delimited OpenID scope string, always leading with the base "openid profile" and
-    /// dropping null/empty/whitespace entries so a persisted bad scope cannot inject a doubled or trailing
-    /// separator (#407) or throw on a provider stored without scopes (#368).
+    /// Builds the space-delimited OpenID scope string, always leading with the base scopes and carrying
+    /// each further scope once.
     /// </summary>
-    /// <param name="config">The provider configuration whose <c>OidScopes</c> are appended.</param>
+    /// <remarks>
+    /// <para>
+    /// The base leads because <c>openid</c> missing is not an OpenID request at all, and that is worth
+    /// guaranteeing rather than trusting to a stored value. It is a UNION and not a prepend (#1612): every
+    /// provider template this plugin ships, and the wiki, tell an administrator to configure
+    /// <c>openid profile email</c>, so prepending sent <c>openid profile openid profile email</c> on every
+    /// login of every installation. Servers read scope as a set and accepted it, which is why it stood; what
+    /// it cost was the authorize URL and the provider's audit log saying this plugin asks twice, and a
+    /// server that validates the parameter rather than parsing it answering <c>invalid_scope</c> with a
+    /// message as opaque as the one #1608 arrived with.
+    /// </para>
+    /// <para>
+    /// Entries are split on whitespace before the union, so an administrator who typed several scopes into
+    /// one field gets each of them once rather than one nonsense token. Null, empty and whitespace entries
+    /// are dropped, which is what keeps a persisted bad scope from injecting a doubled or trailing
+    /// separator (#407) and a provider stored without scopes from throwing (#368). Comparison is ordinal:
+    /// scope values are case-sensitive, so <c>Email</c> and <c>email</c> are two scopes and collapsing them
+    /// would be this method deciding something about a provider it does not know.
+    /// </para>
+    /// </remarks>
+    /// <param name="config">The provider configuration whose <c>OidScopes</c> join the base.</param>
     /// <returns>The normalized scope string.</returns>
     internal static string BuildScopeString(OidConfig config)
-        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>())
-            .Where(s => !string.IsNullOrWhiteSpace(s))
-            .Prepend("openid profile"));
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var scopes = new List<string>();
+
+        foreach (var scope in BaseScopes
+            .Concat(config?.OidScopes ?? Array.Empty<string>())
+            .Where(entry => !string.IsNullOrWhiteSpace(entry))
+            .SelectMany(entry => entry!.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)))
+        {
+            if (seen.Add(scope))
+            {
+                scopes.Add(scope);
+            }
+        }
+
+        return string.Join(" ", scopes);
+    }
 
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place - a Dictionary read-during-write is


### PR DESCRIPTION
Closes #1612. Found while reproducing #1608, unrelated to that login failure.

**What went out.** The scope builder led with `openid profile` and appended the stored
scopes verbatim. Every provider template here, and the wiki, tell an administrator to
configure `openid profile email`, so every login of every installation sent:

```
scope = openid profile openid profile email
```

Read off the authorize redirect of a live login against Pocket ID 2.14.0, and on the
wire again after this change:

```
scope = openid profile email
```

**Why it is worth fixing rather than tolerating.** Servers read scope as a set, which is
why this stood. The cost is elsewhere: it is in the URL of every login and in the
provider's audit log for every login, where anyone reading either sees this plugin
asking twice; and a server that validates the parameter rather than parsing it answers
`invalid_scope`, which would reach an administrator as opaque as the message #1608
arrived with.

**The change.** The base is a union with what is configured rather than a prefix in front
of it, and it still leads. That is deliberate: `openid` missing is not an OpenID request,
so its presence and its position are the builder's to guarantee and not the stored
order's. Entries are split on whitespace first, so a row holding a pasted
space-delimited string becomes several scopes rather than one nonsense token, and cannot
smuggle a repeat of the base past the union. Comparison is ordinal, because scope values
are case-sensitive and collapsing `Email` into `email` would be this builder deciding
something about a provider it does not know.

The null, empty and whitespace handling that #407 and #368 put there is unchanged, and
those tests are untouched.

**Five cases added**, and the first is the one that was missing: a configuration naming
`openid` and `profile`. That is the ordinary shape, it is what the documentation asks
for, and it was the only shape a test file written about this exact method did not
cover. Which is how a repeat on every login of every installation went unnoticed.
