### PR TITLE
Stop a long identifier setting the width of the provider page [#1615]

### DIFF
--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -578,3 +578,22 @@
 .sso-check-list > li[data-state="bad"]::before {
   content: "\26A0";
 }
+
+/* A LONG IDENTIFIER MAY NOT SET THE WIDTH OF THE PAGE (#1615). The help texts carry claim paths, type
+   names, URL templates and JSON fragments inline, and several of them have no break opportunity in them
+   at all: `Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider` is 66 characters of dots
+   and letters. With `white-space: normal` such a token cannot wrap, so it sets its line's width, and the
+   line sets the page's. Measured on a live Jellyfin 12.0 at a 375 viewport with a provider open in the
+   editor: `document.body.scrollWidth` was 448 on that one string, and the horizontal scroll it produced
+   was on the BODY, so every other control on the page moved with it.
+
+   The rule is on the two containers rather than on the five tokens that are long today, because the next
+   provider template brings more and nobody would remember. Breaking ANYWHERE rather than at the usual
+   opportunities is deliberate: these are strings to be read exactly and copied, not prose, so a break
+   mid-token costs nothing a reader relies on - and the copy button on the field beside them is what an
+   administrator actually uses. The stylesheet already takes the same decision for the provider card name
+   and the editor title above; this is the same problem arriving through the help text. */
+.fieldDescription code,
+.sso-callout code {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Closes #1615. Found by walking the five settings pages at a 375 wide viewport rather
than by reading them.

**What it looked like.** With a provider open in the editor, the page scrolled sideways.
One element did it:

```
Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider   431px, in a 375px viewport
```

66 characters of dots and letters, inline in `code` inside a help text. With
`white-space: normal` it cannot wrap, so it sets its line's width and the line sets the
page's. The scroll it produced was on the **body**, so every other control on the page
moved with it.

**Measured**, same page and same width, before and after:

```
before   document.body.scrollWidth 448, one element past the right edge
after    document.body.scrollWidth 375, none
```

**The rule is on the containers, not the tokens.** The provider page carries 26 inline
`code` elements, all under `div.fieldDescription` or `div.sso-callout`, and five are long
enough to matter today:

```
431  Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider
343  {"jellyfin-access": {"<orgId>": "<domain>"}}
232  <this URL>/sso/OID/redirect/<ProviderName>
219  https://example.com/@{user_id}.png
212  urn:zitadel:iam:org:project:roles
```

Every one is a string somebody has to read exactly, so shortening them is not on the
table, and the next provider template brings more. Breaking anywhere rather than at the
usual opportunities is deliberate: these are strings to copy, not prose, so a break
mid-token costs a reader nothing, and the copy button on the field beside them is what an
administrator uses. The stylesheet already takes the same decision for the provider card
name and the editor title.

**The rest of the walk was clean.** Overview, Providers without an editor, Accounts,
Policies and Server all show no overflow at 375 and nothing clipped behind
`overflow: hidden`, and the tab strip wraps to two rows as #1603 intended rather than
scrolling invisibly. It is the editor, where the help texts live, that carried this.
