### PR TITLE
Pin how many sentences bypass the translation catalog, and take the first eleven [#1602]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,6 +73,15 @@ jobs:
       # the shipped sso-core.js against both client shapes and refuses each arm by name. Same runtime and
       # same absence of dependencies as the two steps above.
       run: node tools/ui-folder-checklist.js
+    - name: Sentences that bypass the translation catalog
+      # de.json and en.json carry the same keys and nothing is missing from either, so every check the
+      # localization has is green while a de-DE administrator reads a page that is half English (#1602). A
+      # sentence written as a literal in the bundle never reaches a catalog, so it cannot be reported as
+      # absent from something it was never in - the gap is invisible to a completeness check by
+      # construction. This pins the COUNT instead, and refuses it moving either way: up is the drift, and
+      # down without lowering the pin leaves slack the next one hides in. Same runtime and same absence of
+      # dependencies as the three steps above.
+      run: node tools/ui-untranslated.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -214,5 +214,16 @@
   "config.server_settings_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts gespeichert und keiner der beiden Schalter geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.provider_removed": "Anbieter entfernt.",
   "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
-  "config.config_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut."
+  "config.config_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
+  "config.validation_required": "{label} ist erforderlich.",
+  "config.validation_endpoint_required": "Der OpenID-Endpunkt ist erforderlich.",
+  "config.validation_endpoint_absolute": "Geben Sie eine absolute URL an, z. B. https://id.example.com",
+  "config.validation_endpoint_insecure": "Verwendet http://, die Erkundung liefe also unverschlüsselt. Bevorzugen Sie einen https://-Endpunkt.",
+  "config.validation_endpoint_https": "Verwenden Sie für den OpenID-Endpunkt eine https://-URL.",
+  "config.validation_base_origin_only": "Geben Sie einen vollständigen Ursprung an, z. B. https://jellyfin.example.com (nur Schema und Host).",
+  "config.validation_base_origin": "Geben Sie einen vollständigen Ursprung an, z. B. https://jellyfin.example.com",
+  "config.validation_base_no_path": "Geben Sie nur die Basis-URL ohne Pfad an, z. B. https://jellyfin.example.com, nicht die /sso/...-Rückleitungsadresse.",
+  "config.validation_name_required": "Ein Anbietername ist erforderlich.",
+  "config.validation_name_control_chars": "Entfernen Sie Steuerzeichen aus dem Namen, etwa Tabulator oder Zeilenumbruch, die beim Kopieren oft hineingeraten.",
+  "config.validation_name_reserved": "Entfernen Sie den umgekehrten Schrägstrich und die URI-reservierten Zeichen (\\ / ? # %) aus dem Namen."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -214,5 +214,16 @@
   "config.server_settings_read_failed": "Could not read the stored configuration, so nothing was saved and neither switch was changed. Reload the page and try again.",
   "config.provider_removed": "Provider removed.",
   "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
-  "config.config_read_failed": "Could not read the stored configuration, so nothing was changed. Reload the page and try again."
+  "config.config_read_failed": "Could not read the stored configuration, so nothing was changed. Reload the page and try again.",
+  "config.validation_required": "{label} is required.",
+  "config.validation_endpoint_required": "OpenID Endpoint is required.",
+  "config.validation_endpoint_absolute": "Enter an absolute URL, e.g. https://id.example.com",
+  "config.validation_endpoint_insecure": "Uses http://, so discovery would be unencrypted. Prefer an https:// endpoint.",
+  "config.validation_endpoint_https": "Use an https:// URL for the OpenID endpoint.",
+  "config.validation_base_origin_only": "Enter a full origin such as https://jellyfin.example.com (scheme + host only).",
+  "config.validation_base_origin": "Enter a full origin such as https://jellyfin.example.com",
+  "config.validation_base_no_path": "Enter the base URL only (no path), e.g. https://jellyfin.example.com, not the /sso/... redirect URI.",
+  "config.validation_name_required": "A provider name is required.",
+  "config.validation_name_control_chars": "Remove control characters (such as a tab or newline, often introduced by copy-paste) from the name.",
+  "config.validation_name_reserved": "Remove backslash and URI-reserved characters (\\ / ? # %) from the name."
 }

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -1000,7 +1000,9 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.setFieldError(
       page,
       id,
-      value ? "" : label + " is required.",
+      value
+        ? ""
+        : tr("config.validation_required", "{label} is required.", { label }),
     );
   },
   validateEndpoint: (page) => {
@@ -1009,7 +1011,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidEndpoint",
-        "OpenID Endpoint is required.",
+        tr(
+          "config.validation_endpoint_required",
+          "OpenID Endpoint is required.",
+        ),
       );
       return;
     }
@@ -1020,7 +1025,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidEndpoint",
-        "Enter an absolute URL, e.g. https://id.example.com",
+        tr(
+          "config.validation_endpoint_absolute",
+          "Enter an absolute URL, e.g. https://id.example.com",
+        ),
       );
       return;
     }
@@ -1028,7 +1036,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidEndpoint",
-        "Uses http://, so discovery would be unencrypted. Prefer an https:// endpoint.",
+        tr(
+          "config.validation_endpoint_insecure",
+          "Uses http://, so discovery would be unencrypted. Prefer an https:// endpoint.",
+        ),
       );
       return;
     }
@@ -1036,7 +1047,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidEndpoint",
-        "Use an https:// URL for the OpenID endpoint.",
+        tr(
+          "config.validation_endpoint_https",
+          "Use an https:// URL for the OpenID endpoint.",
+        ),
       );
       return;
     }
@@ -1056,7 +1070,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "BaseUrlOverride",
-        "Enter a full origin such as https://jellyfin.example.com (scheme + host only).",
+        tr(
+          "config.validation_base_origin_only",
+          "Enter a full origin such as https://jellyfin.example.com (scheme + host only).",
+        ),
       );
       return;
     }
@@ -1064,7 +1081,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "BaseUrlOverride",
-        "Enter a full origin such as https://jellyfin.example.com",
+        tr(
+          "config.validation_base_origin",
+          "Enter a full origin such as https://jellyfin.example.com",
+        ),
       );
       return;
     }
@@ -1073,7 +1093,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "BaseUrlOverride",
-        "Enter the base URL only (no path), e.g. https://jellyfin.example.com, not the /sso/... redirect URI.",
+        tr(
+          "config.validation_base_no_path",
+          "Enter the base URL only (no path), e.g. https://jellyfin.example.com, not the /sso/... redirect URI.",
+        ),
       );
       return;
     }
@@ -1085,7 +1108,7 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidProviderName",
-        "A provider name is required.",
+        tr("config.validation_name_required", "A provider name is required."),
       );
       return;
     }
@@ -1099,7 +1122,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidProviderName",
-        "Remove control characters (such as a tab or newline, often introduced by copy-paste) from the name.",
+        tr(
+          "config.validation_name_control_chars",
+          "Remove control characters (such as a tab or newline, often introduced by copy-paste) from the name.",
+        ),
       );
       return;
     }
@@ -1109,7 +1135,10 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidProviderName",
-        "Remove backslash and URI-reserved characters (\\ / ? # %) from the name.",
+        tr(
+          "config.validation_name_reserved",
+          "Remove backslash and URI-reserved characters (\\ / ? # %) from the name.",
+        ),
       );
       return;
     }

--- a/tools/ui-untranslated.js
+++ b/tools/ui-untranslated.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Counts the English sentences the settings surface writes without going through
+ * the catalog, and refuses the number moving in either direction (#1602).
+ *
+ * WHY A COUNT AND NOT A REFUSAL. `de.json` and `en.json` carry the same 216 keys
+ * and nothing is missing from either, so every check the localization has is
+ * green while a `de-DE` administrator reads a page that is half English. The
+ * reason is not the catalogs: a sentence written as a literal in the bundle
+ * never reaches them, so it cannot be reported as absent from something it was
+ * never in. The gap is invisible to a completeness check by construction.
+ *
+ * What it is NOT invisible to is a count, and the count is what this pins. It
+ * refuses an increase, which is the drift - one more literal is one more
+ * sentence a translator will never see. It refuses a decrease too, which is not
+ * pedantry: a tranche that wraps ten of them and leaves the pin alone would let
+ * the next ten arrive unseen behind the slack it left. The pin moves in the same
+ * commit as the work, and that is what makes it a ratchet rather than a number.
+ *
+ * WHAT COUNTS. A double-quoted literal of twenty characters or more, opening
+ * with a capital and containing a space, that is not the English default of a
+ * `tr(...)` or `t(...)` call. That is deliberately coarse. It matches things
+ * that are not prose and misses prose written without a capital, and both are
+ * fine for a ratchet: what it has to be is STABLE, so the same tree always
+ * yields the same number and a change to the number is always a change somebody
+ * made.
+ *
+ * Comments are stripped character by character rather than line by line,
+ * because this file's siblings in `SSO-Auth/Web` carry paragraphs of reasoning
+ * with sentences in them, and a line-based strip would count the reasoning.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-mock-fields.js and tools/ui-unsaved-state.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, "..", "SSO-Auth", "Web");
+
+// The pinned count. It goes DOWN as sentences are wrapped, in the same commit
+// that wraps them, and it never goes up. 73 on 2026-09-10, over the six page
+// controllers and the core, after the first tranche below.
+const PINNED = 73;
+
+// Files that are not this plugin's prose: the vendored API client, and the
+// translator itself, which cannot translate through the thing it is.
+const SKIP = new Set(["jellyfin-apiClient.esm.min.js", "i18n.js"]);
+
+// Sentences that stay literal on purpose, each with the reason it cannot go
+// through the catalog. Matched on the exact text, and a stale entry - one no
+// file carries any more - is refused, so this list cannot quietly grant an
+// exemption to a sentence that has since changed.
+const EXEMPT = [
+  {
+    text:
+      "This settings page could not finish loading, so its controls will not do anything and " +
+      "nothing typed into them would be saved. Reload the page; if it keeps happening the plugin's " +
+      "assets are not being served, and the server log will say why.",
+    why:
+      "The bootstrap banner of the five page controllers. It is written exactly when the dynamic " +
+      "import of the core did not arrive, and the localization module is loaded by the core through " +
+      "the same route - so at the moment this sentence is needed there is no translator to ask. A " +
+      "catalog lookup here would fail in the same way the page just did.",
+  },
+];
+
+/** Replaces comment CONTENT with spaces, keeping every line and column in place. */
+function withoutComments(source) {
+  let out = "";
+  let index = 0;
+  let inLine = false;
+  let inBlock = false;
+  let quote = null;
+
+  while (index < source.length) {
+    const ch = source[index];
+    const two = source.slice(index, index + 2);
+
+    if (inLine) {
+      if (ch === "\n") {
+        inLine = false;
+        out += ch;
+      } else {
+        out += " ";
+      }
+      index += 1;
+    } else if (inBlock) {
+      if (two === "*/") {
+        inBlock = false;
+        out += "  ";
+        index += 2;
+      } else {
+        out += ch === "\n" ? "\n" : " ";
+        index += 1;
+      }
+    } else if (quote) {
+      out += ch;
+      if (ch === "\\") {
+        out += source[index + 1] ?? "";
+        index += 2;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      index += 1;
+    } else if (two === "//") {
+      inLine = true;
+      out += "  ";
+      index += 2;
+    } else if (two === "/*") {
+      inBlock = true;
+      out += "  ";
+      index += 2;
+    } else if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      out += ch;
+      index += 1;
+    } else {
+      out += ch;
+      index += 1;
+    }
+  }
+
+  return out;
+}
+
+const SENTENCE = /"([A-Z][^"]{19,})"/g;
+
+// The English default of a catalog call, in both spellings this tree uses: `tr(` is the
+// core's own wrapper, `t(` is what i18n.js exports and the linking page imports.
+const AS_DEFAULT = /\btr?\(\s*"[a-z0-9_.]+"\s*,\s*$/;
+
+/*
+ * Reads the WHOLE file rather than a line at a time, and that is not a detail. The
+ * formatter breaks a long catalog call across four lines, so the key sits on the line
+ * above its English default:
+ *
+ *     tr(
+ *       "config.validation_endpoint_https",
+ *       "Use an https:// URL for the OpenID endpoint.",
+ *     ),
+ *
+ * A line-based test sees only the sentence and calls a translated string untranslated.
+ * The first draft of this tool did exactly that, and its pinned baseline counted
+ * sentences that already went through the catalog - which the first tranche exposed by
+ * moving the number two instead of eleven.
+ */
+function findIn(file) {
+  const source = withoutComments(fs.readFileSync(file, "utf8"));
+  const found = [];
+
+  SENTENCE.lastIndex = 0;
+  let match;
+  while ((match = SENTENCE.exec(source)) !== null) {
+    const text = match[1];
+    if (!text.includes(" ")) {
+      continue;
+    }
+    // Anchored at the end, so it reads the text immediately before the literal, across
+    // any newlines and indentation the formatter put there.
+    if (AS_DEFAULT.test(source.slice(0, match.index))) {
+      continue;
+    }
+    const line = source.slice(0, match.index).split("\n").length;
+    found.push({ file: path.basename(file), line, text });
+  }
+
+  return found;
+}
+
+function main() {
+  const files = fs
+    .readdirSync(WEB)
+    .filter((name) => name.endsWith(".js") && !SKIP.has(name))
+    .sort()
+    .map((name) => path.join(WEB, name));
+
+  const all = files.flatMap(findIn);
+  const exemptTexts = new Set(EXEMPT.map((entry) => entry.text));
+  const counted = all.filter((entry) => !exemptTexts.has(entry.text));
+
+  const faults = [];
+
+  // A stale exemption is refused: an entry naming a sentence no file carries any
+  // more is an exemption nobody can see the effect of, and the next edit to that
+  // sentence would silently lose it.
+  const present = new Set(all.map((entry) => entry.text));
+  EXEMPT.filter((entry) => !present.has(entry.text)).forEach((entry) =>
+    faults.push(
+      `a stale exemption: no file carries "${entry.text.slice(0, 60)}..." any more, so remove it`,
+    ),
+  );
+
+  if (counted.length > PINNED) {
+    const byFile = new Map();
+    counted.forEach((entry) => {
+      byFile.set(entry.file, (byFile.get(entry.file) ?? 0) + 1);
+    });
+    faults.push(
+      `${counted.length} sentences bypass the catalog, ${counted.length - PINNED} more than the pinned ${PINNED}. ` +
+        `Wrap the new one in tr("<key>", "<English>") and add the key to en.json and de.json. Per file: ` +
+        [...byFile.entries()]
+          .map(([file, count]) => `${file} ${count}`)
+          .join(", "),
+    );
+  } else if (counted.length < PINNED) {
+    faults.push(
+      `${counted.length} sentences bypass the catalog, ${PINNED - counted.length} fewer than the pinned ${PINNED}. ` +
+        `That is the work going in the right direction - lower PINNED to ${counted.length} in this same commit, ` +
+        `so the slack cannot hide the next one that arrives.`,
+    );
+  }
+
+  if (faults.length > 0) {
+    faults.forEach((fault) => console.error("REFUSED  " + fault));
+    process.exit(1);
+  }
+
+  console.log(
+    `${counted.length} sentences still bypass the catalog, which is the pinned count.`,
+  );
+  console.log(
+    `  exempt   ${EXEMPT.length} sentence(s) stay literal on purpose, with the reason beside each`,
+  );
+  console.log(
+    `  scanned  ${files.length} files under SSO-Auth/Web, comments stripped`,
+  );
+}
+
+main();


### PR DESCRIPTION
First step on #1602, which stays open: the drift stops here and eleven of the sentences
are done.

**Why the existing checks see nothing.** `de.json` and `en.json` carry the same keys and
nothing is missing from either. A sentence written as a literal in the bundle never
reaches a catalog, so it cannot be reported as absent from something it was never in.
The gap is invisible to a completeness check by construction.

**What this pins.** `tools/ui-untranslated.js` counts the sentences that bypass the
catalog and refuses the number moving either way. Up is the drift. Down without lowering
the pin leaves slack for the next one to arrive in unseen, so the pin moves in the same
commit as the work.

**The first draft of that tool counted wrong, and the first tranche is what showed it.**
It tested each line on its own, and the formatter breaks a long catalog call across four
lines:

```js
tr(
  "config.validation_endpoint_https",
  "Use an https:// URL for the OpenID endpoint.",
),
```

Line by line that reads as untranslated. The draft pinned 135 on that basis. Wrapping
eleven strings then moved the number by two instead of eleven, which is the only reason
the error surfaced: 62 of the 135 had been through the catalog the whole time. Reading
the file whole gives **73**, and that is what is pinned.

**The eleven** are the field validation messages, which is where #1602 opens and the
sharpest end of it. The calm prose an administrator reads while nothing is wrong was
already translated; the sentences telling them what they did wrong were not.

**One sentence stays literal**, with the reason beside it in the tool: the bootstrap
banner the five page controllers write when the dynamic import of the core did not
arrive. The localization module comes through that same route, so at the moment that
sentence is needed there is no translator to ask. A stale exemption is refused.

**Proved on the rig.** With a `de` client, an invalid endpoint now answers

```
Geben Sie eine absolute URL an, z. B. https://id.example.com
```

where it answered English before.

**Still open on #1602:** the remaining 73, most of them the provider template
descriptions, which are a tranche of their own.
