### PR TITLE
Pin how many sentences bypass the translation catalog [#1602]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,6 +73,15 @@ jobs:
       # the shipped sso-core.js against both client shapes and refuses each arm by name. Same runtime and
       # same absence of dependencies as the two steps above.
       run: node tools/ui-folder-checklist.js
+    - name: Sentences that bypass the translation catalog
+      # de.json and en.json carry the same keys and nothing is missing from either, so every check the
+      # localization has is green while a de-DE administrator reads a page that is half English (#1602). A
+      # sentence written as a literal in the bundle never reaches a catalog, so it cannot be reported as
+      # absent from something it was never in - the gap is invisible to a completeness check by
+      # construction. This pins the COUNT instead, and refuses it moving either way: up is the drift, and
+      # down without lowering the pin leaves slack the next one hides in. Same runtime and same absence of
+      # dependencies as the three steps above.
+      run: node tools/ui-untranslated.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/tools/ui-untranslated.js
+++ b/tools/ui-untranslated.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Counts the English sentences the settings surface writes without going through
+ * the catalog, and refuses the number moving in either direction (#1602).
+ *
+ * WHY A COUNT AND NOT A REFUSAL. `de.json` and `en.json` carry the same 216 keys
+ * and nothing is missing from either, so every check the localization has is
+ * green while a `de-DE` administrator reads a page that is half English. The
+ * reason is not the catalogs: a sentence written as a literal in the bundle
+ * never reaches them, so it cannot be reported as absent from something it was
+ * never in. The gap is invisible to a completeness check by construction.
+ *
+ * What it is NOT invisible to is a count, and the count is what this pins. It
+ * refuses an increase, which is the drift - one more literal is one more
+ * sentence a translator will never see. It refuses a decrease too, which is not
+ * pedantry: a tranche that wraps ten of them and leaves the pin alone would let
+ * the next ten arrive unseen behind the slack it left. The pin moves in the same
+ * commit as the work, and that is what makes it a ratchet rather than a number.
+ *
+ * WHAT COUNTS. A double-quoted literal of twenty characters or more, opening
+ * with a capital and containing a space, that is not the English default of a
+ * `tr(...)` or `t(...)` call. That is deliberately coarse. It matches things
+ * that are not prose and misses prose written without a capital, and both are
+ * fine for a ratchet: what it has to be is STABLE, so the same tree always
+ * yields the same number and a change to the number is always a change somebody
+ * made.
+ *
+ * Comments are stripped character by character rather than line by line,
+ * because this file's siblings in `SSO-Auth/Web` carry paragraphs of reasoning
+ * with sentences in them, and a line-based strip would count the reasoning.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-mock-fields.js and tools/ui-unsaved-state.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, "..", "SSO-Auth", "Web");
+
+// The pinned count. It goes DOWN as sentences are wrapped, in the same commit
+// that wraps them, and it never goes up. 83 on 2026-09-10, over the six page
+// controllers and the core.
+const PINNED = 83;
+
+// Files that are not this plugin's prose: the vendored API client, and the
+// translator itself, which cannot translate through the thing it is.
+const SKIP = new Set(["jellyfin-apiClient.esm.min.js", "i18n.js"]);
+
+// Sentences that stay literal on purpose, each with the reason it cannot go
+// through the catalog. Matched on the exact text, and a stale entry - one no
+// file carries any more - is refused, so this list cannot quietly grant an
+// exemption to a sentence that has since changed.
+const EXEMPT = [
+  {
+    text:
+      "This settings page could not finish loading, so its controls will not do anything and " +
+      "nothing typed into them would be saved. Reload the page; if it keeps happening the plugin's " +
+      "assets are not being served, and the server log will say why.",
+    why:
+      "The bootstrap banner of the five page controllers. It is written exactly when the dynamic " +
+      "import of the core did not arrive, and the localization module is loaded by the core through " +
+      "the same route - so at the moment this sentence is needed there is no translator to ask. A " +
+      "catalog lookup here would fail in the same way the page just did.",
+  },
+];
+
+/** Replaces comment CONTENT with spaces, keeping every line and column in place. */
+function withoutComments(source) {
+  let out = "";
+  let index = 0;
+  let inLine = false;
+  let inBlock = false;
+  let quote = null;
+
+  while (index < source.length) {
+    const ch = source[index];
+    const two = source.slice(index, index + 2);
+
+    if (inLine) {
+      if (ch === "\n") {
+        inLine = false;
+        out += ch;
+      } else {
+        out += " ";
+      }
+      index += 1;
+    } else if (inBlock) {
+      if (two === "*/") {
+        inBlock = false;
+        out += "  ";
+        index += 2;
+      } else {
+        out += ch === "\n" ? "\n" : " ";
+        index += 1;
+      }
+    } else if (quote) {
+      out += ch;
+      if (ch === "\\") {
+        out += source[index + 1] ?? "";
+        index += 2;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      index += 1;
+    } else if (two === "//") {
+      inLine = true;
+      out += "  ";
+      index += 2;
+    } else if (two === "/*") {
+      inBlock = true;
+      out += "  ";
+      index += 2;
+    } else if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      out += ch;
+      index += 1;
+    } else {
+      out += ch;
+      index += 1;
+    }
+  }
+
+  return out;
+}
+
+const SENTENCE = /"([A-Z][^"]{19,})"/g;
+
+// The English default of a catalog call, in both spellings this tree uses: `tr(` is the
+// core's own wrapper, `t(` is what i18n.js exports and the linking page imports.
+const AS_DEFAULT = /\btr?\(\s*"[a-z0-9_.]+"\s*,\s*$/;
+
+/*
+ * Reads the WHOLE file rather than a line at a time, and that is not a detail. The
+ * formatter breaks a long catalog call across four lines, so the key sits on the line
+ * above its English default:
+ *
+ *     tr(
+ *       "config.validation_endpoint_https",
+ *       "Use an https:// URL for the OpenID endpoint.",
+ *     ),
+ *
+ * A line-based test sees only the sentence and calls a translated string untranslated.
+ * The first draft of this tool did exactly that, and its pinned baseline counted
+ * sentences that already went through the catalog - which the first tranche exposed by
+ * moving the number two instead of eleven.
+ */
+function findIn(file) {
+  const source = withoutComments(fs.readFileSync(file, "utf8"));
+  const found = [];
+
+  SENTENCE.lastIndex = 0;
+  let match;
+  while ((match = SENTENCE.exec(source)) !== null) {
+    const text = match[1];
+    if (!text.includes(" ")) {
+      continue;
+    }
+    // Anchored at the end, so it reads the text immediately before the literal, across
+    // any newlines and indentation the formatter put there.
+    if (AS_DEFAULT.test(source.slice(0, match.index))) {
+      continue;
+    }
+    const line = source.slice(0, match.index).split("\n").length;
+    found.push({ file: path.basename(file), line, text });
+  }
+
+  return found;
+}
+
+function main() {
+  const files = fs
+    .readdirSync(WEB)
+    .filter((name) => name.endsWith(".js") && !SKIP.has(name))
+    .sort()
+    .map((name) => path.join(WEB, name));
+
+  const all = files.flatMap(findIn);
+  const exemptTexts = new Set(EXEMPT.map((entry) => entry.text));
+  const counted = all.filter((entry) => !exemptTexts.has(entry.text));
+
+  const faults = [];
+
+  // A stale exemption is refused: an entry naming a sentence no file carries any
+  // more is an exemption nobody can see the effect of, and the next edit to that
+  // sentence would silently lose it.
+  const present = new Set(all.map((entry) => entry.text));
+  EXEMPT.filter((entry) => !present.has(entry.text)).forEach((entry) =>
+    faults.push(
+      `a stale exemption: no file carries "${entry.text.slice(0, 60)}..." any more, so remove it`,
+    ),
+  );
+
+  if (counted.length > PINNED) {
+    const byFile = new Map();
+    counted.forEach((entry) => {
+      byFile.set(entry.file, (byFile.get(entry.file) ?? 0) + 1);
+    });
+    faults.push(
+      `${counted.length} sentences bypass the catalog, ${counted.length - PINNED} more than the pinned ${PINNED}. ` +
+        `Wrap the new one in tr("<key>", "<English>") and add the key to en.json and de.json. Per file: ` +
+        [...byFile.entries()]
+          .map(([file, count]) => `${file} ${count}`)
+          .join(", "),
+    );
+  } else if (counted.length < PINNED) {
+    faults.push(
+      `${counted.length} sentences bypass the catalog, ${PINNED - counted.length} fewer than the pinned ${PINNED}. ` +
+        `That is the work going in the right direction - lower PINNED to ${counted.length} in this same commit, ` +
+        `so the slack cannot hide the next one that arrives.`,
+    );
+  }
+
+  if (faults.length > 0) {
+    faults.forEach((fault) => console.error("REFUSED  " + fault));
+    process.exit(1);
+  }
+
+  console.log(
+    `${counted.length} sentences still bypass the catalog, which is the pinned count.`,
+  );
+  console.log(
+    `  exempt   ${EXEMPT.length} sentence(s) stay literal on purpose, with the reason beside each`,
+  );
+  console.log(
+    `  scanned  ${files.length} files under SSO-Auth/Web, comments stripped`,
+  );
+}
+
+main();


### PR DESCRIPTION
First step on #1602, which stays open. This one stops the drift; the sentences themselves
follow in changes that carry a reader's name.

**Why the existing checks see nothing.** `de.json` and `en.json` carry the same 216 keys
and nothing is missing from either. A sentence written as a literal in the bundle never
reaches a catalog, so it cannot be reported as absent from something it was never in. The
gap is invisible to a completeness check by construction, and stays invisible however many
are added.

**What this pins.** The count, at 83, refusing the number moving either way. Up is the
drift. Down without lowering the pin leaves slack for the next one to arrive in unseen, so
the pin moves in the same commit as the work.

**The first draft counted wrong, and says so in its own comments.** It tested each line on
its own, and the formatter breaks a long catalog call across four lines:

```js
tr(
  "config.validation_endpoint_https",
  "Use an https:// URL for the OpenID endpoint.",
),
```

Line by line that reads as untranslated, and the draft pinned 135 on that basis, 52 of them
already through the catalog. It surfaced only because a trial tranche of eleven wraps moved
the number by two. Reading the file whole gives 83.

**One sentence stays literal**, with the reason beside it: the bootstrap banner the five
page controllers write when the dynamic import of the core did not arrive. The localization
module comes through that same route, so at the moment that sentence is needed there is no
translator to ask. A stale exemption is refused, so the list cannot quietly cover a
sentence that has since changed.

**Why the wraps are not here.** `EveryNonEnglishCatalog_HasExactlyTheEnglishKeySet` means a
new key cannot land in English alone, and a non-English catalogue ships when a person who
reads that language has read it (#1154), which the hygiene gate asks for by name. Writing
the German and vouching for my own reading of it is the one thing that rule exists to
prevent. Both guards are right and neither is worked around.

**Checked in both directions** before being trusted: adding one sentence refuses with the
file and the count, and taking the tree below the pin refuses with the number to lower it
to.
