### PR TITLE
Take the restart note off the settings surface, because it is false [#1573]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RestartClaim.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RestartClaim.cs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <content>
+/// Conformance rule for the restart claim the settings surface used to carry (#1573).
+/// </content>
+public partial class ArchitectureConformanceTests
+{
+    // The claim, in the two spellings this tree carried it in. A phrase list rather than the word
+    // "restart", because a restart is a real instruction in one place and the rule must not refuse it:
+    // the total-lockout recovery on the legacy page tells an administrator to stop Jellyfin, edit
+    // config.xml and restart, and that one is true - the flag is reconciled against the user database on
+    // startup, which is the whole point of that paragraph.
+    private static readonly string[] RestartClaims =
+    {
+        "requires a restart",
+        "restart of Jellyfin to take effect",
+        "restart Jellyfin to take effect",
+    };
+
+    [Fact]
+    public void NoServedAssetClaimsThatSavingNeedsARestart()
+    {
+        // #1573, and the reason it is a rule rather than a deletion is that the sentence was in the markup
+        // for years and reads as harmless. It is not harmless and it was not true.
+        //
+        // Nothing in this plugin holds a configuration snapshot: no field anywhere is of type
+        // PluginConfiguration, and the call sites either fetch the live object at the moment they need it
+        // or take it as a parameter. A save writes the file and then mutates that live object in place,
+        // so the next request reads the new value and there is no path by which it could read the old
+        // one. The one component that reaches into Jellyfin's own state - the login-page branding - is
+        // subscribed to the configuration-changed event rather than read once at startup. There is no
+        // setting on the restart side of the line.
+        //
+        // What the sentence cost is the half that makes this worth pinning: a Jellyfin restart drops every
+        // playing session and every connected client, and the footer asked for one after every save.
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth", "Web")))
+        {
+            var name = Path.GetFileName(file);
+            if (!name.EndsWith(".html", StringComparison.Ordinal)
+                && !name.EndsWith(".js", StringComparison.Ordinal)
+                && !name.EndsWith(".css", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var lineNumber = 0;
+            foreach (var line in File.ReadLines(file))
+            {
+                lineNumber++;
+                var claim = RestartClaims.FirstOrDefault(
+                    phrase => line.Contains(phrase, StringComparison.OrdinalIgnoreCase));
+                if (claim is null)
+                {
+                    continue;
+                }
+
+                // The reasoning left where the sentence was is allowed to quote it. A comment cannot
+                // reach an administrator, and a rule that refused the explanation would take the record
+                // of why the sentence is gone along with the sentence.
+                var trimmed = line.TrimStart();
+                if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith("*", StringComparison.Ordinal)
+                    || trimmed.StartsWith("/*", StringComparison.Ordinal)
+                    || InsideMarkupComment(file, lineNumber))
+                {
+                    continue;
+                }
+
+                offenders.Add(
+                    name + ":" + lineNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                    + ": " + line.Trim());
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "No served asset tells an administrator that a saved change needs a restart (#1573): a save "
+            + "mutates the live configuration in place and every reader takes it from there, while a "
+            + "Jellyfin restart drops every playing session on the server. These lines break that: "
+            + string.Join(" | ", offenders));
+    }
+
+    /// <summary>
+    /// Whether a line of an HTML file sits inside a markup comment.
+    /// </summary>
+    /// <remarks>
+    /// Counted rather than matched per line, because the reasoning this rule exempts is a paragraph and
+    /// the phrase it quotes is in the middle of it. An odd number of opened-and-not-closed comments before
+    /// the line means it is inside one.
+    /// </remarks>
+    /// <param name="file">The file to read.</param>
+    /// <param name="lineNumber">The one-based line to judge.</param>
+    /// <returns>True when that line is inside a markup comment.</returns>
+    private static bool InsideMarkupComment(string file, int lineNumber)
+    {
+        if (!file.EndsWith(".html", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var before = string.Join("\n", File.ReadLines(file).Take(lineNumber - 1));
+        var opened = before.Split("<!--").Length - 1;
+        var closed = before.Split("-->").Length - 1;
+        return opened > closed;
+    }
+}

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -170,9 +170,6 @@
                 <div class="collapseContent">
                   <p>
                     <i>Note:</i>
-                    Making changes to this configuration requires a restart of
-                    Jellyfin.
-                    <br />
                     <span data-i18n="config.username_normalization_note"
                       >A provider username carrying characters Jellyfin does not
                       accept in an account name is normalized before a new

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -2399,9 +2399,19 @@
 
                   <!-- Sticky save footer (Fitts): the primary action stays reachable at the bottom edge. -->
                   <div class="sso-save-footer">
-                    <div class="fieldDescription sso-restart-reminder">
-                      Saving requires a restart of Jellyfin to take effect.
-                    </div>
+                    <!--
+                      NO RESTART NOTE HERE, AND ITS ABSENCE IS THE DECISION (#1573). The footer used to
+                      say that saving requires a restart of Jellyfin to take effect. It does not, and the
+                      reading that settles it is on that issue: nothing in this plugin holds a
+                      configuration snapshot - no field anywhere is of that type, and the thirty-eight
+                      call sites fetch the live object at the moment they need it or take it as a
+                      parameter - while a save writes the file and then mutates that live object in
+                      place. The one component that reaches into Jellyfin's own state, the login-page
+                      branding, is subscribed to the configuration-changed event rather than read at
+                      startup. So there is no setting on the restart side of the line.
+                      What the sentence cost was not nothing: a Jellyfin restart drops every playing
+                      session and every connected client, and it was being asked for after every save.
+                    -->
                     <!--
                       The save outcome sits WITH the button (#1572), not in the editor header where it
                       used to. The footer is sticky, so this is on screen whenever the editor is; the
@@ -4111,9 +4121,19 @@
                   </div>
 
                   <div class="sso-save-footer">
-                    <div class="fieldDescription sso-restart-reminder">
-                      Saving requires a restart of Jellyfin to take effect.
-                    </div>
+                    <!--
+                      NO RESTART NOTE HERE, AND ITS ABSENCE IS THE DECISION (#1573). The footer used to
+                      say that saving requires a restart of Jellyfin to take effect. It does not, and the
+                      reading that settles it is on that issue: nothing in this plugin holds a
+                      configuration snapshot - no field anywhere is of that type, and the thirty-eight
+                      call sites fetch the live object at the moment they need it or take it as a
+                      parameter - while a save writes the file and then mutates that live object in
+                      place. The one component that reaches into Jellyfin's own state, the login-page
+                      branding, is subscribed to the configuration-changed event rather than read at
+                      startup. So there is no setting on the restart side of the line.
+                      What the sentence cost was not nothing: a Jellyfin restart drops every playing
+                      session and every connected client, and it was being asked for after every save.
+                    -->
                     <!--
                       The save outcome sits WITH the button (#1572), not in the editor header where it
                       used to. The footer is sticky, so this is on screen whenever the editor is; the

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -401,11 +401,6 @@
   background: rgba(20, 20, 20, 0.94);
 }
 
-.sso-restart-reminder {
-  flex: 1 1 auto;
-  margin: 0;
-}
-
 .sso-save-button {
   flex: 0 0 auto;
   min-width: 10em;


### PR DESCRIPTION
Closes #1573, taking the third of its three options - the one decided and recorded on the
issue on 2026-09-10.

**The claim.** The save footer told an administrator that saving requires a restart of
Jellyfin to take effect, on both provider editors, and the legacy page said it about the
configuration as a whole.

**It is false, and the reading is on the issue.** Nothing in this plugin holds a
configuration snapshot: no field anywhere is of type `PluginConfiguration`, and the
thirty-eight call sites either fetch the live object when they need it or take it as a
parameter. A save writes the file and then mutates that live object in place, so the next
request reads the new value. The one component that reaches into Jellyfin's own state, the
login-page branding, is subscribed to the configuration-changed event rather than read
once at startup. There is no setting on the restart side of the line.

**What it cost** is the half that makes this worth doing rather than tidying: a Jellyfin
restart drops every playing session and every connected client, and the footer asked for
one after every save.

**Nothing replaces it, and that is the vouch rule rather than a view about footers.** A new
sentence here needs a catalog key, a non-English catalogue cannot lag the English one, and
a catalogue ships when a person who reads that language has read it (#1154). A true
sentence about when a change takes effect is worth having and goes in with a reading, not
ahead of one. After a save the page still says `Settings saved.`, as it did before.

**The reasoning stays where the sentence was**, in the markup, because the next person to
find an empty spot in a save footer is owed the reason it is empty.

**One mention of the word survives on purpose:** the legacy page's total-lockout recovery,
which tells an administrator to stop Jellyfin, edit `config.xml` and restart. That one is
true - the flag is reconciled against the user database on startup. The rule added here is
a phrase list rather than the word, so it refuses the claim without refusing that.

**Measured** on a live Jellyfin 12.0 with the editor open:

```
footer height   109 -> 93
save button     737 -> 737
```

so what is gone is a line of text and not a layout. The rule was checked against the claim
coming back before being trusted.
