### PR TITLE
Close the other protocol editor when one is opened

### DIFF
--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -765,7 +765,24 @@ const ssoConfigurationPage = {
       list.appendChild(card);
     });
   },
+  // ONE WORKSPACE AT A TIME (#1527), and the two lines that enforce it are here and at showSamlEditor.
+  //
+  // This page carries two protocol editors side by side and each one has its own Save. Opening one while
+  // the other is open put BOTH on the screen, under a single page-wide unsaved-changes notice that cannot
+  // say which of the two it is about - so the reader is shown two buttons and told, once, that something
+  // is unsaved. Read off a live Jellyfin 12 during the stage-1 walk: an OpenID provider opened beside a
+  // SAML one gave a 21163px page carrying #SaveProvider and #saml-SaveProvider at the same time.
+  //
+  // CLOSING THE OTHER ONE RATHER THAN REFUSING TO OPEN THIS ONE, because opening an editor is ALREADY an
+  // act that discards: openProvider and addProvider both call resetEditor before they fill, so switching
+  // provider within a protocol drops whatever was typed and marks the page clean again. Crossing the
+  // protocol boundary is the same act and now behaves the same way, rather than being the one direction
+  // that quietly keeps a second form alive.
+  //
+  // Both editors ship in the same markup - providersPage.html is the only page that declares either - so
+  // the sibling lookup is as safe as the one on the line below it, and a page missing one is missing both.
   showEditor: (page) => {
+    ssoConfigurationPage.hideSamlEditor(page);
     page.querySelector("#sso-editor").hidden = false;
   },
   hideEditor: (page) => {
@@ -4347,7 +4364,9 @@ const ssoConfigurationPage = {
       list.appendChild(card);
     });
   },
+  // The other half of the one-workspace rule stated at showEditor (#1527).
   showSamlEditor: (page) => {
+    ssoConfigurationPage.hideEditor(page);
     page.querySelector("#saml-editor").hidden = false;
   },
   hideSamlEditor: (page) => {

--- a/tools/ui-unsaved-state.js
+++ b/tools/ui-unsaved-state.js
@@ -845,6 +845,53 @@ async function main() {
     }
   }
 
+  // ---- Arm: one workspace at a time, so the page never carries two Saves (#1527) ----
+  {
+    // The Providers page is the only one with two editors and the only one that can break stage 1's
+    // central promise of one Save per page. The walk found it doing exactly that: opening a SAML provider
+    // and then an OpenID one left both editors on the screen with a Save each. Both directions are asked,
+    // because the defect was symmetric and a fix applied to one show path only would pass a one-way test.
+    const page = providersPageFixture();
+    wire(core, page);
+    const oid = page.querySelector("#sso-editor");
+    const saml = page.querySelector("#saml-editor");
+    if (oid.hidden !== true || saml.hidden !== true) {
+      refuse(
+        "one-workspace",
+        "the fixture starts with an editor already open, so this arm proves nothing",
+      );
+    }
+
+    core.showSamlEditor(page);
+    core.showEditor(page);
+    if (saml.hidden !== true) {
+      refuse(
+        "one-workspace",
+        "opening the OpenID editor left the SAML one open, so the page carries two Save buttons under one unsaved-changes notice that cannot say which is which",
+      );
+    }
+    if (oid.hidden === true) {
+      refuse(
+        "one-workspace",
+        "the OpenID editor did not open at all, so closing its sibling cost the thing it was opened for",
+      );
+    }
+
+    core.showSamlEditor(page);
+    if (oid.hidden !== true) {
+      refuse(
+        "one-workspace",
+        "opening the SAML editor left the OpenID one open, which is the same two-Save page from the other direction",
+      );
+    }
+    if (saml.hidden === true) {
+      refuse(
+        "one-workspace",
+        "the SAML editor did not open at all, so closing its sibling cost the thing it was opened for",
+      );
+    }
+  }
+
   // ---- The managed set survives a failed read (#1589) ----
   //
   // WHAT THIS ARM CAN AND CANNOT SAY, and the bound is the same one this file's header states. It judges
@@ -1057,7 +1104,7 @@ async function main() {
   }
 
   console.log(
-    "unsaved state:     sixteen arms run against the shipped sso-core.js and the pages it serves",
+    "unsaved state:     seventeen arms run against the shipped sso-core.js and the pages it serves",
   );
   console.log(
     "  untouched        a page nobody typed into is clean, shows nothing, and its Save is open",
@@ -1106,6 +1153,9 @@ async function main() {
   );
   console.log(
     "  refresh-ordinary a save, delete or import still replaces the page whatever state it is in",
+  );
+  console.log(
+    "  one-workspace    opening either protocol editor closes the other, so one Save is on the page",
   );
   console.log(
     "  managed-report-failure a failed managed-set read keeps the last set it read and says it failed",


### PR DESCRIPTION
# What & why

The Providers page carries two protocol editors and each one has its own Save.
Opening one while the other was open left BOTH on the screen, under a single
page-wide unsaved-changes notice that cannot say which of the two it is about.
So the reader was shown two Save buttons and told, once, that something was
unsaved, on the page that has the most to save. That is stage 1's central
promise of one Save per page, broken where it matters most.

Measured on a live Jellyfin 12 during the stage-1 walk rather than reasoned from
the source: an OpenID provider opened beside a SAML one gave a 21163px page
carrying `#SaveProvider` and `#saml-SaveProvider` at the same time. The earlier
reading of this page said only one workspace is open at a time. It was wrong in
exactly one direction, which is why nothing here caught it.

Opening an editor now closes its sibling rather than refusing to open. That is
already what the page does INSIDE a protocol: `openProvider` and `addProvider`
both call `resetEditor` before they fill, so switching provider drops whatever
was typed and marks the page clean again. Crossing the protocol boundary is the
same act and behaves the same way now, instead of being the one direction that
quietly kept a second form alive. Both editors are declared by the same markup
and no other page declares either, so the sibling lookup is as safe as the one
beside it.

A note on the issue reference, written after the fact. This body set out to
carry no closing keyword, because merging #1571 shut the issue once before by
matching a number inside a sentence that denied it. The sentence explaining that
trap sprang it again: it spelled the keyword out loud next to the number, and
merging this closed the issue. The outcome is right, since the walk the issue
asks for is done and recorded there, but the lesson is sharper than it was. The
number and any form of the word cannot share a sentence, however the sentence is
meant.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Untouched. This changes which of two
      admin forms is on screen and no validation, no persistence and no login
      path.
- [x] No secrets logged; secrets are redacted on config export. Untouched.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Not applicable: none of the
      three is touched. The one property worth asking about is whether hiding a
      form can cause its values to be written, and it cannot: each Save reads
      only its own form, and each Save button lives inside the region that is
      hidden, so a hidden editor has no reachable write path.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      1 / PLAUSIBLE 0**. The finding is the defect this fixes, confirmed by
      reproduction on a live server before the change and re-measured after it.
      Disposition: FIX.
- [x] Log inputs from the IdP are sanitized inline at the log call. No logging
      in this change.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. One line in each of the two show paths, which are the
      single funnel all four open paths already go through.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and the new property is locked in.
      It is locked in `tools/ui-unsaved-state.js` rather than in C#, because the
      property is behavioural: a text rule matching a token passes on a file
      where the call it matched is in the wrong order. The arm asks both
      directions against the shipped `sso-core.js` and the shipped
      `providersPage.html`, and it was run against the unfixed file first, where
      it refused both directions.
- [x] Docs impact considered: no README or wiki change. The behaviour this adds
      is what the page already promised.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings.
- [x] `dotnet test` is green. 3869 on net9.0 and 3870 on net10.0, 0 failed.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Node gates: `ui-unsaved-state` seventeen arms, `ui-mock-fields` 123 of 123,
`ui-untranslated` 0 against a pinned 0, `ui-folder-checklist` both client
shapes.

## Notes

Walked on a live Jellyfin 12.0.0 with two OpenID providers and one SAML
provider, at 1440x900 and at 375x812, before and after.

```
375x812, Providers, after
  on load            no Save
  SAML opened        saml-SaveProvider         page  9557px
  then OpenID        SaveProvider              page 12630px
  then SAML again    saml-SaveProvider         page  9557px
  before: OpenID beside SAML gave both, page 21163px
```

Two things the same walk turned up that are not this change's and belong to
stage 3 (#1529), which already owns one language per view: 237 text nodes in
the five page templates carry no catalog marker, and a handful of sentences go
through `tr()` from code that runs during init, while the catalog is still
arriving, so they freeze at English and nothing retranslates them. The second
kind is invisible to `tools/ui-untranslated.js` by construction, since it counts
a `tr()` call as translated. Both are written up on #1529.
