### PR TITLE
Let a translated sentence hold the markup it is written around

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -90,6 +90,15 @@ jobs:
       # show without a marker, and ratchets them the same way. Same runtime and same absence of
       # dependencies as the four steps above.
       run: node tools/ui-untranslated-markup.js
+    - name: A sentence that holds markup
+      # The C# rules over the catalogs read TEXT, and they can say that a parts value names the same slots
+      # the element has children. What they cannot say is what happens when it does not, and that is the
+      # whole safety of the mechanism: the applier must leave the English sentence whole rather than
+      # assemble a partial one, because a sentence missing the `<code>` sample out of instructions for
+      # recovering from a lockout is worse than a sentence in the wrong language (#1529). A live server
+      # cannot answer it either, since its catalog comes from the server and the refusal cases would need a
+      # broken one shipped to reach them. Same runtime and same absence of dependencies as the steps above.
+      run: node tools/ui-sentence-parts.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
+++ b/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
@@ -77,6 +77,20 @@ public class LocalizationCatalogTests
     // A text-marked element together with its tag name, so the element's own content can be located.
     private static readonly Regex MarkedElementPattern = new(@"<(?<tag>[a-z0-9]+)(?:\s[^>]*?)?\sdata-i18n=""(?<key>[^""]+)""[^>]*>", RegexOptions.Compiled);
 
+    // A parts-marked element together with its tag name (#1529). Same shape as the text marker above; the
+    // content behind it is walked rather than matched, because a sentence that holds markup is exactly the
+    // case `[^<]*` cannot describe.
+    private static readonly Regex PartsElementPattern = new(@"<(?<tag>[a-z0-9]+)(?:\s[^>]*?)?\sdata-i18n-parts=""(?<key>[^""]+)""[^>]*>", RegexOptions.Compiled);
+
+    // Any tag, so the content of a parts element can be walked with a depth counter.
+    private static readonly Regex AnyTagPattern = new(@"<(?<closing>/?)(?<tag>[a-z0-9]+)(?<attrs>[^>]*?)(?<selfClosing>/?)>", RegexOptions.Compiled);
+
+    // The elements that never close, so a walk must not expect a closing tag for them.
+    private static readonly string[] VoidElements = ["br", "hr", "img", "input", "link", "meta", "wbr", "source", "area", "base", "col", "embed", "param", "track"];
+
+    // A numbered slot in a parts value, which is what distinguishes one from an ordinary catalog entry.
+    private static readonly Regex PlaceholderIndexPattern = new(@"\{(?<index>\d+)\}", RegexOptions.Compiled);
+
     // A script element with its content, so markup can be inspected without reading JavaScript.
     private static readonly Regex ScriptBlockPattern = new(@"<script\b[^>]*>.*?</script>", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
@@ -89,6 +103,102 @@ public class LocalizationCatalogTests
     private const string ResourcePrefixWeb = "Jellyfin.Plugin.SSO_Auth.Web.";
 
     private static string CollapseWhitespace(string text) => Regex.Replace(text, @"\s+", " ").Trim();
+
+    /*
+     * Turns the named entities this markup uses into the characters a browser would show.
+     *
+     * The catalogs hold TEXT, because the applier writes through createTextNode and a catalog row saying
+     * `&mdash;` would put those eight characters on the screen. The markup holds ENTITIES, because that is
+     * how an em dash has always been written here. So the two are only comparable once one side is
+     * decoded, and decoding the markup is the side that does not change what ships.
+     *
+     * `&amp;` is decoded LAST and that order is the whole correctness of this: decoding it first would
+     * turn `&amp;lt;` into `&lt;` and then into `<`, inventing markup out of text that said the opposite.
+     * The table is the five entities these templates actually use rather than a general decoder, because a
+     * general one is a dependency and a wrong general one is worse than none.
+     */
+    private static string DecodeEntities(string text) => text
+        .Replace("&lt;", "<", System.StringComparison.Ordinal)
+        .Replace("&gt;", ">", System.StringComparison.Ordinal)
+        .Replace("&mdash;", "—", System.StringComparison.Ordinal)
+        .Replace("&rarr;", "→", System.StringComparison.Ordinal)
+        .Replace("&amp;", "&", System.StringComparison.Ordinal);
+
+    /*
+     * Reads a parts element the way `applyParts` in i18n.js sees it, and reports what it found.
+     *
+     * The assembled string is what the catalog value has to equal: every direct child element becomes
+     * `{n}` in document order, and the text between them is kept with its whitespace collapsed. The whole
+     * result is trimmed, because the markup's own indentation before the first child and after the last is
+     * not part of the sentence.
+     *
+     * `nested` names a direct child that itself contains an element. Such a child is not wrong for the
+     * APPLIER - it moves whole nodes and never looks inside one - but it is wrong for a translator, who
+     * gets a slot whose content they cannot see and cannot reorder within. The rule below refuses it, and
+     * this walk is what lets it say which child.
+     */
+    private static (string Assembled, int Slots, List<string> Nested) AssembleParts(string content, int contentStart, string outerTag)
+    {
+        var assembled = new System.Text.StringBuilder();
+        var nested = new List<string>();
+        var depth = 0;
+        var slots = 0;
+        var at = contentStart;
+        string? openChild = null;
+
+        foreach (Match tag in AnyTagPattern.Matches(content, contentStart))
+        {
+            if (depth == 0)
+            {
+                assembled.Append(Regex.Replace(content[at..tag.Index], @"\s+", " "));
+            }
+
+            at = tag.Index + tag.Length;
+            var name = tag.Groups["tag"].Value;
+            var closing = tag.Groups["closing"].Value.Length > 0;
+            var selfClosing = tag.Groups["selfClosing"].Value.Length > 0 || VoidElements.Contains(name);
+
+            if (closing)
+            {
+                if (depth == 0)
+                {
+                    // The outer element's own closing tag: the content ends here.
+                    Assert.Equal(outerTag, name);
+                    break;
+                }
+
+                depth--;
+                if (depth == 0)
+                {
+                    openChild = null;
+                }
+            }
+            else if (selfClosing)
+            {
+                if (depth == 0)
+                {
+                    assembled.Append('{').Append(slots++).Append('}');
+                }
+            }
+            else
+            {
+                if (depth == 0)
+                {
+                    assembled.Append('{').Append(slots++).Append('}');
+                    openChild = name;
+                }
+                else if (openChild is not null)
+                {
+                    nested.Add(openChild);
+                    openChild = null;
+                }
+
+                depth++;
+            }
+        }
+
+        return (DecodeEntities(CollapseWhitespace(assembled.ToString())), slots, nested);
+    }
 
     // The assets that CONSUME the catalog. Excluded are the vendored Jellyfin client bundles (third-party
     // code that never carries our markers, and a minified bundle only invites false positives) and i18n.js
@@ -204,10 +314,22 @@ public class LocalizationCatalogTests
 
         Assert.Equal(new[] { "aria-label", "placeholder", "title" }, allowed.OrderBy(name => name, System.StringComparer.Ordinal));
 
+        // `data-i18n-parts` borrows the SHAPE of an attribute marker and is not one: it names no attribute,
+        // it is handled by its own branch of the applier, and the scan below would otherwise read it as a
+        // request to localize an attribute called "parts" (#1529). Excluded here by name, and the gap that
+        // opens is closed immediately afterwards rather than trusted: the branch that handles it must set no
+        // attribute at all, and it must build nothing from the catalog except a text node.
+        const string PartsMarker = "parts";
+        var partsBranch = Regex.Match(applier, @"function applyParts\b(?<body>[\s\S]*?)\n\}");
+        Assert.True(partsBranch.Success, "i18n.js must declare applyParts, which the parts marker is excluded on the strength of");
+        Assert.DoesNotContain("setAttribute", partsBranch.Groups["body"].Value, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("innerHTML", partsBranch.Groups["body"].Value, System.StringComparison.Ordinal);
+        Assert.Contains("createTextNode", partsBranch.Groups["body"].Value, System.StringComparison.Ordinal);
+
         var offenders = FirstPartyWebAssets()
             .SelectMany(resource => Regex.Matches(ReadResourceText(resource), @"data-i18n-(?<attr>[a-z-]+)=")
                 .Select(match => match.Groups["attr"].Value)
-                .Where(attribute => !allowed.Contains(attribute))
+                .Where(attribute => !allowed.Contains(attribute) && !string.Equals(attribute, PartsMarker, System.StringComparison.Ordinal))
                 .Select(attribute => $"{resource}: data-i18n-{attribute}"))
             .ToList();
 
@@ -227,7 +349,7 @@ public class LocalizationCatalogTests
         foreach (var (resource, _, match) in ScanHtmlAssets(MarkupTextPattern, "built-in English"))
         {
             var key = match.Groups["key"].Value;
-            var builtIn = CollapseWhitespace(match.Groups["text"].Value);
+            var builtIn = DecodeEntities(CollapseWhitespace(match.Groups["text"].Value));
             if (english.TryGetValue(key, out var catalogValue) && !string.Equals(catalogValue, builtIn, System.StringComparison.Ordinal))
             {
                 mismatches.Add($"{resource}: '{key}' markup \"{builtIn}\" != catalog \"{catalogValue}\"");
@@ -235,6 +357,91 @@ public class LocalizationCatalogTests
         }
 
         Assert.True(mismatches.Count == 0, "These built-in English strings have drifted from the catalog: " + string.Join(" | ", mismatches));
+    }
+
+    [Fact]
+    public void PartsBuiltInEnglish_MatchesTheCatalogAndNamesEveryChild()
+    {
+        // A parts marker localizes a sentence that HOLDS markup, which the text marker above cannot: it
+        // assigns textContent and would delete the `<code>` sample out of the middle of a sentence about
+        // recovering from a lockout. So the catalog value carries `{0}`, `{1}` for the children and the
+        // applier writes only the text between them (#1529).
+        //
+        // Three things have to hold, and all three are the same failure seen from different sides. The
+        // assembled English must equal the catalog value, for the reason the text-marker rule states: the
+        // markup's own English is the offline rendering and a drift means two readers see two sentences.
+        // Every child must be named exactly once, because a value naming fewer leaves a `<code>` out of
+        // the translated sentence and a value naming more asks for a node that does not exist - in both
+        // cases applyParts refuses and the whole sentence silently stays English. And no child may itself
+        // contain an element, because a slot a translator cannot see inside is a slot they cannot place.
+        var english = ReadCatalog(EnglishResource);
+        var problems = new List<string>();
+
+        foreach (var (resource, content, match) in ScanHtmlAssets(PartsElementPattern, "parts-marker"))
+        {
+            var key = match.Groups["key"].Value;
+            var (assembled, slots, nested) = AssembleParts(content, match.Index + match.Length, match.Groups["tag"].Value);
+
+            if (nested.Count > 0)
+            {
+                problems.Add($"{resource}: '{key}' - the child <{string.Join(">, <", nested)}> holds markup of its own, so its slot cannot be read or placed by a translator");
+            }
+
+            if (!english.TryGetValue(key, out var catalogValue))
+            {
+                // Absence is the orphan check's finding, not this one's.
+                continue;
+            }
+
+            if (!string.Equals(catalogValue, assembled, System.StringComparison.Ordinal))
+            {
+                problems.Add($"{resource}: '{key}' markup \"{assembled}\" != catalog \"{catalogValue}\"");
+            }
+
+            var named = PlaceholderIndexPattern.Matches(catalogValue).Select(m => int.Parse(m.Groups["index"].Value, System.Globalization.CultureInfo.InvariantCulture)).ToList();
+            if (named.Count != slots || named.Distinct().Count() != slots || named.Any(index => index >= slots))
+            {
+                problems.Add($"{resource}: '{key}' has {slots} child element(s) and its catalog value names [{string.Join(", ", named)}], so applyParts would refuse it and the sentence would stay English");
+            }
+        }
+
+        Assert.True(problems.Count == 0, "These parts markers do not describe the element they sit on: " + string.Join(" | ", problems));
+    }
+
+    [Fact]
+    public void EveryNonEnglishCatalog_NamesTheSameSlotsAsTheEnglishOne()
+    {
+        // A translation may REORDER the slots - that is the point of the mechanism, since German does not
+        // put the pieces of a sentence where English does - but it may not add, drop, or repeat one. Any of
+        // those makes applyParts refuse, and a refusal leaves the reader with the English sentence while
+        // every other string around it is translated, which reads as a bug in the page rather than in a
+        // catalog row (#1529).
+        var english = ReadCatalog(EnglishResource);
+        var slotted = english
+            .Where(entry => PlaceholderIndexPattern.IsMatch(entry.Value))
+            .ToDictionary(entry => entry.Key, entry => PlaceholderIndexPattern.Matches(entry.Value).Select(m => m.Groups["index"].Value).OrderBy(index => index, System.StringComparer.Ordinal).ToList(), System.StringComparer.Ordinal);
+
+        var problems = new List<string>();
+        foreach (var culture in CommittedCultures.Where(name => !string.Equals(name, "en", System.StringComparison.Ordinal)))
+        {
+            var other = ReadCatalog(ResourcePrefix + culture + ResourceSuffix);
+            foreach (var (key, indexes) in slotted)
+            {
+                if (!other.TryGetValue(key, out var value))
+                {
+                    // A missing key is the key-set rule's finding, not this one's.
+                    continue;
+                }
+
+                var theirs = PlaceholderIndexPattern.Matches(value).Select(m => m.Groups["index"].Value).OrderBy(index => index, System.StringComparer.Ordinal).ToList();
+                if (!theirs.SequenceEqual(indexes, System.StringComparer.Ordinal))
+                {
+                    problems.Add($"{culture}: '{key}' names [{string.Join(", ", theirs)}] where English names [{string.Join(", ", indexes)}]");
+                }
+            }
+        }
+
+        Assert.True(problems.Count == 0, "These translations do not name the same slots as the English value: " + string.Join(" | ", problems));
     }
 
     [Fact]

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -278,5 +278,7 @@
   "config.preset_note_generic_oidc": "Ein standardkonformer OpenID-Anbieter. Richten Sie den Endpunkt auf sein Erkundungsdokument und setzen Sie den Rollen-Claim auf das, was Ihr Identitätsanbieter ausgibt (oft `groups` oder `roles`).",
   "config.preset_note_generic_saml": "Ein allgemeiner SAML-2.0-Identitätsanbieter. Füllen Sie den SSO-Endpunkt und das Signaturzertifikat über die Metadaten-Einfuhr unten aus den Metadaten Ihres Identitätsanbieters, setzen Sie dann die SAML-Client-Kennung (die Entitätskennung dieses Dienstanbieters) und prüfen Sie, bevor Sie speichern.",
   "config.preset_label_generic_oidc": "Allgemeines OpenID Connect",
-  "config.preset_label_generic_saml": "Allgemeines SAML 2.0"
+  "config.preset_label_generic_saml": "Allgemeines SAML 2.0",
+  "config.sso_only_recovery_title": "Die Wiederherstellung nach einer totalen Aussperrung gelingt von der Festplatte aus.",
+  "config.sso_only_recovery": "{0} Wenn Sie jemals vollständig ausgesperrt sind, halten Sie Jellyfin an, bearbeiten Sie die {1} des Plugins, setzen Sie {2} zurück auf {3} und starten Sie neu. Beim Start gleicht das Plugin die Benutzerdatenbank mit dem Schalter ab — die Konten, die der Modus umgeleitet hat, werden auf den eingebauten Passwortanbieter zurückgestellt (Passwort-Hashes bleiben unberührt), sodass die Passwortanmeldung wieder funktioniert. Wiederhergestellt werden nur Konten, die der Modus selbst verschoben hat; per SSO angelegte Konten behalten ihre reine SSO-Leitung."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -278,5 +278,7 @@
   "config.preset_note_generic_oidc": "A standards-compliant OpenID provider. Point the endpoint at its discovery document and set the role claim to whatever your IdP issues (often `groups` or `roles`).",
   "config.preset_note_generic_saml": "A generic SAML 2.0 identity provider. Use the metadata import below to fill the SSO endpoint and signing certificate from your IdP's metadata, then set the SAML Client ID (this service provider's entity id) and review before saving.",
   "config.preset_label_generic_oidc": "Generic OpenID Connect",
-  "config.preset_label_generic_saml": "Generic SAML 2.0"
+  "config.preset_label_generic_saml": "Generic SAML 2.0",
+  "config.sso_only_recovery_title": "Total-lockout recovery works from disk.",
+  "config.sso_only_recovery": "{0} If you are ever fully locked out, stop Jellyfin, edit the plugin's {1}, set {2} back to {3}, and restart. On startup the plugin reconciles the user database to the flag — the accounts the mode repointed are restored to the built-in password provider (password hashes untouched), so native login works again. Only accounts the mode itself moved are restored; accounts created by SSO keep their SSO-only routing."
 }

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -275,8 +275,10 @@
                       accounts the mode repointed and never resets or reveals
                       any password.
                     </li>
-                    <li>
-                      <strong>Total-lockout recovery works from disk.</strong>
+                    <li data-i18n-parts="config.sso_only_recovery">
+                      <strong data-i18n="config.sso_only_recovery_title"
+                        >Total-lockout recovery works from disk.</strong
+                      >
                       If you are ever fully locked out, stop Jellyfin, edit the
                       plugin's <code>config.xml</code>, set
                       <code>DisablePasswordLogin</code> back to

--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -37,9 +37,75 @@ export function t(key, params, fallback) {
 // future edit) drive href, src, or an event handler through the same path.
 const LOCALIZABLE_ATTRIBUTES = ["title", "placeholder", "aria-label"];
 
+// The marker for a SENTENCE THAT HOLDS MARKUP (#1529), and it is deliberately not spelled
+// `data-i18n-<something>`: that shape means "localize the attribute of this name", the allowlist above
+// is what keeps it safe, and a marker that borrowed the shape without being an attribute would make
+// that rule ask a question it no longer means.
+const PARTS_MARKER = "data-i18n-parts";
+
+// A slot in a parts value. `{0}` stands for this element's FIRST child element, `{1}` for its second,
+// and so on in document order.
+const SLOT = /\{(\d+)\}/g;
+
+/*
+ * Splits a parts value into the pieces to write and the children to keep, or returns null if the value
+ * does not describe this element.
+ *
+ * WHY THIS REFUSES RATHER THAN DOING ITS BEST. A value that names four slots applied to an element with
+ * three children would silently drop a `<code>` sample out of a sentence about recovering from a
+ * lockout. Leaving the English standing is a visible, correct fallback; a half-assembled sentence is
+ * neither. So every index must be in range and each one must appear exactly once - which also refuses a
+ * value that names the same child twice, where one copy would have to be a clone and this never clones.
+ */
+function plan(value, childCount) {
+  const tokens = [];
+  const used = new Set();
+  let at = 0;
+  let match;
+  SLOT.lastIndex = 0;
+  while ((match = SLOT.exec(value)) !== null) {
+    const index = Number(match[1]);
+    if (index >= childCount || used.has(index)) {
+      return null;
+    }
+    used.add(index);
+    tokens.push({ text: value.slice(at, match.index) });
+    tokens.push({ child: index });
+    at = match.index + match[0].length;
+  }
+  tokens.push({ text: value.slice(at) });
+  return used.size === childCount ? tokens : null;
+}
+
+/*
+ * Writes a parts value into one element.
+ *
+ * NOTHING HERE IS PARSED AS MARKUP AND NOTHING IS CLONED. The children are the element's own nodes,
+ * held in an array while the element is emptied and then put back - so they keep their identity, their
+ * own content, and any listener on them, and the catalog can reorder them without being able to create
+ * one. The only thing built from the catalog is a text node, through createTextNode, which cannot carry
+ * markup by construction. That is the same posture as the attribute allowlist above and for the same
+ * reason: a localization file is data, and data never becomes structure here.
+ */
+function applyParts(el, value) {
+  const children = [...el.children];
+  const tokens = plan(value, children.length);
+  if (tokens === null) {
+    return;
+  }
+
+  const built = tokens.map((token) =>
+    token.child === undefined
+      ? document.createTextNode(token.text)
+      : children[token.child],
+  );
+  el.replaceChildren(...built);
+}
+
 // Apply the loaded catalog under `root` (default: the whole document): `data-i18n="key"` replaces an
-// element's text content, and `data-i18n-<attr>="key"` replaces one of the allowlisted attributes above
-// (e.g. data-i18n-title). A key that is not in the catalog leaves the built-in English in place.
+// element's text content, `data-i18n-parts="key"` rewrites a sentence AROUND the child elements it
+// holds, and `data-i18n-<attr>="key"` replaces one of the allowlisted attributes above (e.g.
+// data-i18n-title). A key that is not in the catalog leaves the built-in English in place.
 export function applyTo(root) {
   const scope = root || document;
 
@@ -47,6 +113,13 @@ export function applyTo(root) {
     const key = el.getAttribute("data-i18n");
     if (Object.prototype.hasOwnProperty.call(catalog, key)) {
       el.textContent = catalog[key];
+    }
+  });
+
+  scope.querySelectorAll("[" + PARTS_MARKER + "]").forEach((el) => {
+    const key = el.getAttribute(PARTS_MARKER);
+    if (Object.prototype.hasOwnProperty.call(catalog, key)) {
+      applyParts(el, catalog[key]);
     }
   });
 

--- a/tools/ui-sentence-parts.js
+++ b/tools/ui-sentence-parts.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Drives the REAL parts applier of the shipped i18n.js and refuses each way it
+ * can be wrong (#1529).
+ *
+ * WHY A RUNNING PROOF AND NOT A CONFORMANCE RULE. The C# rules beside this one
+ * read the TEXT of the markup and the catalogs: they can say that a parts value
+ * names the same slots the element has children, and they do. What they cannot
+ * say is what happens when it does not - and that is the whole safety of this
+ * mechanism. `applyParts` must leave the English sentence standing rather than
+ * assemble a partial one, because a sentence missing a `<code>` sample in the
+ * middle of instructions for recovering from a lockout is worse than a sentence
+ * in the wrong language. Whether it does is a property of the code, and the
+ * inverted condition reads exactly like the correct one.
+ *
+ * A LIVE WALK COULD NOT ANSWER IT EITHER, which is why this file exists rather
+ * than a note in a pull request. On a real server the catalog comes from the
+ * server, so the refusal cases cannot be reached without shipping a broken
+ * catalog to reach them. The first attempt to check this in a browser drove
+ * four different bad values through a key the catalog did not carry, so the
+ * applier was never entered and all four "passed" for the same empty reason.
+ *
+ * WHAT THE STUB CAN AND CANNOT SAY. The DOM below is the smallest one the
+ * applier touches: createTextNode, children, replaceChildren, getAttribute and a
+ * selector lookup for exactly the two marker forms. It is not a browser. It
+ * cannot say anything about layout, about the order the page runs its own
+ * scripts in, or about a client whose createElement behaves differently - the
+ * folder-checklist gate beside it exists for that last one. What keeps it from
+ * being a proof about itself is that the code under test is the shipped
+ * i18n.js, loaded whole through a data URL, and that the catalog reaches it
+ * through its own loadCatalog and its own fetch rather than by assignment.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-mock-fields.js and tools/ui-untranslated.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APPLIER = path.join(HERE, "..", "SSO-Auth", "Web", "i18n.js");
+
+// ---------------------------------------------------------------------------
+// The stub.
+// ---------------------------------------------------------------------------
+
+class TextNode {
+  constructor(text) {
+    this.text = text;
+  }
+  get rendered() {
+    return this.text;
+  }
+}
+
+class Element {
+  constructor(tag, attributes = {}, nodes = []) {
+    this.tag = tag;
+    this.attributes = attributes;
+    this.nodes = nodes;
+  }
+
+  get children() {
+    return this.nodes.filter((node) => node instanceof Element);
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+
+  replaceChildren(...nodes) {
+    this.nodes = nodes;
+  }
+
+  set textContent(value) {
+    this.nodes = [new TextNode(value)];
+  }
+
+  get rendered() {
+    return this.nodes.map((node) => node.rendered).join("");
+  }
+
+  // The shape a reader can compare: text as text, an element as <tag>content</tag>.
+  get shape() {
+    return this.nodes
+      .map((node) =>
+        node instanceof Element
+          ? `<${node.tag}>${node.rendered}</${node.tag}>`
+          : node.text,
+      )
+      .join("");
+  }
+}
+
+function documentWith(elements) {
+  return {
+    createTextNode: (text) => new TextNode(text),
+    querySelectorAll: (selector) => {
+      const attribute = selector.slice(1, -1);
+      return elements.filter((el) => el.getAttribute(attribute) !== null);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The legs.
+// ---------------------------------------------------------------------------
+
+async function applierWith(catalog, elements) {
+  // The catalog reaches the module the way it does on a server: through its own
+  // loadCatalog, over a fetch. Assigning it directly would test a module this
+  // tree does not ship.
+  globalThis.ApiClient = {
+    getUrl: (route) => "https://example.invalid/" + route,
+  };
+  globalThis.fetch = () =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(catalog) });
+  globalThis.document = documentWith(elements);
+
+  const source = fs.readFileSync(APPLIER, "utf8");
+  const url =
+    "data:text/javascript;base64," +
+    Buffer.from(source, "utf8").toString("base64") +
+    "#" +
+    Math.random();
+  const module = await import(url);
+  await module.loadCatalog();
+  return module;
+}
+
+/** The sentence the shipped Overview page carries, in miniature. */
+function sentence() {
+  return new Element("li", { "data-i18n-parts": "probe.sentence" }, [
+    new Element("strong", {}, [new TextNode("Recovery works from disk.")]),
+    new TextNode(" Edit the plugin's "),
+    new Element("code", {}, [new TextNode("config.xml")]),
+    new TextNode(", set "),
+    new Element("code", {}, [new TextNode("Flag")]),
+    new TextNode(" back."),
+  ]);
+}
+
+const faults = [];
+const refuse = (leg, detail) => faults.push(leg + ": " + detail);
+
+// ---- Arm: a value naming every child exactly once assembles, and may reorder ----
+{
+  const el = sentence();
+  const before = el.shape;
+  const kept = el.children;
+  const module = await applierWith(
+    { "probe.sentence": "{0} Setze {2} zurueck, in {1} des Plugins." },
+    [el],
+  );
+  module.applyTo();
+
+  const expected =
+    "<strong>Recovery works from disk.</strong> Setze <code>Flag</code> zurueck, in <code>config.xml</code> des Plugins.";
+  if (el.shape !== expected) {
+    refuse(
+      "assemble",
+      `the sentence came out as "${el.shape}" rather than "${expected}", so a translation cannot move a slot`,
+    );
+  }
+  if (before === el.shape) {
+    refuse(
+      "assemble",
+      "nothing happened at all, so every arm below proves nothing",
+    );
+  }
+
+  // The children must be the SAME nodes. A clone would drop a listener and, on a
+  // page where a child is a link or a button, would quietly disconnect it.
+  const now = el.children;
+  if (
+    now.length !== kept.length ||
+    now.some((child) => !kept.includes(child))
+  ) {
+    refuse(
+      "assemble",
+      "the children are not the element's own nodes any more, so the catalog created markup instead of moving it",
+    );
+  }
+}
+
+// ---- Arms: every value that does not describe the element leaves it alone ----
+for (const [leg, value] of [
+  ["too-few", "Only {0} named."],
+  ["too-many", "{0} {1} {2} {3} named."],
+  ["repeated", "{0} and {0} again, with {1}."],
+  ["out-of-range", "{0} {1} {9}."],
+]) {
+  const el = sentence();
+  const before = el.shape;
+  const module = await applierWith({ "probe.sentence": value }, [el]);
+  module.applyTo();
+  if (el.shape !== before) {
+    refuse(
+      leg,
+      `a value of "${value}" was applied to an element with 3 children and gave "${el.shape}", where the English sentence had to stay whole`,
+    );
+  }
+}
+
+// ---- Arm: a key the catalog does not carry leaves the English standing ----
+{
+  const el = sentence();
+  const before = el.shape;
+  const module = await applierWith({ "some.other.key": "{0}" }, [el]);
+  module.applyTo();
+  if (el.shape !== before) {
+    refuse(
+      "absent-key",
+      "an element whose key is not in the catalog was rewritten anyway",
+    );
+  }
+}
+
+// ---- Arm: a catalog value is TEXT and never becomes markup ----
+{
+  const el = sentence();
+  const module = await applierWith(
+    { "probe.sentence": "{0}<b>bold</b>{1} & {2}" },
+    [el],
+  );
+  module.applyTo();
+  const text = el.nodes
+    .filter((node) => node instanceof TextNode)
+    .map((node) => node.text);
+  if (!text.some((piece) => piece.includes("<b>bold</b>"))) {
+    refuse(
+      "text-only",
+      "the angle brackets in a catalog value did not survive as text, which means something parsed them",
+    );
+  }
+  if (el.children.some((child) => child.tag === "b")) {
+    refuse(
+      "text-only",
+      "a catalog value created an element, which is the one thing this mechanism must never do",
+    );
+  }
+}
+
+// ---- Arm: the text marker still works, and runs BEFORE the parts pass ----
+{
+  // The <strong> inside a parts element carries its own text marker, because the
+  // parts pass moves nodes and never looks inside one. It only translates if the
+  // text pass has already run when the node is moved.
+  const el = sentence();
+  el.children[0].setAttribute("data-i18n", "probe.title");
+  const module = await applierWith(
+    {
+      "probe.title": "Wiederherstellung von der Platte.",
+      "probe.sentence": "{0} Ein Satz mit {1} und {2}.",
+    },
+    [el, ...el.children],
+  );
+  module.applyTo();
+  if (
+    !el.shape.includes("<strong>Wiederherstellung von der Platte.</strong>")
+  ) {
+    refuse(
+      "order",
+      `a marked child inside a parts element kept its English: "${el.shape}"`,
+    );
+  }
+}
+
+if (faults.length) {
+  faults.forEach((fault) => console.error(fault));
+  console.error(
+    faults.length + " refusal(s) in the sentence-parts applier (#1529)",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "sentence parts:    seven arms run against the shipped i18n.js and its own loadCatalog",
+);
+console.log(
+  "  assemble         a value naming every child once is written, may reorder, and moves the nodes rather than copying them",
+);
+console.log(
+  "  too-few / too-many / repeated / out-of-range   a value that does not describe the element leaves the English sentence whole",
+);
+console.log(
+  "  absent-key       a key the catalog does not carry changes nothing",
+);
+console.log(
+  "  text-only        angle brackets in a catalog value stay text and never become an element",
+);
+console.log(
+  "  order            a marked child is translated before the sentence around it is rebuilt",
+);

--- a/tools/ui-untranslated-markup.js
+++ b/tools/ui-untranslated-markup.js
@@ -78,7 +78,7 @@ const WEB = path.join(HERE, "..", "SSO-Auth", "Web");
 
 // The pinned count. It goes DOWN as runs are keyed, in the same commit that keys
 // them, and it never goes up.
-const PINNED = 348;
+const PINNED = 343;
 const PINNED_ATTRIBUTES = 23;
 
 // The six templates a reader of this plugin actually sees: the five dashboard
@@ -160,6 +160,9 @@ function scan(file) {
     const text = html.slice(textStart, match.index).replace(/\s+/g, " ").trim();
     if (text && /[A-Za-z]{2}/.test(text)) {
       const parent = open[open.length - 1];
+      // Either marker covers the run. `data-i18n` replaces the element's whole content, so the
+      // run IS what it replaces. `data-i18n-parts` rewrites the sentence AROUND the children,
+      // and the text between them is precisely that sentence (#1529).
       const marked = parent ? parent.marker !== null : false;
       const opaque = parent ? OPAQUE.has(parent.name) : false;
       const declared =
@@ -195,7 +198,9 @@ function scan(file) {
       if (!selfClosing) {
         open.push({
           name,
-          marker: attributeOf(match[2], "data-i18n"),
+          marker:
+            attributeOf(match[2], "data-i18n") ??
+            attributeOf(match[2], "data-i18n-parts"),
           value: attributeOf(match[2], "value"),
         });
       }


### PR DESCRIPTION
# What & why

Refs #1529, stage 3's third bullet. No closing keyword: the stage has three more
bullets after this one.

A third of the text left on these pages is a sentence broken by inline markup:
prose with a `<code>` sample, a `<strong>` lead-in or a link in the middle of
it. The text marker cannot carry one, and the rule beside it says why: it
assigns `textContent`, which would delete the `<code>` out of the middle of
instructions for recovering from a lockout.

What was left was to translate the pieces separately, and that does not work in
German. "edit the plugin's" + `config.xml` is "bearbeiten Sie die" +
`config.xml` + "des Plugins". The slot moves INSIDE the sentence, so a fragment
translated on its own cannot be put back in the right place by anybody.

So the catalog value carries the sentence whole, with `{0}` and `{1}` where the
children go, and `data-i18n-parts` marks the element. Counted before building
it rather than after:

```
181  the run is its parent's whole content   -> a marker works today
 56  a whole sentence beside a sibling       -> its own span
111  a sentence interrupted by inline markup -> this
348
```

**Nothing is parsed and nothing is cloned.** The children are the element's own
nodes, held in an array while the element is emptied and put back in the order
the value names, so they keep their identity, their content and any listener,
and the catalog can REORDER them without being able to create one. The only
thing built from a catalog value is a text node, through `createTextNode`. That
is the same posture as the attribute allowlist beside it and for the same
reason: a localization file is data, and data does not become structure here.

**A value that does not describe the element is refused rather than
half-applied**, because a sentence with a `<code>` sample missing from the
middle of lockout recovery instructions is worse than a sentence in the wrong
language. Every index must be in range and each must appear exactly once, which
also refuses a value naming one child twice, where a second copy would have to
be a clone.

The first use is the total-lockout recovery item on the Overview page, the
sentence that motivated the whole thing. Its `<strong>` carries a text marker of
its own, because the assembly moves nodes and never looks inside one, and the
text pass runs first so the node is already German when it is moved.

The German is mine and has been read; the vouch line is at the end.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a value that does not describe its element is
      refused and the English sentence stays whole. That is the fail-closed
      direction for a localizer, and it is what the new node gate spends four of
      its seven arms on.
- [x] No secrets logged; secrets are redacted on config export. Untouched.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. None of the three is touched,
      but this DOES widen what a catalog file can do to a page, so the property
      is pinned rather than reviewed. The marker is deliberately not spelled as
      an attribute marker: `data-i18n-<name>` means "localize the attribute of
      this name" and the three-entry inert allowlist is what makes that safe. A
      marker borrowing the shape without being one would make that rule ask a
      question it no longer means, so it is excluded there BY NAME and the gap
      that opens is closed in the same rule: the branch that handles it must
      contain no `setAttribute`, no `innerHTML`, and a `createTextNode`.
- [x] Review record: **CONFIRMED 1 / PLAUSIBLE 0**. The finding is my own first
      check of the refusal path, which proved nothing: four bad values were
      driven through a key the catalog did not carry, so the applier was never
      entered and all four "passed" for the same empty reason. Disposition: FIX,
      as the node gate, and the episode is written into its header.
- [x] Log inputs from the IdP are sanitized inline at the log call. No logging.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. `plan` decides and `applyParts` writes, so the decision can
      be wrong in only one place.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and the new structural properties are
      locked in: two new catalog rules pin the assembled English equal to the
      catalog value and refuse a translation naming different slots, and a third
      existing rule now decodes the five named entities these templates use, so
      markup and catalog are comparable at all.
- [x] Docs impact considered: no README or wiki change. Nothing a reader of the
      plugin sees changes except that one sentence is now German on a German
      client.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings.
- [x] `dotnet test` is green. 3871 on net9.0 and 3872 on net10.0, 0 failed, each
      run on an otherwise idle machine.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

All six browser gates run green.

## Notes

Measured in three places rather than argued.

**The node gate was run against broken builds before being trusted.** With the
completeness check removed it refused the too-few arm by name. With the children
cloned instead of moved it failed rather than passing. A gate that has never
failed says nothing about the code it guards.

**The assembled sentence was read off a live Jellyfin 12** with a de-DE client.
The German came out with its three `<code>` samples in place as real elements
and the slot in the German position:

```
Die Wiederherstellung nach einer totalen Aussperrung gelingt von der
Festplatte aus. Wenn Sie jemals vollstaendig ausgesperrt sind, halten Sie
Jellyfin an, bearbeiten Sie die config.xml des Plugins, setzen Sie
DisablePasswordLogin zurueck auf false und starten Sie neu. ...
```

That walk also turned up something worth knowing for the next one: the browser
caches the module, so a rebuilt `i18n.js` is not what the page imports until the
cache is bypassed. The first reading said the mechanism did nothing, and the
mechanism was fine.

**The template counter now knows the new marker**, so a parts-marked element's
runs read as covered and the pin comes down by the five runs this converts.

Catalogue-Vouch: de read by iderex

The German has been read. What the reader was asked to look at was the two rows
this adds and the assembled sentence they produce on a live server, with the
three code samples in the German positions rather than the English ones, since
the whole point of the mechanism is that the slot moves.
