### PR TITLE
Let the linked-accounts table be filtered, and say when it is

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -99,6 +99,15 @@ jobs:
       # cannot answer it either, since its catalog comes from the server and the refusal cases would need a
       # broken one shipped to reach them. Same runtime and same absence of dependencies as the steps above.
       run: node tools/ui-sentence-parts.js
+    - name: The linked-accounts filter
+      # A filter is not a string, so no rule that reads these assets can judge it, and both ways it goes
+      # wrong are silent (#1529). A narrowed table that does not say it is narrowed looks exactly like a
+      # complete one, and an administrator counting rows to answer "how many accounts are linked" gets the
+      # filter's answer. A filter with no match that says "no account holds a link" is a statement about
+      # the server rather than about the box, on a page whose other button revokes links. This drives the
+      # shipped renderer and refuses both by name. Same runtime and same absence of dependencies as the
+      # steps above.
+      run: node tools/ui-account-filter.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -510,5 +510,10 @@
   "config.saml_insecure_options_help": "Diese Optionen schalten Schutzmechanismen von SAML ab. Schalten Sie eine nur ein, wenn Ihr Anbieter sie wirklich verlangt; jede wird als Prüfwarnung aufgezeichnet.",
   "config.saml_no_validate_audience_label": "Audience nicht prüfen (unsicher)",
   "config.saml_no_validate_audience_help": "⚠ Unsicher: Schaltet die Prüfung {0} ab, sodass eine Assertion, die für einen anderen Dienstanbieter ausgestellt wurde, hier wiedereingespielt werden könnte. Nur wenn Ihr Identitätsanbieter die Audience nicht richtig setzen kann. Das Einschalten wird als Prüfwarnung aufgezeichnet.",
-  "config.saml_test_help": "Prüft den {0} Anbieter: Er liest das gespeicherte Signaturzertifikat des Identitätsanbieters und meldet dessen nicht geheime Angaben (Inhaber, Aussteller, Gültigkeit, Fingerabdruck). Speichern Sie den Anbieter zuerst. Erfordert Administratorrechte; kein Signaturschlüssel wird gezeigt."
+  "config.saml_test_help": "Prüft den {0} Anbieter: Er liest das gespeicherte Signaturzertifikat des Identitätsanbieters und meldet dessen nicht geheime Angaben (Inhaber, Aussteller, Gültigkeit, Fingerabdruck). Speichern Sie den Anbieter zuerst. Erfordert Administratorrechte; kein Signaturschlüssel wird gezeigt.",
+  "config.linked_accounts_filter_label": "Filter:",
+  "config.linked_accounts_filter_placeholder": "Konto, Anbieter oder Subjekt",
+  "config.linked_accounts_filter_help": "Engt die Tabelle auf die Zeilen ein, deren Kontoname, Anbieter, Protokoll oder Subjekt beim Identitätsanbieter enthält, was Sie eingeben. Gefiltert wird, was bereits geladen ist; der Server wird dabei nicht gefragt.",
+  "config.linked_accounts_filter_empty": "Kein verknüpftes Konto passt zum Filter. Geladen sind {total}.",
+  "config.linked_accounts_filter_count": "Gezeigt werden {shown} von {total} verknüpften Konten."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -510,5 +510,10 @@
   "config.saml_insecure_options_help": "These options disable SAML security defenses. Enable one only if your provider genuinely requires it; each is recorded as an audit warning.",
   "config.saml_no_validate_audience_label": "Do Not Validate Audience (Insecure)",
   "config.saml_no_validate_audience_help": "⚠ Insecure: disables the {0} check, so an assertion minted for a different service provider could be replayed here. Only if your IdP cannot set the audience correctly. Enabling it is recorded as an audit warning.",
-  "config.saml_test_help": "Validates the {0} provider: parses the stored IdP signing certificate and reports its non-secret facts (subject, issuer, validity, thumbprint). Save the provider first. Requires administrator privileges; no signing key is shown."
+  "config.saml_test_help": "Validates the {0} provider: parses the stored IdP signing certificate and reports its non-secret facts (subject, issuer, validity, thumbprint). Save the provider first. Requires administrator privileges; no signing key is shown.",
+  "config.linked_accounts_filter_label": "Filter:",
+  "config.linked_accounts_filter_placeholder": "account, provider or subject",
+  "config.linked_accounts_filter_help": "Narrows the table to the rows whose account name, provider, protocol or identity-provider subject contains what you type. It filters what is already loaded and asks the server for nothing.",
+  "config.linked_accounts_filter_empty": "No linked account matches the filter. {total} are loaded.",
+  "config.linked_accounts_filter_count": "Showing {shown} of {total} linked accounts."
 }

--- a/SSO-Auth/Web/accountsPage.html
+++ b/SSO-Auth/Web/accountsPage.html
@@ -151,6 +151,39 @@
                       >
                     </button>
 
+                    <!--
+                  The filter (#1529). NOT a persisting field: it carries no sso-* marker class and no id
+                  matching any configuration property, so listArgumentsByType never picks it up and a save
+                  cannot write it anywhere. It narrows what the roster renders, and the count line below the
+                  table says how many of how many are shown - a table that silently shows a subset is a
+                  table an administrator draws the wrong conclusion from.
+                -->
+                    <div class="inputContainer">
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="LinkedAccountsFilter"
+                        data-i18n="config.linked_accounts_filter_label"
+                        >Filter:</label
+                      >
+                      <input
+                        is="emby-input"
+                        id="LinkedAccountsFilter"
+                        type="search"
+                        autocomplete="off"
+                        placeholder="account, provider or subject"
+                        data-i18n-placeholder="config.linked_accounts_filter_placeholder"
+                      />
+                      <div
+                        class="fieldDescription"
+                        data-i18n="config.linked_accounts_filter_help"
+                      >
+                        Narrows the table to the rows whose account name,
+                        provider, protocol or identity-provider subject contains
+                        what you type. It filters what is already loaded and
+                        asks the server for nothing.
+                      </div>
+                    </div>
+
                     <div id="LinkedAccountsRevokeResult"></div>
                     <div id="LinkedAccountsResult"></div>
                   </div>

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -5,8 +5,30 @@ let i18n = null;
 
 // Localized text for a catalog key, falling back to the English default the call site carries. The
 // default is the same wording the static markup holds, so a JS-set string and its HTML twin cannot drift.
+//
+// THE FALLBACK SUBSTITUTES TOO, and that is a fix rather than a flourish (#1529). It used to return the
+// default verbatim, so every parameterised call rendered its braces: before the catalog arrived, and
+// permanently on a server whose fetch fails, a reader saw "Deleted account ({id})" and "Showing {shown} of
+// {total} linked accounts." The default is the SAME string the catalog carries, placeholders included, so
+// the only question was whether anything filled them, and on this path nothing did. Found by the arm in
+// tools/ui-account-filter.js, which drives the renderer with no localization module loaded at all - which
+// is precisely the state this branch describes.
+//
+// The substitution is written here rather than imported because this is the branch where the module is
+// ABSENT; reaching into it for the helper is the one thing this path cannot do. An absent parameter is
+// left as it stands, exactly as i18n.js does, so a mismatched call never drops text.
 function tr(key, englishDefault, params) {
-  return i18n ? i18n.t(key, params, englishDefault) : englishDefault;
+  if (i18n) {
+    return i18n.t(key, params, englishDefault);
+  }
+
+  if (!params) {
+    return englishDefault;
+  }
+
+  return String(englishDefault).replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(params, name) ? params[name] : match,
+  );
 }
 
 // What the tracked controls of a page held the last time it was read (#1572), keyed on the page element.
@@ -3932,9 +3954,53 @@ const ssoConfigurationPage = {
         ),
     );
   },
+  // THE ROSTER IS KEPT so the filter can re-render without asking the server again (#1529). Held on the
+  // module rather than on the page because the page is a DOM node the client may replace, and a filter
+  // keystroke must not turn into a request: the roster is elevation-gated and rate-limited, and typing six
+  // characters would spend six calls on data that has not changed.
+  linkedAccountRoster: null,
+  // Everything on one row that a reader might search by. The Jellyfin username, the provider name, the
+  // protocol, and the identity-provider subject - which is the one an administrator usually arrives with,
+  // because it is what the provider's own console shows them.
+  linkedAccountHaystack: (account) =>
+    [
+      account && account.Username,
+      account && account.UserId,
+      ...(account && Array.isArray(account.Links) ? account.Links : []).flatMap(
+        (link) => [
+          link && link.Provider,
+          link && link.Protocol,
+          link && link.CanonicalName,
+        ],
+      ),
+    ]
+      .filter((part) => part !== null && part !== undefined)
+      .join(" ")
+      .toLowerCase(),
+  filteredLinkedAccounts: (accounts, needle) => {
+    const wanted = String(needle || "")
+      .trim()
+      .toLowerCase();
+    if (wanted === "") {
+      return accounts;
+    }
+
+    return accounts.filter((account) =>
+      ssoConfigurationPage.linkedAccountHaystack(account).includes(wanted),
+    );
+  },
   renderLinkedAccounts: (page, container, roster) => {
-    const accounts =
-      roster && Array.isArray(roster.Accounts) ? roster.Accounts : [];
+    if (roster !== undefined) {
+      ssoConfigurationPage.linkedAccountRoster = roster;
+    }
+
+    const held = ssoConfigurationPage.linkedAccountRoster;
+    const accounts = held && Array.isArray(held.Accounts) ? held.Accounts : [];
+    const filter = page.querySelector("#LinkedAccountsFilter");
+    const shown = ssoConfigurationPage.filteredLinkedAccounts(
+      accounts,
+      filter && filter.value,
+    );
     container.replaceChildren();
 
     // The empty state is a sentence rather than an empty table: a blank panel reads as a failed fetch, and
@@ -3945,6 +4011,21 @@ const ssoConfigurationPage = {
         tr(
           "config.linked_accounts_empty",
           "No Jellyfin account holds an SSO link on this server.",
+        ),
+      );
+      return;
+    }
+
+    // A FILTER THAT MATCHES NOTHING IS ITS OWN SENTENCE, and not the one above. "No account holds a link"
+    // is a statement about the server; "nothing matches what you typed" is a statement about the box. A
+    // reader who saw the first one after typing would conclude the links were gone.
+    if (shown.length === 0) {
+      ssoConfigurationPage.renderTransferMessage(
+        container,
+        tr(
+          "config.linked_accounts_filter_empty",
+          "No linked account matches the filter. {total} are loaded.",
+          { total: String(accounts.length) },
         ),
       );
       return;
@@ -3966,13 +4047,28 @@ const ssoConfigurationPage = {
     table.appendChild(head);
 
     const body = document.createElement("tbody");
-    accounts.forEach((account) => {
+    shown.forEach((account) => {
       body.appendChild(
         ssoConfigurationPage.renderLinkedAccountRow(page, account),
       );
     });
     table.appendChild(body);
     container.appendChild(table);
+
+    // THE COUNT LINE IS WHAT MAKES A FILTERED TABLE HONEST. Without it a narrowed table looks exactly like
+    // a complete one, and an administrator counting rows to answer "how many accounts are linked" gets the
+    // filter's answer instead of the server's. Rendered only while a filter is narrowing something, so an
+    // unfiltered table gains no furniture.
+    if (shown.length !== accounts.length) {
+      const count = document.createElement("div");
+      count.className = "fieldDescription";
+      count.textContent = tr(
+        "config.linked_accounts_filter_count",
+        "Showing {shown} of {total} linked accounts.",
+        { shown: String(shown.length), total: String(accounts.length) },
+      );
+      container.appendChild(count);
+    }
   },
   renderLinkedAccountRow: (page, account) => {
     const row = document.createElement("tr");
@@ -6009,6 +6105,19 @@ function initAccountsPage(view) {
       e.preventDefault();
       return false;
     });
+
+  // The filter re-renders from the roster already held and asks the server for nothing (#1529). Bound on
+  // `input` rather than on `change` so the table narrows while the reader types: `change` on a search box
+  // waits for a blur or an Enter, which reads as a filter that does not work.
+  //
+  // `container` is looked up per event rather than captured, because the region is replaced on every load
+  // and a captured node would be one that is no longer in the page.
+  view.querySelector("#LinkedAccountsFilter").addEventListener("input", () => {
+    ssoConfigurationPage.renderLinkedAccounts(
+      view,
+      view.querySelector("#LinkedAccountsResult"),
+    );
+  });
 
   ssoConfigurationPage.loadLinkedAccounts(view);
 

--- a/docs/ui/mock/FIELDS.md
+++ b/docs/ui/mock/FIELDS.md
@@ -14,12 +14,12 @@ The count is read off the pages rather than written here:
 $ node tools/ui-mock-fields.js
 configPage.html:     0 form controls outside HTML comments
 providersPage.html:107 form controls outside HTML comments
-accountsPage.html:   1 form controls outside HTML comments
+accountsPage.html:   2 form controls outside HTML comments
 policiesPage.html:  12 form controls outside HTML comments
 serverPage.html:     3 form controls outside HTML comments
-the five pages:    123 in total
-FIELDS.md:         123 rows
-fields.js:         123 entries
+the five pages:    124 in total
+FIELDS.md:         124 rows
+fields.js:         124 entries
 controllers:         5 page controllers checked against the ids their page declares
 page names:         14 registered by SSOPlugin.GetPages, checked against every tab link, controller and core reference
 every field has one row, no row names a field the pages lost, every field is on the page and inside the risk region its row names, no controller reaches off its own page, and every link names a page the plugin registers
@@ -77,11 +77,12 @@ section below.
 ## What is not a field
 
 Four rows are the mechanism of a button rather than a setting, and they are in
-the table anyway, because a table four short of the number cannot be reconciled
+the table anyway, because a table five short of the number cannot be reconciled
 against it:
 
 - `ImportConfigFile` - the file picker behind Import configuration, not a setting
 - `ImportLinksFile` - the file picker behind Import account links, not a setting
+- `LinkedAccountsFilter` - the filter over the linked-accounts table, not a setting
 - `selectProvider` - hidden state holder the save path reads back, not a setting
 - `saml-selectProvider` - hidden state holder the save path reads back, not a setting
 
@@ -203,6 +204,7 @@ from the server rather than set, so no row lands there. That follows the plan in
 | `DoNotValidateIssuerName`                 | checkbox | Security & hardening             | Providers | Insecure              | insecure  |                                                                                      |
 | `DoNotValidateResponseIssuer`             | checkbox | Security & hardening             | Providers | Insecure              | insecure  |                                                                                      |
 | `saml-DoNotValidateAudience`              | checkbox | Security & hardening             | Providers | Insecure              | insecure  |                                                                                      |
+| `LinkedAccountsFilter`                    | search   | Linked Accounts                  | Accounts  | Linked accounts       | -         | the filter over the linked-accounts table, not a setting                             |
 | `ImportLinksFile`                         | file     | Export / Import Configuration    | Accounts  | Export and import     | -         | the file picker behind Import account links, not a setting                           |
 | `selectProvisioningProfile`               | select   | Provisioning Profiles            | Policies  | Profile editor        | -         |                                                                                      |
 | `ProvisioningProfileName`                 | text     | Provisioning Profiles            | Policies  | Profile editor        | -         |                                                                                      |

--- a/docs/ui/mock/fields.js
+++ b/docs/ui/mock/fields.js
@@ -24,6 +24,15 @@ window.SSO_MOCK_FIELDS = [
     note: "the file picker behind Import configuration, not a setting",
   },
   {
+    id: "LinkedAccountsFilter",
+    type: "search",
+    risk: "",
+    block: "Linked Accounts",
+    tab: "Accounts",
+    accordion: "Linked accounts",
+    note: "the filter over the linked-accounts table, not a setting",
+  },
+  {
     id: "ImportLinksFile",
     type: "file",
     risk: "",

--- a/tools/ui-account-filter.js
+++ b/tools/ui-account-filter.js
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Drives the REAL linked-accounts renderer of the shipped sso-core.js and
+ * refuses each way its filter can mislead (#1529).
+ *
+ * WHY THIS IS A RUNNING PROOF. Every rule this tree has over these assets reads
+ * their TEXT, and a filter is not a string: it is a decision about which rows a
+ * reader is shown and whether the page says so. The two ways it goes wrong are
+ * both silent.
+ *
+ * A NARROWED TABLE THAT DOES NOT SAY IT IS NARROWED looks exactly like a
+ * complete one. An administrator counting rows to answer "how many accounts are
+ * linked" then gets the filter's answer instead of the server's, and nothing on
+ * the page contradicts them. So a filtered render must carry a count line, and
+ * an unfiltered one must not - furniture that is always there stops being read.
+ *
+ * A FILTER THAT MATCHES NOTHING MUST NOT SAY THE SERVER HAS NOTHING. "No account
+ * holds a link" is a statement about the server; "nothing matches what you
+ * typed" is about the box. A reader who saw the first after typing would
+ * conclude the links were gone, and on a page whose other button revokes links
+ * that is a conclusion with consequences.
+ *
+ * THE THIRD PROPERTY IS THAT IT ASKS THE SERVER FOR NOTHING. The roster is
+ * elevation-gated and rate-limited; a filter that re-fetched would spend one
+ * call per keystroke on data that has not changed, and would hit the limiter on
+ * a six-letter word.
+ *
+ * WHAT THE STUB CAN AND CANNOT SAY. The DOM below is the smallest one the
+ * renderer touches: createElement for the tags it builds, appendChild,
+ * replaceChildren, textContent, classList, setAttribute, addEventListener and
+ * querySelector by id. It is not a browser and it has no layout, no CSS and no
+ * event dispatch, so it cannot say what the table LOOKS like or that the input
+ * is reachable by keyboard. What it can say is which rows were built and which
+ * sentence was written, which is what the three properties above are about.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-mock-fields.js and tools/ui-untranslated.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CORE = path.join(HERE, "..", "SSO-Auth", "Web", "sso-core.js");
+
+// ---------------------------------------------------------------------------
+// The stub.
+// ---------------------------------------------------------------------------
+
+class Element {
+  constructor(tag) {
+    this.tag = tag;
+    this.children = [];
+    this.attributes = {};
+    this.classes = new Set();
+    this.value = "";
+    this.text = "";
+    this.classList = {
+      add: (...names) => names.forEach((name) => this.classes.add(name)),
+    };
+  }
+
+  set className(value) {
+    this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+  }
+
+  set textContent(value) {
+    this.text = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join(" ")
+      : this.text;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  addEventListener() {}
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...nodes) {
+    this.children = nodes;
+    this.text = "";
+  }
+
+  /** Every element under this one with the given tag, at any depth. */
+  all(tag) {
+    return this.children.flatMap((child) => [
+      ...(child.tag === tag ? [child] : []),
+      ...child.all(tag),
+    ]);
+  }
+}
+
+function pageWith(filterValue) {
+  const filter = new Element("input");
+  filter.value = filterValue;
+  const container = new Element("div");
+  const nodes = {
+    LinkedAccountsFilter: filter,
+    LinkedAccountsResult: container,
+  };
+  return {
+    page: { querySelector: (selector) => nodes[selector.slice(1)] ?? null },
+    filter,
+    container,
+  };
+}
+
+// BOTH spellings, because the renderer uses both. The row builder reaches for a
+// bare `document` and renderTransferMessage for `window.document`; one stub
+// object behind both names is what keeps this a test of the shipped code rather
+// than of whichever spelling the stub happened to provide.
+globalThis.document = {
+  createElement: (tag) => new Element(tag),
+};
+globalThis.window = { document: globalThis.document };
+
+// ---------------------------------------------------------------------------
+// The fixture and the legs.
+// ---------------------------------------------------------------------------
+
+/** Three accounts whose only overlap is deliberate, so each arm can aim. */
+const ROSTER = {
+  Accounts: [
+    {
+      Username: "alice",
+      UserId: "1",
+      AccountExists: true,
+      Links: [
+        {
+          Provider: "keycloak",
+          Protocol: "OIDC",
+          CanonicalName: "alice@example.com",
+          LastSsoLoginUtc: null,
+        },
+      ],
+    },
+    {
+      Username: "bob",
+      UserId: "2",
+      AccountExists: true,
+      Links: [
+        {
+          Provider: "authentik",
+          Protocol: "OIDC",
+          CanonicalName: "bob@example.com",
+          LastSsoLoginUtc: null,
+        },
+      ],
+    },
+    {
+      Username: "carol",
+      UserId: "3",
+      AccountExists: true,
+      Links: [
+        {
+          Provider: "keycloak",
+          Protocol: "SAML",
+          CanonicalName: "S-1-5-21-carol",
+          LastSsoLoginUtc: null,
+        },
+      ],
+    },
+  ],
+};
+
+async function loadCore() {
+  const source = fs.readFileSync(CORE, "utf8");
+  const url =
+    "data:text/javascript;base64," +
+    Buffer.from(source, "utf8").toString("base64");
+  return (await import(url)).default;
+}
+
+const core = await loadCore();
+const faults = [];
+const refuse = (leg, detail) => faults.push(leg + ": " + detail);
+
+/** Renders the fixture through the shipped renderer and reports what came out. */
+function render(filterValue, roster = ROSTER) {
+  const { page, container } = pageWith(filterValue);
+  core.renderLinkedAccounts(page, container, roster);
+  const rows = container.all("tbody").flatMap((body) => body.children);
+  const notes = container.children
+    .filter((child) => child.tag !== "table")
+    .map((child) => child.textContent);
+  return { rows, notes, container };
+}
+
+// ---- Arm: no filter shows every row and adds no count line ----
+{
+  const { rows, notes } = render("");
+  if (rows.length !== 3) {
+    refuse(
+      "unfiltered",
+      `${rows.length} rows rendered where the roster holds 3`,
+    );
+  }
+  if (notes.length !== 0) {
+    refuse(
+      "unfiltered",
+      `an unfiltered table carries the line "${notes.join(" ")}", and furniture that is always there stops being read`,
+    );
+  }
+}
+
+// ---- Arm: a narrowing filter shows the matches AND says it narrowed ----
+{
+  const { rows, notes } = render("bob");
+  if (rows.length !== 1) {
+    refuse(
+      "narrowed",
+      `${rows.length} rows rendered where one account matches "bob"`,
+    );
+  }
+  if (notes.length !== 1 || !/1/.test(notes[0]) || !/3/.test(notes[0])) {
+    refuse(
+      "narrowed",
+      `a narrowed table must say how many of how many are shown; it said "${notes.join(" ")}"`,
+    );
+  }
+}
+
+// ---- Arm: the filter reaches the provider and the subject, not just the name ----
+for (const [leg, needle, expected] of [
+  ["by-provider", "keycloak", 2],
+  ["by-protocol", "saml", 1],
+  ["by-subject", "example.com", 2],
+  ["case", "KEYCLOAK", 2],
+]) {
+  const { rows } = render(needle);
+  if (rows.length !== expected) {
+    refuse(
+      leg,
+      `"${needle}" matched ${rows.length} rows where ${expected} were expected, so the filter does not reach every value a reader arrives with`,
+    );
+  }
+}
+
+// ---- Arm: a filter matching nothing says so, and does not say the server is empty ----
+{
+  const { rows, container } = render("nobody-by-that-name");
+  const said = container.children.map((child) => child.textContent).join(" ");
+  if (rows.length !== 0) {
+    refuse("no-match", `${rows.length} rows survived a filter nothing matches`);
+  }
+  if (!/filter/i.test(said)) {
+    refuse(
+      "no-match",
+      `a filter with no match said "${said}", which does not name the filter as the reason`,
+    );
+  }
+  if (/No Jellyfin account holds an SSO link/.test(said)) {
+    refuse(
+      "no-match",
+      "a filter with no match claimed the server holds no linked account, which is a statement about the server and not about the box",
+    );
+  }
+}
+
+// ---- Arm: an empty roster says the server is empty, whatever is typed ----
+{
+  const { container } = render("alice", { Accounts: [] });
+  const said = container.children.map((child) => child.textContent).join(" ");
+  if (!/No Jellyfin account holds an SSO link/.test(said)) {
+    refuse(
+      "empty-roster",
+      `a server with no linked account said "${said}" instead of saying so`,
+    );
+  }
+}
+
+// ---- Arm: re-rendering asks the server for nothing ----
+{
+  // The roster is passed ONCE and then held. A second render without one must
+  // still draw the table: if it fetched instead, this call would need ApiClient,
+  // which is not defined here at all, and the arm would throw rather than pass.
+  const { page, container } = pageWith("");
+  core.renderLinkedAccounts(page, container, ROSTER);
+  const again = pageWith("carol");
+  core.renderLinkedAccounts(again.page, again.container);
+  const rows = again.container.all("tbody").flatMap((body) => body.children);
+  if (rows.length !== 1) {
+    refuse(
+      "held-roster",
+      `a re-render without a roster drew ${rows.length} rows, so the filter does not work off what is already loaded`,
+    );
+  }
+}
+
+if (faults.length) {
+  faults.forEach((fault) => console.error(fault));
+  console.error(
+    faults.length + " refusal(s) in the linked-accounts filter (#1529)",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "account filter:    eight arms run against the shipped sso-core.js renderer",
+);
+console.log("  unfiltered       every row is drawn and no count line is added");
+console.log(
+  "  narrowed         the matches are drawn and the page says how many of how many",
+);
+console.log(
+  "  by-provider / by-protocol / by-subject / case   the filter reaches every value a reader arrives with",
+);
+console.log(
+  "  no-match         a filter with no match names the filter, and never claims the server is empty",
+);
+console.log(
+  "  empty-roster     a server with no linked account says so, whatever is typed",
+);
+console.log(
+  "  held-roster      a re-render works off the roster already loaded and asks for nothing",
+);


### PR DESCRIPTION
# What & why

Refs #1529, stage 3's first bullet. No closing keyword: the pending-approval half
of that bullet and two more bullets are still to do.

Search and filter over the linked accounts. One box above the table, matching the
account name, the provider, the protocol and the identity-provider subject - the
last of which is what an administrator usually arrives with, because it is what
the provider's own console shows them.

**Two properties are what this is actually about**, and both fail silently.

A narrowed table that does not say so looks exactly like a complete one. An
administrator counting rows to answer "how many accounts are linked" would get
the filter's answer instead of the server's, with nothing on the page to
contradict them. So a narrowed render carries a count line, and an unfiltered one
does not: furniture that is always there stops being read.

A filter with no match must not say the server has nothing. "No account holds a
link" is a statement about the server; "nothing matches what you typed" is about
the box. A reader who saw the first after typing would conclude the links were
gone, on the page whose other button revokes links.

It asks the server for nothing. The roster is elevation-gated and rate-limited,
and a filter that re-fetched would spend a call per keystroke on data that has
not changed, hitting the limiter on a six-letter word.

The German is mine and has been read; the vouch line is at the end.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved. Untouched. The filter narrows what is drawn and
      changes no state; the revoke beside it is unchanged, and a row that
      survives the filter carries exactly the button it carried before.
- [x] No secrets logged; secrets are redacted on config export. Untouched. The
      filter reads the roster, which carries no secret.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. None of the three is touched.
      Two properties were checked deliberately: the filter is not a persisting
      field, so a save cannot write it anywhere, and it drives no request, so it
      cannot be used to walk the rate limiter. Every cell still renders through
      textContent, which matters here because the values it now matches on are
      the attacker-influenced ones.
- [x] Review record: **CONFIRMED 1 / PLAUSIBLE 0**. The finding is the `tr()`
      fallback described in the notes, found by the new gate and fixed here.
      Disposition: FIX.
- [x] Log inputs from the IdP are sanitized inline at the log call. No logging.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The match is one function over one string per row, and the
      render decides once which rows it was given.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and the new property is locked in as
      `tools/ui-account-filter.js`, which drives the shipped renderer. The new
      control is registered in both halves of the field register, so the
      reconciliation counts 124 where it counted 123.
- [x] Docs impact considered: `docs/ui/mock/FIELDS.md` is updated in the same
      commit, which is what that file is for. No README or wiki change.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings.
- [x] `dotnet test` is green. 3872 on net9.0 and 3873 on net10.0, 0 failed, each
      run on an otherwise idle machine.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

All seven browser gates run green.

## Notes

**A defect the new gate found, and it is older than this change.** `tr()`
returned its English default verbatim when no localization module was loaded, so
every PARAMETERISED call rendered its braces. Before the catalogue arrives, and
permanently on a server whose fetch fails, a reader saw "Deleted account ({id})"
and "Showing {shown} of {total} linked accounts." The default is the same string
the catalogue carries, placeholders included; the only question was whether
anything filled them, and on that path nothing did. The fallback now substitutes
the same way `i18n.js` does, leaving an absent parameter as it stands.

It was found because the gate drives the renderer with no localization module at
all, which is precisely the state that branch describes. It is fixed here rather
than deferred because the sentence this change adds is one of the ones that was
broken.

**The gate was run against two broken builds before being trusted.** With the
count line made unconditional it refuses the unfiltered arm; with the empty-filter
sentence replaced by the empty-server one it refuses the no-match arm twice.

Catalogue-Vouch: de read by iderex

The German has been read. What the reader was asked to look at was the five new
rows, and above all that the two empty states say different things: one about the
server, one about the box.
