### PR TITLE
Record which account this plugin provisioned inert, and when

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
@@ -63,6 +63,14 @@ public partial class ArchitectureConformanceTests
         //   ONE shape this rule has to keep out: a per-login event log would need a cap and a sweep, and the
         //   reason this needs neither is the bound, so the exemption is granted to the bounded design and not
         //   to the subject matter.
+        // - ProviderConfigBase._canonicalLinkPendingApprovals: the persisted per-link pending-approval
+        //   records (#1529), bounded by the link map exactly as the two above are - written only beside a
+        //   link this plugin's own create arm wrote, removed with the link on every route that removes one,
+        //   and cleared by every route that writes the same key for any other reason. The bound is what is
+        //   exempted here and not the subject: this map decides whether an account is OFFERED FOR APPROVAL,
+        //   so an entry that outlived its link would be an offer to enable an account with no SSO route
+        //   left. Its value names the account it was written about, so the bound holds over the ACCOUNT and
+        //   not merely over the key, which a subject whose account was deleted does not keep.
         // - DeclarativeManagedProviders._profiles: the provisioning-profile-name-to-source map (#1102), the
         //   same immutable shape as the two below and exempt for the same reason, on the object a managed
         //   provider provisions THROUGH rather than on the provider.
@@ -76,7 +84,7 @@ public partial class ArchitectureConformanceTests
         //   fields were HashSets until a refusal had to say WHICH source owns a provider, so what changed is
         //   the value beside each name, not where the state lives or how long it lives.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins", "DeclarativeManagedProviders._oid", "DeclarativeManagedProviders._saml", "DeclarativeManagedProviders._profiles" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins", "ProviderConfigBase._canonicalLinkPendingApprovals", "DeclarativeManagedProviders._oid", "DeclarativeManagedProviders._saml", "DeclarativeManagedProviders._profiles" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/Config/PendingApprovalRecordTests.cs
+++ b/SSO-Auth.Tests/Config/PendingApprovalRecordTests.cs
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Jellyfin.Data;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The pending-approval record (#1529): that it says what this plugin DID rather than what it can guess,
+/// that it cannot outlive the link that gives it meaning, and that it cannot follow a key onto an account
+/// it was never written about.
+/// <para>
+/// The whole reason the record exists is that a disabled account is a Jellyfin PERMISSION and the permission
+/// does not say who set it. Three accounts wear the same flag - one provisioned inert by this plugin seconds
+/// ago, one disabled by an administrator as a sanction, one disabled long ago and forgotten - and a surface
+/// offering to approve "the disabled accounts" would offer to undo the second. So the tests below assert the
+/// NEGATIVE cases as hard as the positive one: a provisioning that was not inert leaves nothing behind, and
+/// the race loser that abandons its account leaves nothing either.
+/// </para>
+/// <para>
+/// The second property is the bound, and it has two halves because the key is bounded by the link map while
+/// the ACCOUNT behind that key is not. Every route that removes a link is asserted to remove the record;
+/// every route that WRITES one over an existing key is asserted to clear it, because a link whose target was
+/// deleted counts as absent and the next login for that subject writes the key at another account. The last
+/// test is the backstop under both: a record naming an account the link no longer points at is reported as
+/// no record at all, so a write path that forgets is a tidiness defect and not an offer to enable somebody
+/// else's account. Each is driven through the route rather than read off the code.
+/// </para>
+/// </summary>
+public class PendingApprovalRecordTests
+{
+    private static readonly Guid User = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid Other = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid Deleted = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AProvisioningThatCreatesTheAccountInert_RecordsTheAccountAndTheInstant()
+    {
+        // The call site. Without it the map is a field nothing fills and the accounts page has no list. The
+        // account is asserted beside the instant because it is the half that makes the record refutable: an
+        // instant alone would describe whichever account the key came to name later.
+        var config = new OidConfig { Enabled = true, EnableAuthorization = true, ProvisionNewUsersDisabled = true };
+        var (service, users, configuration) = BuildLogin(config);
+        Provisionable(users);
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var record = Assert.Single(config.CanonicalLinkPendingApprovals).Value;
+        Assert.Equal("sub-1", Assert.Single(config.CanonicalLinkPendingApprovals).Key);
+        Assert.Equal(User, record.UserId);
+        Assert.Equal(Now, record.SinceUtc);
+        Assert.NotNull(configuration);
+    }
+
+    [Fact]
+    public async Task AnOrdinaryProvisioning_RecordsNothing()
+    {
+        // The negative that carries the feature. An account created ENABLED is not waiting for anybody, and a
+        // record for it would put a working account on an approval list - where pressing the button is a no-op
+        // and the list stops meaning what it says.
+        var config = new OidConfig { Enabled = true, EnableAuthorization = true, ProvisionNewUsersDisabled = false };
+        var (service, users, _) = BuildLogin(config);
+        Provisionable(users);
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void ARecordIsRemovedWithItsLink()
+    {
+        // Every route that removes a link must remove the record, because the record is an OFFER TO ENABLE and
+        // an offer whose link is gone points at an account with no SSO route left. This drives the unlink
+        // rather than reading it.
+        var config = new OidConfig { Enabled = true };
+        var configuration = Holding(config, "sub-1", User);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(User).Returns(TestUsers.Named("alice", User));
+
+        service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", User);
+
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void AProviderPurge_TakesEveryRecordWithTheLinks()
+    {
+        // The purge empties the link map wholesale, so it empties this one in the same transaction. Nothing
+        // survives a provider whose links are gone: a record left here would name a provider that can no
+        // longer explain why anybody is inert.
+        var config = new OidConfig { Enabled = true };
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinkPendingApprovals["sub-gone"] = Record(User);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(Arg.Any<Guid>()).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+
+        service.TryPurgeProviderLinks(ProviderMode.Oid, "kc", 0, System.Array.Empty<AccountDoors>());
+
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void ARecordWhoseLinkTheUnregisterRevoked_IsPrunedAndItsNeighbourIsNot()
+    {
+        // The bulk route removes links directly rather than through the single unlink, so it carries its own
+        // prune - and a record missed there would be exactly the standing offer this map must not become.
+        // The neighbour is asserted as hard as the removal: this prune is keyed, not a sweep, so revoking one
+        // account's links must not empty the approval list for everybody else.
+        var config = new OidConfig { Enabled = true };
+        var configuration = Holding(config, "sub-1", User);
+        config.CanonicalLinks["sub-other"] = Other;
+        config.CanonicalLinkPendingApprovals["sub-other"] = Record(Other);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(Arg.Any<Guid>()).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+
+        service.RemoveUserEverywhere(User);
+
+        Assert.False(config.CanonicalLinkPendingApprovals.ContainsKey("sub-1"));
+        Assert.True(config.CanonicalLinkPendingApprovals.ContainsKey("sub-other"));
+    }
+
+    [Fact]
+    public async Task TheRaceLoser_RecordsNothing()
+    {
+        // #133 read as this map sees it. Two first logins for one identity run at once; the loser finds the
+        // winner's link already written, keeps the account it created, and writes no link - so it must write
+        // no record either, or it would offer an administrator the account it just abandoned. The property
+        // lives in WHERE the record is written (inside the branch only the writer enters), which is exactly
+        // the kind of placement that survives a refactor only if something drives it: the winner's link is
+        // planted from inside CreateUserAsync, which is the window the race actually opens.
+        var config = new OidConfig { Enabled = true, AllowExistingAccountLink = false };
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+
+        var service = BuildLinks(configuration, out var users);
+        var created = TestUsers.Named("alice", User);
+        users.GetUserByName(Arg.Any<string>()).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+        users.GetUserById(User).Returns(created);
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+        users.CreateUserAsync(Arg.Any<string>()).Returns(_ =>
+        {
+            config.CanonicalLinks["sub-1"] = Other;
+            return Task.FromResult(created);
+        });
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisionDisabled: true);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task AnAdoptionOverADanglingLink_DropsTheRecordItFound()
+    {
+        // THE ONE THIS FEATURE TURNS ON, and the one the removal routes alone do not cover. The account this
+        // plugin provisioned inert was DELETED rather than unlinked - which is the only rejection route an
+        // administrator has today - so the link dangles and its record stands. A dangling link counts as
+        // absent, so the next login for the same subject writes the key again, and here it writes it at an
+        // account that already existed. Inheriting the record would put somebody else's account on the
+        // approval list, including one an administrator disabled deliberately, which is precisely the
+        // privilege escalation this map exists to prevent, arrived at from the other side.
+        var config = new OidConfig { Enabled = true, AllowExistingAccountLink = true };
+        var configuration = Holding(config, "sub-1", Deleted);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(Deleted).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ALegacyMigration_DropsTheRecordsOnBothKeys()
+    {
+        // The #155 re-key moves a link from the legacy username key onto the subject key, overwriting the
+        // subject key only when it dangles. Both keys lose their record for the same reason the adoption
+        // above does: neither write is this plugin provisioning an account inert, and the account the
+        // dangling record was written about is gone.
+        var config = new OidConfig { Enabled = true, AllowExistingAccountLink = true };
+        var configuration = Holding(config, "sub-1", Deleted);
+        config.CanonicalLinks["alice"] = Other;
+        config.CanonicalLinkPendingApprovals["alice"] = Record(Other);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(Deleted).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void AManualLink_DropsTheRecordTheKeyHeld()
+    {
+        // The admin/self link endpoint repoints a key on purpose, so it is the second route that can land on
+        // a key carrying a record. A manual link is nobody's provisioning, so whatever the key was recorded
+        // as before goes with the link it described.
+        var config = new OidConfig { Enabled = true };
+        var configuration = Holding(config, "sub-1", User);
+
+        var service = BuildLinks(configuration, out var users);
+        users.GetUserById(Arg.Any<Guid>()).Returns(TestUsers.Named("alice", Other));
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Other));
+
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void AnOrdinarySave_KeepsTheRecords()
+    {
+        // The records are withheld from JSON, so a configuration-page save arrives with the map empty. Without
+        // the preserve, an unrelated settings change would silently empty the approval list - and the
+        // accounts waiting on it would simply stop being offered, with nothing saying why.
+        var live = new OidConfig { OidEndpoint = "https://id.example.com" };
+        live.CanonicalLinkPendingApprovals["sub-1"] = Record(User);
+        var incoming = new OidConfig { OidEndpoint = "https://id.example.com" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.True(incoming.CanonicalLinkPendingApprovals.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void ARepointDropsTheRecordsWithTheLinks()
+    {
+        // A repoint re-identifies the provider, so a record carried across it would say this plugin
+        // provisioned an account inert for an identity the NEW provider has never seen - and that record is
+        // what makes the account approvable. Dropped with its link, the account stops being offered, which is
+        // the safe direction for a surface that grants access.
+        var live = new OidConfig { OidEndpoint = "https://id.example.com" };
+        live.CanonicalLinkPendingApprovals["sub-1"] = Record(User);
+        var incoming = new OidConfig { OidEndpoint = "https://other.example.com" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Empty(incoming.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void TheRecordIsWithheldFromJson_AndSurvivesTheXmlRoundTrip()
+    {
+        // The JsonIgnore is load-bearing here in a way it is not on the neighbouring maps: a config PUT that
+        // could forge an entry would make an account approvable that this plugin never provisioned, which is
+        // the same escalation as the stale record, reached from the other side. The XML half is asserted in
+        // the same test because the value is a class rather than an instant, so that it round-trips at all is
+        // a property of this change and not of the dictionary it is stored in.
+        var config = new OidConfig
+        {
+            OidClientId = "client",
+            CanonicalLinkPendingApprovals = new SerializableDictionary<string, PendingApproval> { ["sub-secret"] = Record(User) },
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("CanonicalLinkPendingApprovals", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-secret", json, StringComparison.Ordinal);
+
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("CanonicalLinkPendingApprovals", xml, StringComparison.Ordinal);
+
+        using var reader = new System.IO.StringReader(xml);
+        using var xmlReader = System.Xml.XmlReader.Create(
+            reader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var back = (OidConfig)serializer.Deserialize(xmlReader)!;
+
+        Assert.Equal(User, back.CanonicalLinkPendingApprovals["sub-secret"].UserId);
+        Assert.Equal(Now, back.CanonicalLinkPendingApprovals["sub-secret"].SinceUtc.ToUniversalTime());
+    }
+
+    [Fact]
+    public void APostedRecordIsDropped()
+    {
+        // The forge, driven rather than argued. The test above asserts the map does not LEAVE over the JSON
+        // boundary; this one asserts it cannot ARRIVE over it, which is the direction the escalation runs:
+        // a body naming an account and an instant would make that account approvable from the accounts page
+        // without this plugin ever having provisioned it inert. JsonIgnore suppresses both directions, and
+        // the value being a class rather than an instant does not change that - which is worth a row,
+        // because it is the kind of thing a converter added later could quietly change.
+        var posted = System.Text.Json.JsonSerializer.Deserialize<OidConfig>(
+            """{"OidClientId":"client","CanonicalLinkPendingApprovals":{"sub-forged":{"UserId":"33333333-3333-3333-3333-333333333333","SinceUtc":"2026-09-11T09:00:00Z"}}}""")!;
+
+        Assert.Equal("client", posted.OidClientId);
+        Assert.Empty(posted.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void TheRosterReportsTheRecordAndItsAbsence()
+    {
+        // The page reads the roster, so the record has to survive the trip. Both answers are asserted: an
+        // unrecorded link must report null rather than a default instant a reader would render as a date in
+        // year one, because null is what tells the page NOT to offer the row.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-pending"] = User;
+        config.CanonicalLinks["sub-ordinary"] = User;
+        config.CanonicalLinkPendingApprovals["sub-pending"] = Record(User);
+
+        var document = LinkRoster.Build(configuration, _ => "alice");
+
+        var links = Assert.Single(document.Accounts).Links;
+        Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "sub-pending").PendingApprovalSinceUtc);
+        Assert.Null(Assert.Single(links, l => l.CanonicalName == "sub-ordinary").PendingApprovalSinceUtc);
+    }
+
+    [Fact]
+    public void TheRosterRefusesARecordThatNamesAnotherAccount()
+    {
+        // THE BACKSTOP UNDER EVERY WRITE ROUTE, present and future. The record above is about a different
+        // account than the link now points at, so it describes nothing that is true of this row and the
+        // roster reports none. It is what keeps a write path that forgets to clear a record from becoming a
+        // page that offers to enable an account nobody provisioned inert - fail closed, at the cost of an
+        // administrator enabling one account by hand.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkPendingApprovals["sub-1"] = Record(Other);
+
+        var document = LinkRoster.Build(configuration, _ => "alice");
+
+        Assert.Null(Assert.Single(Assert.Single(document.Accounts).Links).PendingApprovalSinceUtc);
+    }
+
+    private static PendingApproval Record(Guid userId) => new PendingApproval { UserId = userId, SinceUtc = Now };
+
+    // A provider holding one link and the record that goes with it, which is the state every rebind test
+    // starts from.
+    private static PluginConfiguration Holding(OidConfig config, string canonicalName, Guid userId)
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks[canonicalName] = userId;
+        config.CanonicalLinkPendingApprovals[canonicalName] = Record(userId);
+        return configuration;
+    }
+
+    // An account the provisioning arm can actually create: no existing user answers the name, and the
+    // created one comes back so the disabled flag has somewhere to land.
+    private static void Provisionable(IUserManager users)
+    {
+        var created = TestUsers.Named("alice", User);
+        users.GetUserByName(Arg.Any<string>()).Returns((Jellyfin.Database.Implementations.Entities.User?)null);
+        users.GetUserById(User).Returns(created);
+        users.CreateUserAsync(Arg.Any<string>()).Returns(Task.FromResult(created));
+    }
+
+    private static AuthResponse Response() =>
+        new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity Identity() =>
+        TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: "sub-1",
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null,
+            ExpiresAtUtc: null));
+
+    private static CanonicalLinkService BuildLinks(PluginConfiguration configuration, out IUserManager users)
+    {
+        users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+    }
+
+    private static (LoginCompletionService Service, IUserManager Users, PluginConfiguration Configuration) BuildLogin(OidConfig config)
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, new CapturingLogger()), users, configuration);
+    }
+}

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -731,7 +731,7 @@ internal sealed class CanonicalLinkService
             // call actually wrote the link, in the same transaction. That placement is the whole guarantee: the
             // #133 race loser writes no link and therefore stamps no deadline over the winner's, and a deadline
             // can only ever come into existence beside a live link, which is what bounds the map.
-            var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer, provisionedAccessDuration);
+            var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer, provisionedAccessDuration, provisionDisabled);
 
             // The race loser is the one case that reaches here having written no link and still keeps its
             // account: LinkCanonicalIfAbsent returns the winner's id rather than throwing, so the guard
@@ -1403,6 +1403,13 @@ internal sealed class CanonicalLinkService
 
             links[providerUserId] = jellyfinUserId;
             StampIssuerInPlace(configuration, mode, provider, providerUserId, issuer);
+
+            // A manual link is not this plugin provisioning an account inert, so any pending-approval
+            // record under this key is about the account the key held before and goes with it (#1529).
+            // TryCreateLink repoints on purpose, so this is the one of the two entry points that can land
+            // on a key that carries one; the clear is written for both, because a rule that only holds on
+            // the arm somebody remembered is not a rule.
+            RemovePendingApproval(configuration, mode, provider, providerUserId);
             return CanonicalLinkWriteResult.Created;
         });
     }
@@ -1465,6 +1472,12 @@ internal sealed class CanonicalLinkService
             // history retained for a subject the server no longer knows, and a re-link of the same subject
             // would report a "last SSO login" that belongs to the previous holder of the key.
             RemoveLastSsoLogin(configuration, mode, provider, canonicalName);
+
+            // Drop the pending-approval mark alongside the link (#1529). The mark says this plugin created
+            // the account inert and it is waiting for an administrator; once the link is gone that sentence
+            // is no longer true of anything, and a mark that outlived it would keep an account on the
+            // approval list with no SSO route behind it.
+            RemovePendingApproval(configuration, mode, provider, canonicalName);
 
             // Whether the user keeps any other canonical link across ALL providers, read in the SAME
             // transaction as the removal (#468): computing it here rather than in a second lock acquisition
@@ -1567,6 +1580,15 @@ internal sealed class CanonicalLinkService
                     foreach (var staleKey in config.CanonicalLinkLastLogins.Keys.Where(k => !remaining.ContainsKey(k)).ToList())
                     {
                         config.CanonicalLinkLastLogins.Remove(staleKey);
+                    }
+
+                    // And the pending-approval marks (#1529), on both protocols and for a reason of its own:
+                    // a mark left behind here would keep offering an account for approval after the link
+                    // that explains why it is inert was revoked. The approve action would then enable an
+                    // account whose SSO route no longer exists - a grant of access nobody asked for.
+                    foreach (var staleKey in config.CanonicalLinkPendingApprovals.Keys.Where(k => !remaining.ContainsKey(k)).ToList())
+                    {
+                        config.CanonicalLinkPendingApprovals.Remove(staleKey);
                     }
                 }
             }
@@ -1759,6 +1781,7 @@ internal sealed class CanonicalLinkService
             {
                 config.CanonicalLinkDeadlines.Clear();
                 config.CanonicalLinkLastLogins.Clear();
+                config.CanonicalLinkPendingApprovals.Clear();
                 if (config is OidConfig oid)
                 {
                     oid.CanonicalLinkIssuers.Clear();
@@ -1896,7 +1919,7 @@ internal sealed class CanonicalLinkService
     // reports WroteLink=false (so the caller does not re-emit the adoption audit). The link write goes
     // straight into the config (no discarded ActionResult), so a failure to persist propagates rather
     // than falling through as a successful adoption.
-    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId, string? issuer, TimeSpan? provisionedAccessDuration = null)
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId, string? issuer, TimeSpan? provisionedAccessDuration = null, bool provisionedPendingApproval = false)
     {
         return _configStore.Mutate(configuration =>
         {
@@ -1929,6 +1952,18 @@ internal sealed class CanonicalLinkService
                 // sliding deadline is the one defect this direction of the feature can have, and this is the
                 // single place it is prevented rather than a rule restated at each caller.
                 StampProvisionedDeadlineInPlace(configuration, mode, provider, canonicalKey, provisionedAccessDuration);
+
+                // A link written by a login that provisioned its account INERT carries the pending-approval
+                // record (#1529), written in the same transaction as the link for the same reason the
+                // deadline is: the #133 race loser writes no link and must therefore leave no record, or it
+                // would offer an administrator an account it abandoned. The adopt arm never reaches here
+                // with the flag set, because adoption takes over an account that already exists and is not
+                // this plugin's to declare pending.
+                //
+                // Passed the id the link now holds, and a SET-OR-CLEAR: this is the branch that repoints a
+                // key whose previous account was deleted, and the record it may be repointing away from was
+                // written about that account. Clearing it here is what stops an adoption from inheriting it.
+                RecordPendingApprovalInPlace(configuration, mode, provider, canonicalKey, effectiveUserId, provisionedPendingApproval);
             }
 
             return (effectiveUserId, wroteLink);
@@ -1974,6 +2009,13 @@ internal sealed class CanonicalLinkService
                 // issuer (#186). The legacy key carried no issuer (it predates the store); the new key is
                 // bound to the login that migrated it, matching the create/adopt write paths.
                 StampIssuerInPlace(configuration, mode, provider, canonicalKey, issuer);
+
+                // Both keys lose any pending-approval record (#1529). The subject key is only overwritten
+                // here when it DANGLES, so a record under it was written about an account that is gone; the
+                // legacy key has no link left to explain one. Neither is this plugin provisioning an
+                // account inert, which is the only thing that may leave a record behind.
+                RemovePendingApproval(configuration, mode, provider, canonicalKey);
+                RemovePendingApproval(configuration, mode, provider, legacyKey);
                 return legacyUserId;
             }
 
@@ -2062,6 +2104,51 @@ internal sealed class CanonicalLinkService
         if (TryGetProvider(configuration, mode, provider, out var config))
         {
             config.CanonicalLinkLastLogins.Remove(canonicalKey);
+        }
+    }
+
+    // Records that THIS login provisioned the linked account disabled and awaiting an administrator
+    // (#1529), within the caller's already-held config transaction. The record names the account it was
+    // written for and the instant of the PROVISIONING, not of the approval, so the accounts page can say
+    // how long somebody has been waiting - which is the whole question an administrator opens that list
+    // with.
+    //
+    // A SET-OR-CLEAR rather than a stamp, and that is the security half of it. Every OTHER write of the
+    // same key is by definition not this plugin provisioning an account inert: it is an adoption, a manual
+    // link, or a re-key. Returning early there would leave the previous holder's record standing over a key
+    // that now names somebody else's account, which is a record of what the plugin did decaying into the
+    // guess this map exists to replace. Called from inside the link write, so the clear lands in the same
+    // transaction as the link that invalidated the record.
+    private void RecordPendingApprovalInPlace(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, Guid userId, bool provisionedPendingApproval)
+    {
+        if (!TryGetProvider(configuration, mode, provider, out var config))
+        {
+            return;
+        }
+
+        if (!provisionedPendingApproval)
+        {
+            config.CanonicalLinkPendingApprovals.Remove(canonicalKey);
+            return;
+        }
+
+        config.CanonicalLinkPendingApprovals[canonicalKey] = new PendingApproval
+        {
+            UserId = userId,
+            SinceUtc = _clock().ToUniversalTime(),
+        };
+    }
+
+    // Drops a link's pending-approval mark within the caller's already-held config transaction (#1529),
+    // called alongside a link removal. Its own named step beside the two above, because it is removed for a
+    // third reason: an orphan deadline is bookkeeping the sweep would act on and an orphan stamp is retained
+    // personal data, while an orphan MARK is an offer to enable an account - the only one of the three that
+    // grants anything.
+    private static void RemovePendingApproval(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey)
+    {
+        if (TryGetProvider(configuration, mode, provider, out var config))
+        {
+            config.CanonicalLinkPendingApprovals.Remove(canonicalKey);
         }
     }
 

--- a/SSO-Auth/Config/LinkExport.cs
+++ b/SSO-Auth/Config/LinkExport.cs
@@ -18,7 +18,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// <param name="UserId">The Jellyfin user id the link points at, which may no longer resolve to an account.</param>
 /// <param name="Issuer">The issuer this OpenID link is bound to (#186), or null for SAML and for links written before the binding existed.</param>
 /// <param name="LastSsoLoginUtc">The instant of the last successful SSO login through this link (#1120), or null when none has been stamped since the field existed.</param>
-internal readonly record struct CanonicalLinkRow(string Protocol, string Provider, string CanonicalName, Guid UserId, string? Issuer, DateTime? LastSsoLoginUtc);
+/// <param name="PendingApprovalSinceUtc">The instant this plugin provisioned the linked account disabled and awaiting an administrator (#1529), or null when it did not - which is every link but the ones its own create arm recorded, and every recorded one whose account is no longer the account the link points at.</param>
+internal readonly record struct CanonicalLinkRow(string Protocol, string Provider, string CanonicalName, Guid UserId, string? Issuer, DateTime? LastSsoLoginUtc, DateTime? PendingApprovalSinceUtc);
 
 /// <summary>
 /// Builds the portable account-link snapshot (#1126). It reads the two link maps and resolves each
@@ -69,7 +70,8 @@ internal static class LinkExport
                     link.Key,
                     link.Value,
                     config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null,
-                    LastSsoLogin(config, link.Key));
+                    LastSsoLogin(config, link.Key),
+                    PendingApprovalSince(config, link.Key, link.Value));
             }
         }
 
@@ -77,7 +79,7 @@ internal static class LinkExport
         {
             foreach (var link in config.CanonicalLinks)
             {
-                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null, LastSsoLogin(config, link.Key));
+                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null, LastSsoLogin(config, link.Key), PendingApprovalSince(config, link.Key, link.Value));
             }
         }
     }
@@ -135,6 +137,24 @@ internal static class LinkExport
     private static DateTime? LastSsoLogin(ProviderConfigBase config, string canonicalName) =>
         config.CanonicalLinkLastLogins.TryGetValue(canonicalName, out var stamped)
             ? stamped.ToUniversalTime()
+            : null;
+
+    // The pending-approval record for one link (#1529), keyed by the same canonical name and carried on
+    // both protocols. Null is the answer for EVERY link this plugin did not provision inert itself, which
+    // is almost all of them: the record says what the plugin did, and is never an inference from the
+    // account's disabled flag. Normalized to UTC like its neighbours.
+    //
+    // AND NULL AGAIN WHEN THE RECORD NAMES A DIFFERENT ACCOUNT than the link now points at. The key is a
+    // subject and a subject can change hands: a link whose target account was deleted counts as absent, so
+    // the next login writes the key at another account, by adoption or by a fresh provisioning. The write
+    // paths clear the record when that happens, and this comparison is what makes a path that forgets a
+    // tidiness defect instead of a page offering to enable an account nobody provisioned inert. Fail closed
+    // is the cheap direction here: the cost of refusing a stale record is an administrator enabling an
+    // account by hand, the cost of honouring one is undoing somebody's sanction from a page about
+    // something else.
+    private static DateTime? PendingApprovalSince(ProviderConfigBase config, string canonicalName, Guid linkedUserId) =>
+        config.CanonicalLinkPendingApprovals.TryGetValue(canonicalName, out var record) && record?.UserId == linkedUserId
+            ? record.SinceUtc.ToUniversalTime()
             : null;
 
     // A provider stored with a null config object is reachable through a null-bodied add (#350), and the

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -62,6 +62,7 @@ internal static class LinkRoster
                 Provider = row.Provider,
                 CanonicalName = row.CanonicalName,
                 LastSsoLoginUtc = row.LastSsoLoginUtc,
+                PendingApprovalSinceUtc = row.PendingApprovalSinceUtc,
             });
         }
 

--- a/SSO-Auth/Config/LinkRosterDocument.cs
+++ b/SSO-Auth/Config/LinkRosterDocument.cs
@@ -89,4 +89,18 @@ public class LinkedAccountEntry
     /// </para>
     /// </summary>
     public DateTime? LastSsoLoginUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the instant at which this plugin provisioned the linked account disabled and awaiting an
+    /// administrator (#1529), in UTC, or null when it did not. Null is the answer for every link but the ones
+    /// this plugin's own create arm recorded, and that is the point: a disabled account whose link carries no
+    /// record was disabled by somebody else, for a reason this plugin does not know and must not undo. Null
+    /// again when the record names an account other than the one the link now points at, because a subject
+    /// whose account was deleted is re-linked at another account and the record is about neither.
+    /// <para>
+    /// It is the PROVISIONING instant rather than the approval's, so a reader can see how long somebody has
+    /// been waiting - which is the question an approval list is opened with.
+    /// </para>
+    /// </summary>
+    public DateTime? PendingApprovalSinceUtc { get; set; }
 }

--- a/SSO-Auth/Config/PendingApproval.cs
+++ b/SSO-Auth/Config/PendingApproval.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// One record that this plugin provisioned a linked account disabled and awaiting an administrator
+/// (#1529): which account it did that to, and when.
+/// </summary>
+/// <remarks>
+/// THE ACCOUNT IS HALF THE RECORD, and it is written here rather than left implied by the map's key
+/// because the key is an identity-provider subject and a subject does not hold the same account for ever.
+/// A link whose target account was deleted counts as absent everywhere in this plugin, so the next login
+/// for that subject writes the key again - at a DIFFERENT account, by adoption or by a fresh provisioning.
+/// A mark carrying only an instant would survive that hand-off and go on describing whichever account the
+/// key now names, which is how a record of what this plugin DID turns back into the guess it exists to
+/// replace. Written beside the instant, the account is the thing a reader compares: a mark whose account
+/// is no longer the one the link points at describes nothing, and says so.
+/// <para>
+/// A plain XML-serializable class (public parameterless ctor + get/set), because it is stored as the value
+/// of a <see cref="SerializableDictionary{TKey,TValue}"/> on <see cref="ProviderConfigBase"/> - the shape
+/// <see cref="LogoutSession"/> already takes there. It holds no secret: a user id and an instant, both of
+/// which the administrator-only roster row beside it already carries.
+/// </para>
+/// </remarks>
+public class PendingApproval
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin account this plugin provisioned disabled and awaiting approval, as it
+    /// stood when the link was written. A mark is only about this account: when the link it is keyed
+    /// under points somewhere else, the mark is stale by definition and no reader may act on it.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the instant the account was provisioned, in UTC. The PROVISIONING instant rather than
+    /// the approval's, so a reader can see how long somebody has been waiting, which is the question an
+    /// approval list is opened with.
+    /// </summary>
+    public DateTime SinceUtc { get; set; }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -283,6 +283,7 @@ public abstract class ProviderConfigBase
     private SerializableDictionary<string, Guid>? _canonicalLinks;
     private SerializableDictionary<string, DateTime>? _canonicalLinkDeadlines;
     private SerializableDictionary<string, DateTime>? _canonicalLinkLastLogins;
+    private SerializableDictionary<string, PendingApproval>? _canonicalLinkPendingApprovals;
 
     /// <summary>
     /// Gets or sets the canonical external base URL for this provider, e.g.
@@ -711,6 +712,54 @@ public abstract class ProviderConfigBase
     {
         get => _canonicalLinkLastLogins ??= new SerializableDictionary<string, DateTime>();
         set => _canonicalLinkLastLogins = value;
+    }
+
+    /// <summary>
+    /// Gets or sets, per canonical link, the record that THIS PLUGIN provisioned the linked account
+    /// disabled and awaiting an administrator (#1529): the account and the instant. Written only on the
+    /// create arm under <see cref="ProviderConfigBase.ProvisionNewUsersDisabled"/>, and only by the login
+    /// that actually wrote the link; cleared by any other write of the same key, and removed when the link
+    /// is. It is NOT yet removed when an account is enabled, because nothing in this plugin enables one: a
+    /// record therefore says what was true at provisioning, and the surface that comes to read it owes its
+    /// reader a check of what is true now (#1529).
+    /// <para>
+    /// It exists because a disabled account is a Jellyfin PERMISSION and the permission does not say who set
+    /// it or why. Three accounts wear the same flag: one this plugin created inert seconds ago, one an
+    /// administrator disabled deliberately as a sanction, and one disabled long ago and forgotten. A surface
+    /// that offered to approve "the disabled accounts" would offer to undo the second, from a page about
+    /// something else - which is a privilege escalation with no attacker in it, and therefore the kind that
+    /// happens. This map is the difference between what the plugin DID and what the plugin can GUESS, and
+    /// only the first is safe to act on.
+    /// </para>
+    /// <para>
+    /// Keyed by the same stable subject as <see cref="ProviderConfigBase.CanonicalLinks"/>, so its
+    /// cardinality is bounded by the link map rather than growing on its own, and an entry cannot outlive
+    /// the link that gives it meaning. An account approved, revoked or unlinked loses its entry; a
+    /// configuration that predates this map simply has none, and the pending list starts empty and fills as
+    /// new accounts arrive rather than claiming a history it never recorded.
+    /// </para>
+    /// <para>
+    /// The value names its account (<see cref="PendingApproval.UserId"/>) and not only the instant, because
+    /// the KEY is bounded by the link map while the account behind that key is not: a link whose target was
+    /// deleted counts as absent, so the next login for the same subject writes the key again at a different
+    /// account. Every reader compares the recorded account against the link's current target and treats a
+    /// mismatch as no mark at all, which is what makes a write path that forgets to clear a stale entry a
+    /// tidiness defect rather than an offer to enable somebody else's account.
+    /// </para>
+    /// </summary>
+    // Server-managed exactly like CanonicalLinks and the two maps above: written by logins, never
+    // admin-edited, persisted in the config XML but withheld from every JSON response ([JsonIgnore]).
+    // The JsonIgnore is load-bearing HERE in a way it is not on the neighbours: a config PUT that could
+    // forge an entry would make an account APPROVABLE from the accounts page that this plugin never
+    // provisioned - which is exactly the escalation the map exists to prevent, arrived at from the other
+    // side. Preserved on save by ServerManagedFields.Preserve. Self-healing lazy init, so a direct index
+    // assignment persists into the stored map.
+    [XmlElement("CanonicalLinkPendingApprovals")]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SerializableDictionary<string, PendingApproval> CanonicalLinkPendingApprovals
+    {
+        get => _canonicalLinkPendingApprovals ??= new SerializableDictionary<string, PendingApproval>();
+        set => _canonicalLinkPendingApprovals = value;
     }
 }
 

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -122,6 +122,13 @@ internal static class ServerManagedFields
         // provider no longer knows, with no administrator route left to erase it.
         incoming.CanonicalLinkLastLogins = endpointUnchanged ? live.CanonicalLinkLastLogins : new SerializableDictionary<string, DateTime>();
 
+        // The pending-approval marks ride with the links on both arms as well (#1529), and the DROP arm is
+        // again the one that decides something: a repoint re-identifies the provider, so a mark carried
+        // across it would say this plugin provisioned an account inert for an identity the new provider has
+        // never seen - and that mark is what makes an account approvable from the accounts page. Dropped
+        // with its link, the account simply stops being offered for approval, which is the safe direction.
+        incoming.CanonicalLinkPendingApprovals = endpointUnchanged ? live.CanonicalLinkPendingApprovals : new SerializableDictionary<string, PendingApproval>();
+
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
 
@@ -157,6 +164,12 @@ internal static class ServerManagedFields
         // with the map empty and re-injecting the live one is what stops an unrelated settings change silently
         // resetting every "last SSO login" in the roster to never.
         incoming.CanonicalLinkLastLogins = live.CanonicalLinkLastLogins;
+
+        // Same shape again for the pending-approval marks (#1529), and the same consequence if it is left
+        // out: withheld from JSON, so an ordinary settings save arrives with the map empty, and without this
+        // line every account waiting for approval would quietly stop being offered for one - the list would
+        // empty itself on a save that had nothing to do with it.
+        incoming.CanonicalLinkPendingApprovals = live.CanonicalLinkPendingApprovals;
         incoming.SamlSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlSigningKeyPfx, live.SamlSigningKeyPfx);
         incoming.SamlRolloverSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlRolloverSigningKeyPfx, live.SamlRolloverSigningKeyPfx);
     }


### PR DESCRIPTION
# What & why

Stage 3 of #1529, the half the threat model on that issue turned on. No new endpoint, no new grant and no UI: the plugin writes down what it DID, so the surface that comes next can offer an approval without having to guess.

A disabled account is a Jellyfin PERMISSION, and the permission does not say who set it. Three accounts wear the same flag: one this plugin created inert seconds ago, one an administrator disabled deliberately as a sanction, one disabled long ago and forgotten. A page offering to approve "the disabled accounts" would offer to undo the second, which is a privilege escalation with no attacker in it.

So the record is written where only the login that actually WROTE the link can reach it, in the same configuration transaction as the link. It names the ACCOUNT as well as the instant, every write of the same key that is not an inert provisioning clears it, and the roster reports no record when the account named is not the account the link points at. The three together are what make the map a statement about what this plugin did rather than about what it can infer.

The account binding is what the security review added, and the reason it is not optional: the KEY is bounded by the link map, the ACCOUNT behind that key is not. A link whose target was deleted counts as absent, and deleting the account is the only rejection route an administrator has today, so the next login for that subject writes the key again at a different account. A record carrying only an instant would have followed it there.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The new read is fail-closed in the same
      sense: a record whose account is not the link's current target reports as
      no record at all, so the safe answer is the default one.
- [x] No secrets logged; secrets are redacted on config export. The map holds a
      user id and an instant, is withheld from JSON, and is not carried into the
      portable link export at all.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      1 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. This change
      adds no log call.

### Review record

**Pass 1, the pre-merge review of the record as first written.** One finding, then two independent verifiers on it.

- Finding: the record was keyed by canonical name and carried only an instant, and no link WRITE cleared it. A link whose target was deleted counts as absent, so an adoption, a manual link or the legacy re-key rebinds the key while the record stands, and the record then describes an account this plugin never provisioned inert. **CONFIRMED** (a reproduction exists and is now a test: `AnAdoptionOverADanglingLink_DropsTheRecordItFound` fails against the pre-fix tree). **Disposition: FIX**, both ends: the value names its account, and the stamp became a set-or-clear with the manual link and the re-key carrying their own.
- Verifier A held the mechanism proven but the impact unrealized at this commit, since nothing in the tree enables an account yet. Verifier B held it a MEDIUM that becomes a bypass when the approve surface lands. Both agreed on every mechanical step, so it was fixed rather than argued.

**Pass 2, an adversarial review of the fixed tree.** Verdict FIXED for the finding; it could construct no remaining sequence in which a record reads as live for an account this plugin did not provision inert. Its own findings:

- Three test-quality findings: an undriven claim about the #133 race loser, a test whose comment named the bulk revoke while driving the provider purge, and a JSON test asserting only the outbound direction of the property it named. **Disposition: FIX** - three tests added, one renamed to what it drives.
- The record is not cleared when an account is ENABLED, so an administrator's later sanction could be offered for reversal by a surface that reads the map naively. **Disposition: DEFER**, #1637, and the constraint is named in the commit message so the next change does not inherit it silently.
- `CanonicalLinkDeadlines` and `CanonicalLinkLastLogins` carry the same rebind gap, and the deadline one disables a freshly provisioned account. Pre-existing and out of scope here. **Disposition: DEFER**, #1638.
- `LinkImport.Write` does not clear the record. **Disposition: DECLINE**, with the reason recorded in the commit message: the import refuses an identity this instance already links to another account, so it cannot reach a key whose record is about somebody else, and the roster's account check answers it even if that ever changed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. One value type, one set-or-clear, one read-side check.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The state exemption records the bound it is granted for, which is now the
      bound over the account rather than over the key.
- [x] Docs impact considered: no README or wiki text describes this map. It is
      server-managed state with no administrator-facing control, and the surface
      that will make it visible is the change that documents it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3887 on net9.0 and 3888 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows), on
      an idle machine.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Fifteen tests drive the routes rather than read them. Each was run against a build broken in its own way before being trusted, seven of them, each failing the row that names it and no other: the early return, the manual link's clear, the re-key's clear, the unregister's prune, the roster's account check, the record written outside the writer's branch, and the JsonIgnore taken off.

## Notes

- The map is deliberately absent from the portable link export. The export exists to be re-applied to a rebuilt server, and a record asserting that this plugin provisioned an account inert THERE would be a claim about a provisioning that never happened on it.
- The value is a class rather than an instant, so the configuration XML round trip is a property of this change and is asserted as one.
- This PR replaces an earlier branch that carried the same feature without the account binding. That branch was never opened as a PR; it is closed by being superseded here, and its content is carried forward whole.
