### PR TITLE
Approve an account this plugin provisioned inert, and grant nothing else

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
@@ -296,7 +296,7 @@ public partial class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 18;
+        const int expectedTypedCallSites = 19;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.LoginPath.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.LoginPath.cs
@@ -88,29 +88,59 @@ public partial class ArchitectureConformanceTests
     {
         // Locked in by #737. IsDisabled is a lockout vector: the plugin deliberately never disabled an
         // account until the pending-approval provisioning feature, and it is barred from SSO role mapping
-        // (PermissionRolePolicy) so no login can disable an EXISTING account. The one sanctioned write -
-        // provisioning a BRAND-NEW account inert for admin approval - must stay confined to
-        // CanonicalLinkService (the single create seam). A source scan pins that: any future
-        // SetPermission(PermissionKind.IsDisabled, ...) elsewhere (a mint path, a role mapper, a controller)
-        // would reopen the "an SSO login disabled my account" surface and fails here instead of shipping.
+        // (PermissionRolePolicy) so no login can disable an EXISTING account. The sanctioned writes must
+        // stay confined to CanonicalLinkService (the single seam that owns the flag). A source scan pins
+        // that: any future SetPermission(PermissionKind.IsDisabled, ...) elsewhere (a mint path, a role
+        // mapper, a controller) would reopen the "an SSO login disabled my account" surface and fails here
+        // instead of shipping.
+        //
+        // THE COUNT IS PART OF THE RULE since #1529 put the first ENABLING write on that seam. Two writes
+        // set the flag - the arm that provisions a brand-new account inert (#737), and the one shared
+        // disable that login-time deprovisioning (#831) and account expiry (#1144) both call, which carries
+        // the administrator exemption (T-D1) they depend on. Exactly one write clears it: the approve path,
+        // which acts on this plugin's own record of having provisioned the account inert. A further write of
+        // either value is what this pins - another disabler would be another lockout vector, and another
+        // enabler would be a second route by which an account can be admitted without passing the record
+        // check that keeps an administrator's sanction out of reach.
         var apiRoot = Path.Combine(RepoTree.Root, "SSO-Auth", "Api");
+        var seam = Path.Combine("Linking", "CanonicalLinkService.cs");
         var offenders = new List<string>();
+        var disables = 0;
+        var enables = 0;
         foreach (var src in Directory.EnumerateFiles(apiRoot, "*.cs", SearchOption.AllDirectories))
         {
             var lines = File.ReadAllLines(src);
             for (var i = 0; i < lines.Length; i++)
             {
-                if (lines[i].Contains("SetPermission(PermissionKind.IsDisabled", StringComparison.Ordinal)
-                    && !src.EndsWith(Path.Combine("Linking", "CanonicalLinkService.cs"), StringComparison.Ordinal))
+                if (!lines[i].Contains("SetPermission(PermissionKind.IsDisabled", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!src.EndsWith(seam, StringComparison.Ordinal))
                 {
                     offenders.Add($"{Path.GetFileName(src)}:{i + 1}");
+                }
+                else if (lines[i].Contains("IsDisabled, true", StringComparison.Ordinal))
+                {
+                    disables++;
+                }
+                else if (lines[i].Contains("IsDisabled, false", StringComparison.Ordinal))
+                {
+                    enables++;
+                }
+                else
+                {
+                    offenders.Add($"{Path.GetFileName(src)}:{i + 1} (writes IsDisabled from a value this rule cannot read)");
                 }
             }
         }
 
         Assert.True(
             offenders.Count == 0,
-            "IsDisabled may be written only on CanonicalLinkService's new-account provisioning arm (#737). Writing it elsewhere can disable an existing account via SSO - a lockout vector. Offending sites: " + string.Join(", ", offenders));
+            "IsDisabled may be written only on CanonicalLinkService's provisioning and approve arms (#737, #1529). Writing it elsewhere can disable an existing account via SSO - a lockout vector. Offending sites: " + string.Join(", ", offenders));
+        Assert.Equal(2, disables);
+        Assert.Equal(1, enables);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -64,6 +64,10 @@ public partial class ArchitectureConformanceTests
         // link writes above, in bulk - and here every REFUSAL pays that persist too, because the count
         // comparison and the removal are one transaction, so an unthrottled caller could drive the disk
         // write with nothing but wrong counts.
+        // The approve action (#1529): a config-XML persist under the global lock like the link writes above,
+        // and its 404 is an existence answer about an identity this plugin provisioned - an unthrottled
+        // caller could drive it as an oracle for which subjects were created inert here.
+        "Links/Approve/{mode}/{provider}",
         "{mode}/Links/{provider}/{expectedLinkCount}",
     };
 
@@ -322,6 +326,7 @@ public partial class ArchitectureConformanceTests
         "{mode}/Link/{provider}/{jellyfinUserId}", "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}", // link write against a stored, enabled provider
         "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}", // pre-provision write against a stored, enabled provider (#1133)
         "{mode}/Links/{provider}/{expectedLinkCount}", // bulk unlink of a STORED provider, 400 on a miss (#1519)
+        "Links/Approve/{mode}/{provider}", // approve against a STORED provider, 400 on a miss (#1529)
 
         // Not an SSO provider name at all: Unregister's body parameter happens to be called `provider` and
         // carries a JELLYFIN AuthenticationProviderId, written to the user record so the account falls back

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -65,6 +65,11 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // caller's, every one of them at once, and it is the only route here that can take a whole server
         // off SSO in one call. There is no single subject a per-user authorization check could name.
         "PurgeProviderLinks",
+        // The approve action (#1529): it ENABLES a Jellyfin account, which is a grant of access to somebody
+        // other than the caller. It acts only on this plugin's own record of having provisioned that account
+        // inert, and refuses an administrator outright, but the grant itself is why it sits here rather than
+        // behind a bare [Authorize] - there is no user whose own account this is.
+        "ApproveProvisionedAccount",
         // The mappable permission vocabulary (#1484): read-only and installation-independent, and
         // elevation-gated because the config page is the only caller it exists for - an anonymous route
         // would be a new unauthenticated surface bought for nothing.

--- a/SSO-Auth.Tests/Linking/PendingApprovalActionTests.cs
+++ b/SSO-Auth.Tests/Linking/PendingApprovalActionTests.cs
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The approve action (#1529): what it may act on, what it does, and what it refuses.
+/// <para>
+/// It exists because the Jellyfin disabled flag does not say who set it. The action therefore acts on this
+/// plugin's own RECORD of having provisioned an account inert and never on the flag, and the test that
+/// carries the whole feature is the negative one: an account an administrator disabled deliberately has no
+/// record, so this route cannot see it, cannot list it and cannot enable it. Delete the record check and
+/// that row goes red while every positive one stays green.
+/// </para>
+/// <para>
+/// The second property is that approving GRANTS NOTHING BUT THE ENABLE. The provisioning policy decided the
+/// account's permissions when it created it; an approve that also granted would be a second provisioning
+/// policy that nobody configured, in a button. The third is the state re-read: a record says what was true
+/// at provisioning, and each way it can have become false since has its own arm here.
+/// </para>
+/// </summary>
+public class PendingApprovalActionTests
+{
+    private static readonly Guid Pending = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AnAccountThisPluginProvisionedInert_IsEnabled()
+    {
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: false);
+
+        var (outcome, approved) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.Approved, outcome);
+        Assert.Equal(Pending, approved);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        await users.Received(1).UpdateUserAsync(user);
+
+        // The record goes with the act it described: the account is no longer waiting, so leaving it would
+        // keep an enabled account on a list of accounts that cannot sign in.
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ADisabledAccountWithNoRecord_IsInvisibleToThisRoute()
+    {
+        // THE ROW THE FEATURE IS FOR. This is the account an administrator disabled on purpose: linked,
+        // disabled, and never provisioned inert by this plugin. The flag alone cannot tell it apart from the
+        // row above, which is why this route never reads the flag to decide.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: false);
+        config.CanonicalLinkPendingApprovals.Clear();
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.NotPending, outcome);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task ARecordNamingAnotherAccount_IsNotActedOn()
+    {
+        // The rebind case, from the acting side. The record is about an account this key no longer points
+        // at, so it says nothing about the account it would enable - and the account it would enable is
+        // whoever holds the key now.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: false);
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Other, SinceUtc = Now };
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.NotPending, outcome);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+    }
+
+    [Fact]
+    public async Task AnAdministrator_IsRefused_AndKeepsItsRecord()
+    {
+        // T-D1 read from the other direction: the guard that keeps this plugin from DISABLING an
+        // administrator has a twin that keeps it from ENABLING one. Re-admitting an administrator is the one
+        // mistake on this page that the same page cannot walk back. The record is true and stays; what is
+        // refused is this route acting on it.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: true);
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.Administrator, outcome);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        Assert.Single(config.CanonicalLinkPendingApprovals);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task AnAccountEnabledSinceItWasProvisioned_LosesTheRecordAndIsNotRe_enabled()
+    {
+        // #1637: an administrator can enable the account in the Jellyfin dashboard, which this plugin does
+        // not see. The record is then false, and the danger is not this call - it is the NEXT one, after
+        // somebody disables that account as a sanction. Observed here, the record goes.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: false, admin: false);
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.AlreadyEnabled, outcome);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+        await users.DidNotReceive().UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task ARecordWhoseAccountIsGone_IsCleared()
+    {
+        var (service, config, users) = Build();
+        Recorded(users, config, disabled: true, admin: false);
+        users.GetUserById(Pending).Returns((User?)null);
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.AccountGone, outcome);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task AnUnknownProvider_IsItsOwnAnswer_AndChangesNothing()
+    {
+        // Distinct from NotPending on purpose: collapsing the two would make the endpoint answer the same
+        // way for a provider that does not exist and an identity that is not pending, which is how a
+        // refusal becomes an oracle for provider names.
+        var (service, config, users) = Build();
+        Recorded(users, config, disabled: true, admin: false);
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "nope", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.UnknownProvider, outcome);
+        Assert.Single(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ApprovingGrantsNothingButTheEnable()
+    {
+        // The provisioning policy decided this account's permissions. An approve that also granted would be
+        // a second provisioning policy in a button, configured by nobody, and the administrator pressing it
+        // would have no way to know what it handed out.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: false);
+        user.SetPermission(PermissionKind.EnableAllFolders, false);
+        user.SetPermission(PermissionKind.EnableRemoteAccess, false);
+        user.SetPermission(PermissionKind.EnableLiveTvAccess, false);
+        // One permission the provisioning DID grant, so a reset to defaults is caught as hard as a grant: on
+        // a bare entity every absent permission already reads false, and an approve that wiped the policy
+        // would leave the three above exactly as they are.
+        user.SetPermission(PermissionKind.EnableMediaPlayback, true);
+        var routing = user.AuthenticationProviderId;
+
+        await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        Assert.False(user.HasPermission(PermissionKind.IsAdministrator));
+        Assert.False(user.HasPermission(PermissionKind.EnableAllFolders));
+        Assert.False(user.HasPermission(PermissionKind.EnableRemoteAccess));
+        Assert.False(user.HasPermission(PermissionKind.EnableLiveTvAccess));
+        Assert.True(user.HasPermission(PermissionKind.EnableMediaPlayback));
+        Assert.Equal(routing, user.AuthenticationProviderId);
+    }
+
+    [Fact]
+    public async Task TheRecordRemovedAfterTheEnable_IsOnlyTheOneItRead()
+    {
+        // The window between the locked read and the removal, driven rather than argued: the account's read
+        // is where the key is freed and written again for a NEW account, so by the time the approve drops
+        // "its" record, the record under that key is somebody else's. The old account is still enabled -
+        // this plugin provisioned it inert, and the decision to admit it stands - but the new account's
+        // record must survive, or it would sit disabled with no row anywhere to be found on.
+        var (service, config, users) = Build();
+        var user = Recorded(users, config, disabled: true, admin: false);
+        users.GetUserById(Pending).Returns(_ =>
+        {
+            config.CanonicalLinks["sub-1"] = Other;
+            config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Other, SinceUtc = Now };
+            return user;
+        });
+
+        var (outcome, _) = await service.ApproveProvisionedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(PendingApprovalResult.Approved, outcome);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        Assert.Equal(Other, Assert.Single(config.CanonicalLinkPendingApprovals).Value.UserId);
+    }
+
+    [Fact]
+    public async Task ADisableByThisPlugin_ClearsTheRecordItProvesFalse()
+    {
+        // The third observation point (#1637), and the one that reaches an account which never signs in: a
+        // login-time denial or an expiry can only disable an ENABLED account, and an enabled account with a
+        // record is a record that is false. Cleared here, the account this call just disabled does not go
+        // straight back onto the approval list - where one press would undo the denial.
+        var (service, config, users) = Build();
+        Recorded(users, config, disabled: false, admin: false);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1", issuer: null);
+
+        Assert.True(disabled);
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ADenialOfAStillPendingAccount_LeavesItsRecordStanding()
+    {
+        // The negative that keeps the clear above honest. A pending account's denied login is a no-op on
+        // the disable path (it is already disabled, and the guard returns before any write), so it must not
+        // reach the clear either: otherwise a role the identity provider has not granted yet would remove
+        // the very row an administrator is about to approve.
+        var (service, config, users) = Build();
+        Recorded(users, config, disabled: true, admin: false);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1", issuer: null);
+
+        Assert.False(disabled);
+        Assert.Single(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ASuccessfulLogin_ClearsAStandingRecord()
+    {
+        // The second observation point for #1637, and the one that does not need an administrator to press
+        // anything: a minted session proves the account is past the pending-approval gate, so a record still
+        // standing on it is false. Without this, an account enabled by hand and later sanctioned would be
+        // offered for approval again.
+        var config = new OidConfig { Enabled = true };
+        var (service, users, _) = BuildLogin(config);
+        var user = TestUsers.Named("alice", Pending);
+        users.GetUserById(Pending).Returns(user);
+        users.GetUserByName("alice").Returns(user);
+        config.CanonicalLinks["sub-1"] = Pending;
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Empty(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public async Task ARefusedLoginOfAPendingAccount_LeavesItsRecordStanding()
+    {
+        // The other half of the placement, and the one that would silently empty the approval list: the
+        // pending account's own repeated logins are REFUSED at the gate, so they must not clear the record
+        // that puts it on the list. A clear written before the gate rather than after it turns every login
+        // attempt by a waiting user into a removal of their own row.
+        var config = new OidConfig { Enabled = true };
+        var (service, users, _) = BuildLogin(config);
+        var user = TestUsers.Named("alice", Pending);
+        user.SetPermission(PermissionKind.IsDisabled, true);
+        users.GetUserById(Pending).Returns(user);
+        users.GetUserByName("alice").Returns(user);
+        config.CanonicalLinks["sub-1"] = Pending;
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
+
+        var result = await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        // The refusal is asserted to be THIS gate's, because a login refused earlier - a link forbidden, say
+        // - also leaves the record standing, and the row would then pin nothing about the placement.
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(403, content.StatusCode);
+        Assert.Contains("awaiting administrator approval", content.Content, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(config.CanonicalLinkPendingApprovals);
+    }
+
+    [Fact]
+    public void TheRosterOffersExactlyWhatTheActionWouldAccept()
+    {
+        // One rule, two readers. A row the page presents as waiting and a call the action refuses would be
+        // the same defect seen from either side, so both ask PendingApproval.Live and this pins that they
+        // agree on the three shapes that differ: recorded and live, recorded about another account, and not
+        // recorded at all.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["live"] = Pending;
+        config.CanonicalLinks["moved"] = Pending;
+        config.CanonicalLinks["plain"] = Pending;
+        config.CanonicalLinkPendingApprovals["live"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
+        config.CanonicalLinkPendingApprovals["moved"] = new PendingApproval { UserId = Other, SinceUtc = Now };
+
+        var links = Assert.Single(LinkRoster.Build(configuration, _ => "alice").Accounts).Links;
+
+        Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "live").PendingApprovalSinceUtc);
+        Assert.Null(Assert.Single(links, l => l.CanonicalName == "moved").PendingApprovalSinceUtc);
+        Assert.Null(Assert.Single(links, l => l.CanonicalName == "plain").PendingApprovalSinceUtc);
+        Assert.NotNull(PendingApproval.Live(config, "live"));
+        Assert.Null(PendingApproval.Live(config, "moved"));
+        Assert.Null(PendingApproval.Live(config, "plain"));
+    }
+
+    // One provider holding one linked account, recorded as provisioned inert by this plugin.
+    private static User Recorded(IUserManager users, OidConfig config, bool disabled, bool admin)
+    {
+        var user = TestUsers.Named("alice", Pending);
+        user.SetPermission(PermissionKind.IsDisabled, disabled);
+        user.SetPermission(PermissionKind.IsAdministrator, admin);
+        users.GetUserById(Pending).Returns(user);
+        config.CanonicalLinks["sub-1"] = Pending;
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
+        return user;
+    }
+
+    private static (CanonicalLinkService Service, OidConfig Config, IUserManager Users) Build()
+    {
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        var users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now), config, users);
+    }
+
+    private static AuthResponse Response() =>
+        new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity Identity() =>
+        TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: "sub-1",
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null,
+            ExpiresAtUtc: null));
+
+    private static (LoginCompletionService Service, IUserManager Users, PluginConfiguration Configuration) BuildLogin(OidConfig config)
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, new CapturingLogger()), users, configuration);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -257,7 +257,7 @@ internal static class SsoAudit
         }
 
         logger.LogWarning(
-            "[SSO Audit] New account provisioned pending approval: '{Username}' via {Protocol} provider '{Provider}' was created disabled (ProvisionNewUsersDisabled); no session issued. Enable it in the Jellyfin dashboard to approve.",
+            "[SSO Audit] New account provisioned pending approval: '{Username}' via {Protocol} provider '{Provider}' was created disabled (ProvisionNewUsersDisabled); no session issued. Approve it on the plugin's Accounts tab, or enable it in the Jellyfin dashboard.",
             username?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             protocol,
             provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
@@ -680,6 +680,37 @@ internal static class SsoAudit
             protocol,
             provider?.ReplaceLineEndings(string.Empty).Replace('[', '('),
             jellyfinUserId);
+    }
+
+    /// <summary>
+    /// Records an administrator approving an account this plugin provisioned inert (#1529): the account was
+    /// enabled and can sign in from now on. A grant of access, so it is warned rather than informed, and it
+    /// is the counterpart of the line the provisioning itself wrote - an operator reading the trail should
+    /// find the same account inert at one instant and admitted at another, with a name against the second.
+    /// </summary>
+    /// <remarks>
+    /// The canonical subject is deliberately not a field, for the reason the pre-provision line states
+    /// (T-I1): the account and the provider identify the grant, and the subject is the one member of the
+    /// request that identifies a real person at the identity provider.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="actor">The elevated administrator who approved the account.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider the account was provisioned from.</param>
+    /// <param name="jellyfinUserId">The Jellyfin account that was enabled.</param>
+    internal static void AccountApproved(ILogger logger, string actor, string protocol, string provider, Guid jellyfinUserId)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Account approved by {Actor}: Jellyfin user {UserId}, provisioned inert by {Protocol} provider '{Provider}', was enabled. No other permission was changed.",
+            actor?.ReplaceLineEndings(string.Empty).Replace('[', '('),
+            jellyfinUserId,
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -223,6 +223,14 @@ internal sealed class LoginCompletionService
         // established user's repeat login still pays no configuration persist.
         _canonicalLinks.RecordLastSsoLogin(identity.LinkMode, identity.Provider, identity.Subject);
 
+        // And drop any pending-approval record this link still carries (#1529, #1637). A session was minted,
+        // so the account is past the pending-approval gate above and is demonstrably not inert - the record
+        // is false, and this is the only moment this plugin ever learns that an account it provisioned
+        // disabled was enabled somewhere else. Left standing it would keep a working account on the approval
+        // list, and would offer it again if an administrator later disabled that account deliberately.
+        // Bounded the same way the stamp above is: no record, no write.
+        _canonicalLinks.ClearPendingApprovalAfterLogin(identity.LinkMode, identity.Provider, identity.Subject);
+
         CaptureLogoutState(identity, userId, logoutContext, authenticationResult);
 
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -2193,6 +2193,60 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Approves an account this plugin provisioned disabled and awaiting an administrator (#1529): enables
+    /// that one account and changes nothing else. Requires administrator privileges.
+    /// </summary>
+    /// <remarks>
+    /// It acts only on this plugin's own RECORD of having provisioned the account inert, never on the
+    /// account's disabled flag. The flag is a Jellyfin permission and does not say who set it or why, so a
+    /// page that read it would offer to undo an administrator's sanction from a page about SSO. An identity
+    /// this plugin did not provision inert is a 404 here, whatever state its account is in.
+    /// <para>
+    /// The canonical name travels in the BODY rather than in the route, like the pre-provision write beside
+    /// it: an OpenID subject or a SAML NameID may contain a slash, and a route segment would refuse exactly
+    /// those identities.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The mode of the function; SAML or OID.</param>
+    /// <param name="provider">The provider the account was provisioned from.</param>
+    /// <param name="canonicalName">The provider-side identity key: the OpenID stable subject claim, or the SAML NameID.</param>
+    /// <returns>No content when the account was enabled, or when the record was stale and was cleared; 400 on an unknown provider, 404 when this plugin holds no such record, 403 when the recorded account is an administrator.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("Links/Approve/{mode}/{provider}")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public async Task<ActionResult> ApproveProvisionedAccount([FromRoute] string mode, [FromRoute] string provider, [FromBody] string canonicalName)
+    {
+        // Throttle after the elevation guard, before any work (#382, #516), in the same bucket as the link
+        // writes: this drives the same config-XML persist under the global lock, and it is an existence
+        // oracle for provisioned identities in exactly the way the unlink beside it is.
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
+        {
+            return throttled;
+        }
+
+        if (RefuseUnknownMode(mode, out var parsed) is { } unknownMode)
+        {
+            return unknownMode;
+        }
+
+        var (outcome, userId) = await _canonicalLinks.ApproveProvisionedAccountAsync(parsed, provider, canonicalName).ConfigureAwait(false);
+        if (outcome == PendingApprovalResult.Approved)
+        {
+            // Audited only on the arm that actually granted something. The two arms that merely cleared a
+            // record changed no access, and a line for them would put "account approved" in the trail for an
+            // account nobody approved.
+            SsoAudit.AccountApproved(
+                _logger,
+                await ResolveActorAsync().ConfigureAwait(false),
+                parsed == ProviderMode.Oid ? OpenIdProtocol : SamlProtocol,
+                provider,
+                userId);
+        }
+
+        return FlowResponses.MapPendingApproval(outcome);
+    }
+
+    /// <summary>
     /// Turns SSO-only login on (#165), designating <paramref name="breakGlassAdminUsername"/> as the account
     /// whose native password login is never disabled. Requires administrator privileges. Fail-closed: the
     /// last-admin guard runs first, and unless the designated account is an existing, enabled administrator

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -63,6 +63,35 @@ internal enum CanonicalLinkRemoveResult
 }
 
 /// <summary>
+/// The outcome of approving an account this plugin provisioned inert (#1529). Closed by convention (the
+/// controller's mapper throws on an unhandled arm).
+/// </summary>
+/// <remarks>
+/// The three refusals are deliberately distinct rather than one "no": each says something different to the
+/// administrator holding the mouse, and only one of them means they should go and do it elsewhere.
+/// </remarks>
+internal enum PendingApprovalResult
+{
+    /// <summary>The account was enabled and its record removed.</summary>
+    Approved,
+
+    /// <summary>No provider of that mode/name exists; nothing was changed.</summary>
+    UnknownProvider,
+
+    /// <summary>This plugin holds no live record that it provisioned that identity's account inert; nothing was changed.</summary>
+    NotPending,
+
+    /// <summary>The recorded account is an administrator and is not approvable here; the record was left as it is.</summary>
+    Administrator,
+
+    /// <summary>The recorded account is already enabled; the record it had outlived was removed and nothing else changed.</summary>
+    AlreadyEnabled,
+
+    /// <summary>The recorded account no longer exists; the record was removed and nothing else changed.</summary>
+    AccountGone,
+}
+
+/// <summary>
 /// The issuer binding of a resolved subject-keyed OpenID link against the current login's issuer (#186).
 /// SAML (any non-OpenID mode) and a login with no resolved subject link are <see cref="NotBound"/>.
 /// </summary>
@@ -965,6 +994,138 @@ internal sealed class CanonicalLinkService
     }
 
     /// <summary>
+    /// Approves an account this plugin provisioned inert (#1529): enables it, and does nothing else.
+    /// </summary>
+    /// <remarks>
+    /// WHAT IT MAY ACT ON is the whole of the safety here, and it is one question asked of the record
+    /// rather than of the account: only an identity this plugin's own create arm recorded as provisioned
+    /// disabled, whose record still names the account the link points at. A disabled account with no such
+    /// record was disabled by somebody else, for a reason this plugin does not know, and is invisible to
+    /// this path - which is what keeps an administrator's sanction out of reach of a page about SSO.
+    /// <para>
+    /// WHAT IT DOES is one permission, written on the seam that already owns it. No role, no folder, no
+    /// library and no policy: the provisioning decided those when it created the account, and an approval
+    /// that also granted would make the approve button a second, quieter provisioning policy. An
+    /// administrator account is refused outright, on the same reasoning that keeps adoption away from them
+    /// (T-D1): this route asks for an administrator credential and nothing else, and re-admitting an
+    /// administrator is the one mistake here that cannot be walked back by the same button.
+    /// </para>
+    /// <para>
+    /// THE STATE IS RE-READ HERE rather than trusted from the page that offered the row. A record says what
+    /// was true at provisioning; between the page load and the click the account may have been enabled by
+    /// hand, deleted, or promoted. Each of those has its own arm, and the two that prove the record false
+    /// take it away rather than leaving a row that would be offered again on the next read.
+    /// </para>
+    /// <para>
+    /// The enable is persisted BEFORE the record is removed. The other order loses the account from the
+    /// list on a failed write, leaving it disabled with nothing left to say why; this order can at worst
+    /// leave a record on an account that is already enabled, which the next read refuses on its own.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The protocol the provider speaks.</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="canonicalName">The identity key whose account is approved.</param>
+    /// <returns>What happened, and the account it happened to, so the caller can audit the grant by the account it granted rather than by the subject that names a person.</returns>
+    internal async Task<(PendingApprovalResult Outcome, Guid UserId)> ApproveProvisionedAccountAsync(ProviderMode mode, string provider, string? canonicalName)
+    {
+        // Read under the lock, decided by the one rule the roster reads with: an unknown provider and a key
+        // that names no live record are different answers, because the first is a request against something
+        // that does not exist and the second is a request against something that is not this plugin's to act
+        // on. Collapsing them would make the endpoint an existence oracle for provider names.
+        var known = _configStore.Read(configuration =>
+            TryGetProvider(configuration, mode, provider, out var config)
+                ? (Provider: true, User: (Guid?)PendingApproval.Live(config, canonicalName)?.UserId)
+                : (Provider: false, User: null));
+
+        if (!known.Provider)
+        {
+            return (PendingApprovalResult.UnknownProvider, Guid.Empty);
+        }
+
+        if (known.User is not { } userId)
+        {
+            return (PendingApprovalResult.NotPending, Guid.Empty);
+        }
+
+        var user = _userManager.GetUserById(userId);
+        if (user is null)
+        {
+            // The account went away under a record that outlived it. Nothing to enable, and the record is
+            // now describing nothing at all, so it goes with the answer rather than staying to be offered
+            // again.
+            RemovePendingApprovalOutsideLock(mode, provider, canonicalName!, userId);
+            return (PendingApprovalResult.AccountGone, userId);
+        }
+
+        if (user.HasPermission(PermissionKind.IsAdministrator))
+        {
+            // The record is TRUE - this plugin really did provision that account inert - so it is left
+            // exactly where it is. What is refused is this route acting on it: an administrator account is
+            // enabled in the Jellyfin dashboard, by somebody who went there to do it.
+            return (PendingApprovalResult.Administrator, userId);
+        }
+
+        if (!user.HasPermission(PermissionKind.IsDisabled))
+        {
+            // Enabled by somebody else since it was provisioned, which is the one thing that makes the
+            // record false without any link having moved. Taking it away here is the only place this plugin
+            // ever observes that, and leaving it would keep a working account on a list of accounts that
+            // cannot sign in.
+            RemovePendingApprovalOutsideLock(mode, provider, canonicalName!, userId);
+            return (PendingApprovalResult.AlreadyEnabled, userId);
+        }
+
+        user.SetPermission(PermissionKind.IsDisabled, false);
+        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+
+        RemovePendingApprovalOutsideLock(mode, provider, canonicalName!, userId);
+        return (PendingApprovalResult.Approved, userId);
+    }
+
+    /// <summary>
+    /// Drops a link's pending-approval record after a login that actually minted a session (#1637). A login
+    /// past the pending-approval gate proves the account is not inert, so a record still standing on it is
+    /// false: the account was enabled outside this plugin, which is the one transition nothing else here
+    /// observes. Bounded like the last-login stamp beside it - the common case is a locked read that finds
+    /// no record and writes nothing.
+    /// </summary>
+    /// <param name="mode">The provider protocol.</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="canonicalKey">The identity's stable subject key.</param>
+    internal void ClearPendingApprovalAfterLogin(ProviderMode mode, string provider, string? canonicalKey)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalKey))
+        {
+            return;
+        }
+
+        var standing = _configStore.Read(configuration =>
+            TryGetProvider(configuration, mode, provider, out var config)
+            && config.CanonicalLinkPendingApprovals.ContainsKey(canonicalKey));
+
+        if (!standing)
+        {
+            return;
+        }
+
+        // AVAILABILITY, for the same reason the last-login stamp states it: this runs after the session has
+        // been minted, so a configuration persist that throws must not turn a login that already succeeded
+        // into an error the reader sees. The cost of swallowing it is a stale row on an administrator's
+        // list, which the approve action refuses on its own when somebody presses it.
+        try
+        {
+            _configStore.Mutate(configuration => RemovePendingApproval(configuration, mode, provider, canonicalKey));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "[SSO] Could not clear the pending-approval record for provider {Provider}. The login itself succeeded; the account may still be listed as waiting.",
+                provider?.ReplaceLineEndings(string.Empty).Replace('[', '('));
+        }
+    }
+
+    /// <summary>
     /// Login-time deprovisioning (#831): when an SSO login is DENIED by the role allow-list, disable the
     /// existing linked Jellyfin account so a user offboarded at the identity provider loses Jellyfin access
     /// immediately, rather than keeping any session until a role change would otherwise apply. Opt-in per
@@ -1273,6 +1434,14 @@ internal sealed class CanonicalLinkService
 
         user.SetPermission(PermissionKind.IsDisabled, true);
         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+
+        // An account this path could disable was ENABLED, so a pending-approval record still standing on it
+        // was false (#1529): this plugin never enables one, and the record says the account is waiting to
+        // be. Left in place it would put the account this call just disabled - for a denial, or for an
+        // expiry that the next sweep tick would only repeat - straight back onto the approval list, where
+        // one press undoes the disable and admits it until the reason recurs. The guard above means a
+        // genuinely pending account never reaches this line, so its record is never touched here.
+        RemovePendingApprovalOutsideLock(mode, provider, canonicalKey, userId.Value);
         return userId;
     }
 
@@ -2151,6 +2320,29 @@ internal sealed class CanonicalLinkService
             config.CanonicalLinkPendingApprovals.Remove(canonicalKey);
         }
     }
+
+    // The same removal for a caller that holds no transaction of its own (#1529): the approve and disable
+    // paths, which write the account through the user manager between reading the record and dropping it,
+    // and so cannot hold the config lock across the whole act. Its own named step rather than an inline
+    // Mutate, because every caller is removing a record for a different reason and the reasons belong
+    // beside them.
+    //
+    // COMPARE-AND-REMOVE, not remove. The window between the caller's read and this write is exactly where
+    // the key can be freed and written again for a NEW account - a deleted target counts as absent, and the
+    // next login of the same subject provisions afresh and records that account. A removal that did not
+    // check would then drop the new account's record on the strength of a decision about the old one, and
+    // leave an account disabled with no row anywhere to find it on. So the record goes only if it still
+    // names the account the caller read; otherwise it is somebody else's, and it stays.
+    private void RemovePendingApprovalOutsideLock(ProviderMode mode, string provider, string canonicalKey, Guid userId)
+        => _configStore.Mutate(configuration =>
+        {
+            if (TryGetProvider(configuration, mode, provider, out var config)
+                && config.CanonicalLinkPendingApprovals.TryGetValue(canonicalKey, out var record)
+                && record?.UserId == userId)
+            {
+                config.CanonicalLinkPendingApprovals.Remove(canonicalKey);
+            }
+        });
 
     // Classifies an OpenID subject link's issuer binding against the login's issuer, read under the caller's
     // config lock (#186). SAML (and any non-OID mode) is NotBound - issuer binding is OpenID only. For OID:

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -97,4 +97,28 @@ internal static class FlowResponses
         CanonicalLinkWriteResult.ConflictingUser => new ConflictObjectResult("That identity is already linked to a different Jellyfin account. Remove the existing link first."),
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
+
+    /// <summary>
+    /// The HTTP boundary for approving an account this plugin provisioned inert (#1529): maps the link
+    /// service's closed result to a response.
+    /// </summary>
+    /// <remarks>
+    /// The two arms that DID something without enabling anything - a record whose account is already
+    /// enabled, and one whose account is gone - answer 204 rather than an error. Both leave the caller's
+    /// goal satisfied or unreachable for a reason no retry changes, both removed the record they found, and
+    /// a page that reloads the roster after a 204 will simply not show the row again. The administrator
+    /// refusal is a 403 and says where to go instead, because that one is a decision and not an accident.
+    /// </remarks>
+    /// <param name="result">The closed result variant from <c>CanonicalLinkService.ApproveProvisionedAccountAsync</c>.</param>
+    /// <returns>The mapped <see cref="ActionResult"/>.</returns>
+    internal static ActionResult MapPendingApproval(PendingApprovalResult result) => result switch
+    {
+        PendingApprovalResult.Approved => new NoContentResult(),
+        PendingApprovalResult.AlreadyEnabled => new NoContentResult(),
+        PendingApprovalResult.AccountGone => new NoContentResult(),
+        PendingApprovalResult.UnknownProvider => new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage),
+        PendingApprovalResult.NotPending => new NotFoundObjectResult("This plugin has no record of provisioning that identity's account disabled, so there is nothing here to approve. An account disabled by an administrator is enabled in the Jellyfin dashboard."),
+        PendingApprovalResult.Administrator => new ObjectResult("That account is an administrator. Enable an administrator account in the Jellyfin dashboard, not from here.") { StatusCode = StatusCodes.Status403Forbidden },
+        _ => throw new InvalidOperationException($"Unhandled pending-approval result: {result}"),
+    };
 }

--- a/SSO-Auth/Config/LinkExport.cs
+++ b/SSO-Auth/Config/LinkExport.cs
@@ -71,7 +71,7 @@ internal static class LinkExport
                     link.Value,
                     config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null,
                     LastSsoLogin(config, link.Key),
-                    PendingApprovalSince(config, link.Key, link.Value));
+                    PendingApprovalSince(config, link.Key));
             }
         }
 
@@ -79,7 +79,7 @@ internal static class LinkExport
         {
             foreach (var link in config.CanonicalLinks)
             {
-                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null, LastSsoLogin(config, link.Key), PendingApprovalSince(config, link.Key, link.Value));
+                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null, LastSsoLogin(config, link.Key), PendingApprovalSince(config, link.Key));
             }
         }
     }
@@ -139,23 +139,12 @@ internal static class LinkExport
             ? stamped.ToUniversalTime()
             : null;
 
-    // The pending-approval record for one link (#1529), keyed by the same canonical name and carried on
-    // both protocols. Null is the answer for EVERY link this plugin did not provision inert itself, which
-    // is almost all of them: the record says what the plugin did, and is never an inference from the
-    // account's disabled flag. Normalized to UTC like its neighbours.
-    //
-    // AND NULL AGAIN WHEN THE RECORD NAMES A DIFFERENT ACCOUNT than the link now points at. The key is a
-    // subject and a subject can change hands: a link whose target account was deleted counts as absent, so
-    // the next login writes the key at another account, by adoption or by a fresh provisioning. The write
-    // paths clear the record when that happens, and this comparison is what makes a path that forgets a
-    // tidiness defect instead of a page offering to enable an account nobody provisioned inert. Fail closed
-    // is the cheap direction here: the cost of refusing a stale record is an administrator enabling an
-    // account by hand, the cost of honouring one is undoing somebody's sanction from a page about
-    // something else.
-    private static DateTime? PendingApprovalSince(ProviderConfigBase config, string canonicalName, Guid linkedUserId) =>
-        config.CanonicalLinkPendingApprovals.TryGetValue(canonicalName, out var record) && record?.UserId == linkedUserId
-            ? record.SinceUtc.ToUniversalTime()
-            : null;
+    // The pending-approval record for one link (#1529), carried on both protocols and read through the one
+    // rule that decides whether a record still describes anything - the same rule the approve action asks,
+    // so the roster cannot present a row that action would refuse. Null for EVERY link this plugin did not
+    // provision inert itself, which is almost all of them. Normalized to UTC like its neighbours.
+    private static DateTime? PendingApprovalSince(ProviderConfigBase config, string canonicalName) =>
+        PendingApproval.Live(config, canonicalName)?.SinceUtc.ToUniversalTime();
 
     // A provider stored with a null config object is reachable through a null-bodied add (#350), and the
     // read side treats that the same fail-closed way the link listings do: skipped, never dereferenced.

--- a/SSO-Auth/Config/PendingApproval.cs
+++ b/SSO-Auth/Config/PendingApproval.cs
@@ -40,4 +40,39 @@ public class PendingApproval
     /// approval list is opened with.
     /// </summary>
     public DateTime SinceUtc { get; set; }
+
+    /// <summary>
+    /// The record this provider holds for one canonical link, or null when it holds none that still
+    /// describes the account the link points at (#1529).
+    /// </summary>
+    /// <remarks>
+    /// ONE HOME FOR THE RULE, because two readers act on it and they must not be able to disagree: the
+    /// roster decides from it which rows to present as waiting, and the approve action decides from it
+    /// which account it may enable. A page offering a row the action would refuse, or an action enabling
+    /// an account the page never showed, is the same defect from either side.
+    /// <para>
+    /// The comparison against the link is what makes this a record rather than a rumour. A link whose
+    /// target account was deleted counts as absent, so the key is written again at another account, and a
+    /// write path that forgot to clear the entry would otherwise hand its account over with it.
+    /// </para>
+    /// </remarks>
+    /// <param name="config">The provider configuration holding both maps.</param>
+    /// <param name="canonicalName">The identity key the link is stored under.</param>
+    /// <returns>The live record, or <see langword="null"/>.</returns>
+    internal static PendingApproval? Live(ProviderConfigBase config, string? canonicalName)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (string.IsNullOrEmpty(canonicalName))
+        {
+            return null;
+        }
+
+        return config.CanonicalLinkPendingApprovals.TryGetValue(canonicalName, out var record)
+            && record is not null
+            && config.CanonicalLinks.TryGetValue(canonicalName, out var linked)
+            && record.UserId == linked
+                ? record
+                : null;
+    }
 }


### PR DESCRIPTION
# What & why

Stage 3 of #1529: the approve action for accounts this plugin provisioned disabled, on top of the record that landed in #1639. One endpoint, one permission, three refusals.

It acts on the plugin's own RECORD of having provisioned an account inert and never on the Jellyfin disabled flag, because the flag does not say who set it or why. An account an administrator disabled deliberately carries no record, so this route cannot see it, cannot list it and cannot enable it - which is the one outcome the threat model on the issue said this feature must not have.

What it does is one permission. No role, no folder, no library, no policy: the provisioning decided those when it created the account, and an approve that also granted would be a second provisioning policy that nobody configured, hidden in a button. An administrator account is refused outright and keeps its record; an unknown provider stays distinct from an identity that is not pending, so the refusal is not an oracle for provider names.

The state is re-read at the moment of acting. Between the page load and the click the account may have been enabled by hand, deleted or promoted; each has its own arm, and the two that prove the record false take it away. A successful SSO login now clears a standing record as well (#1637), placed after the pending-approval gate so a waiting user's own refused logins cannot remove their own row.

No UI yet: the Accounts-page list and its button are the next change, and the endpoint lands first so the surface PR carries no server risk.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The action fails closed on every arm
      that cannot prove the record: no record, a record naming another account,
      an unknown provider and an administrator all change nothing.
- [x] No secrets logged; secrets are redacted on config export. The audit line
      carries the actor, the account id, the protocol and the provider, and not
      the subject.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. The one new
      log call strips line endings inline; the audit line takes no IdP input.

### Review record

**Pass 1, the security review of the committed diff.** An identification pass over the full diff and its surroundings raised no candidate finding, so the false-positive filtering stage had nothing to run on. The paths it closed, each with a citation in the review output: a forged record (JsonIgnore, both Preserve arms, the import never references the record); a moved record (PendingApproval.Live requires the record to name the account the link points at, read under the config lock); the window between the locked read and the user write (only administrator-driven actions can move a link inside it, and a login for the same subject is refused at the pending gate before any write); granting more than the enable (the only mutation before UpdateUserAsync is the one flag, and the three IsDisabled writes on the seam are the only ones in the tree); reaching it without elevation (the authorize filter runs before the limiter); the login-time clear (runs only after a minted session, clears only the login's own key); the administrator basis (the resolved account, never a claim); the subject (absent from the audit line and from every response body).

**Pass 2, an adversarial verification of the same tree, attacking each of those claims independently.** Every lens SAFE: no forged or moved record, no grant beyond the enable, no reach below elevation, no way to drive the login-time clear against another account, the administrator basis is the resolved account, and the subject reaches neither the audit line nor a response body. It raised two LOW findings and three weak test pins, all **FIX**, in this commit:

- Approve could re-enable an account this plugin's own expiry sweep or role denial had just disabled, because no disable path cleared the record; the account went straight back onto the list, and one press undid the denial. Now every disable this plugin performs clears the record, which is false by then - a disable presupposes enabled. The guard on that path returns before any write for an already-disabled account, so a genuinely pending account's denied login never reaches the clear. Driven both ways.
- The record removal after the enable was unconditional, so in the window between the locked read and the write a NEW account provisioned under the same freed key could lose its record to a decision about the old one. Now a compare-and-remove: the record goes only if it still names the account that was read. Driven from inside the user read.
- The refused-login row asserts the refusal is the pending gate's; the grants-nothing row holds a permission the provisioning did grant and asserts the routing survives; both were weaker than their names.

**Residual, named rather than hidden.** An account provisioned inert, enabled by hand, that never signs in through SSO and is later disabled by hand as a sanction still carries a live record, so the list would offer it and Approve would re-enable it. Every mitigation here needs an observation event that sequence never produces. It takes an administrator pressing the button, so it is a footgun for the administrator holding the mouse rather than an escalation for an attacker. **DEFER**, it stays on #1637 narrowed to exactly that window.

This PR replaces #1640, which carried the same change without the two fixes; it was never merged and is closed by being superseded here.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The rule that decides whether a record still describes
      anything has one home, `PendingApproval.Live`, and both readers use it.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The disabled-flag rule now counts the writes it permits: two that set the
      flag and exactly one that clears it, on the one seam. The new route is
      classified as throttled and as a lookup of a stored provider name, and the
      elevation roster names it.
- [x] Docs impact considered: the endpoint has no administrator-facing surface
      until the list lands, and that change documents the feature as a whole.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3901 on net9.0 and 3902 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows), on
      an idle machine.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Fourteen tests drive the service and the login path rather than reading them, and they were run against six broken builds before being trusted: acting on the link instead of the record fails the two negatives, the administrator guard fails its own row, the login clear fails one row when removed and a different one when moved before the gate, the disable path's clear fails its row, and the removal without its compare fails the interleaving row.

## Notes

- The provisioning's own audit line now points at the Accounts tab as well as at the dashboard, so whoever reads the trail is told where the button is.
- The canonical name travels in the request body, like the pre-provision write beside it: a subject or a NameID may contain a slash, and a route segment would refuse exactly those identities.
- Next: the Accounts-page list of accounts waiting for approval, with this action behind its button, and the roster read that feeds it.
