### PR TITLE
List who is waiting for approval, and put the button beside the name

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -108,6 +108,15 @@ jobs:
       # shipped renderer and refuses both by name. Same runtime and same absence of dependencies as the
       # steps above.
       run: node tools/ui-account-filter.js
+    - name: The pending-approvals panel
+      # The panel decides which accounts an administrator is offered to ENABLE, and every property that
+      # matters is a decision rather than a string (#1529): which rows are built, what the button sends,
+      # and what the page says when the server refuses. A row the server did not report would be an
+      # offer to enable an account nobody provisioned inert; a body that lost a slash would refuse the
+      # subject that carries one; a bare 403 read as the administrator refusal would send a signed-out
+      # reader to the dashboard for the wrong reason. This drives the shipped panel against a recording
+      # ApiClient and refuses each by name. Same runtime and same absence of dependencies as the steps above.
+      run: node tools/ui-pending-approvals.js
     - name: VEX document check
       # The published VEX statements are only useful if they parse and carry machine-readable
       # dispositions, so a malformed edit fails here rather than at the release leg that ships the

--- a/SSO-Auth.Tests/Config/LastSsoLoginStampTests.cs
+++ b/SSO-Auth.Tests/Config/LastSsoLoginStampTests.cs
@@ -339,7 +339,7 @@ public class LastSsoLoginStampTests
         config.CanonicalLinks["never"] = User;
         config.CanonicalLinkLastLogins["seen"] = Now;
 
-        var document = LinkRoster.Build(live, _ => "alice");
+        var document = LinkRoster.Build(live, _ => new LinkedAccountState("alice", false));
 
         var links = Assert.Single(document.Accounts).Links;
         Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "seen").LastSsoLoginUtc);

--- a/SSO-Auth.Tests/Config/PendingApprovalRecordTests.cs
+++ b/SSO-Auth.Tests/Config/PendingApprovalRecordTests.cs
@@ -338,7 +338,7 @@ public class PendingApprovalRecordTests
         config.CanonicalLinks["sub-ordinary"] = User;
         config.CanonicalLinkPendingApprovals["sub-pending"] = Record(User);
 
-        var document = LinkRoster.Build(configuration, _ => "alice");
+        var document = LinkRoster.Build(configuration, _ => new LinkedAccountState("alice", true));
 
         var links = Assert.Single(document.Accounts).Links;
         Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "sub-pending").PendingApprovalSinceUtc);
@@ -359,7 +359,7 @@ public class PendingApprovalRecordTests
         config.CanonicalLinks["sub-1"] = User;
         config.CanonicalLinkPendingApprovals["sub-1"] = Record(Other);
 
-        var document = LinkRoster.Build(configuration, _ => "alice");
+        var document = LinkRoster.Build(configuration, _ => new LinkedAccountState("alice", true));
 
         Assert.Null(Assert.Single(Assert.Single(document.Accounts).Links).PendingApprovalSinceUtc);
     }

--- a/SSO-Auth.Tests/Linking/PendingApprovalActionTests.cs
+++ b/SSO-Auth.Tests/Linking/PendingApprovalActionTests.cs
@@ -374,7 +374,7 @@ public class PendingApprovalActionTests
         config.CanonicalLinkPendingApprovals["live"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
         config.CanonicalLinkPendingApprovals["moved"] = new PendingApproval { UserId = Other, SinceUtc = Now };
 
-        var links = Assert.Single(LinkRoster.Build(configuration, _ => "alice").Accounts).Links;
+        var links = Assert.Single(LinkRoster.Build(configuration, _ => new LinkedAccountState("alice", true)).Accounts).Links;
 
         Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "live").PendingApprovalSinceUtc);
         Assert.Null(Assert.Single(links, l => l.CanonicalName == "moved").PendingApprovalSinceUtc);
@@ -382,6 +382,30 @@ public class PendingApprovalActionTests
         Assert.NotNull(PendingApproval.Live(config, "live"));
         Assert.Null(PendingApproval.Live(config, "moved"));
         Assert.Null(PendingApproval.Live(config, "plain"));
+    }
+
+    [Fact]
+    public void TheRosterDoesNotOfferAnAccountThatCanAlreadySignIn()
+    {
+        // #1637 from the page's side. The record is live - this plugin did provision the account inert and
+        // the link still points at it - but somebody has since enabled it in the dashboard, which this
+        // plugin never sees happen. A working account on a list of accounts that cannot sign in would be a
+        // row whose button does nothing, and, once that account is later disabled as a sanction, a row
+        // whose button undoes the sanction. The roster reads the flag the action reads, and withholds it.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig();
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = Pending;
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Pending, SinceUtc = Now };
+
+        var enabled = LinkRoster.Build(configuration, _ => new LinkedAccountState("alice", false));
+        var disabled = LinkRoster.Build(configuration, _ => new LinkedAccountState("alice", true));
+        var gone = LinkRoster.Build(configuration, _ => null);
+
+        Assert.Null(Assert.Single(Assert.Single(enabled.Accounts).Links).PendingApprovalSinceUtc);
+        Assert.Equal(Now, Assert.Single(Assert.Single(disabled.Accounts).Links).PendingApprovalSinceUtc);
+        Assert.Null(Assert.Single(Assert.Single(gone.Accounts).Links).PendingApprovalSinceUtc);
+        Assert.False(Assert.Single(gone.Accounts).AccountExists);
     }
 
     // One provider holding one linked account, recorded as provisioned inert by this plugin.

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1654,8 +1654,15 @@ public class SSOController : ControllerBase
         // Snapshot under the config lock so the two protocols' link maps are inverted against each other
         // atomically; the document that leaves the lock holds only strings and ids, so the JSON formatter
         // cannot tear against a concurrent login writing a link.
+        // The disabled flag rides along with the username (#1529) so the roster can withhold a pending row
+        // whose account somebody has since enabled; the page never reads the flag itself and never infers
+        // anything from it - it is the roster agreeing with the approve action, which reads the same flag.
         return Ok(SSOPlugin.Instance.ReadConfiguration(
-            live => LinkRoster.Build(live, userId => _userManager.GetUserById(userId)?.Username)));
+            live => LinkRoster.Build(
+                live,
+                userId => _userManager.GetUserById(userId) is { } account
+                    ? new LinkedAccountState(account.Username, account.HasPermission(PermissionKind.IsDisabled))
+                    : null)));
     }
 
     /// <summary>

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -7,6 +7,15 @@ using System.Collections.Generic;
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>
+/// What the roster needs to know about one Jellyfin account beyond its id (#1529), resolved once per
+/// account by the caller that holds the user manager. Null is the resolver's answer for an id no account
+/// answers to, which the roster keeps as an orphan row rather than dropping.
+/// </summary>
+/// <param name="Username">The account's current username.</param>
+/// <param name="IsDisabled">Whether the account is currently disabled, whoever disabled it and for whatever reason.</param>
+internal readonly record struct LinkedAccountState(string Username, bool IsDisabled);
+
+/// <summary>
 /// Inverts the canonical-link maps into the administrator's roster (#1119): the maps are stored per
 /// provider, keyed by identity, and the question an administrator asks is the other way round - which
 /// accounts are linked, and to what.
@@ -26,43 +35,51 @@ internal static class LinkRoster
     /// <c>ReadConfiguration</c>) so both link maps are read atomically against each other.
     /// </summary>
     /// <param name="live">The live plugin configuration to read.</param>
-    /// <param name="resolveUsername">Resolves a Jellyfin user id to its username, or null when no such account exists.</param>
+    /// <param name="resolve">Resolves a Jellyfin user id to what the roster needs to know about its account, or null when no such account exists.</param>
     /// <returns>The roster document.</returns>
-    internal static LinkRosterDocument Build(PluginConfiguration live, Func<Guid, string?> resolveUsername)
+    internal static LinkRosterDocument Build(PluginConfiguration live, Func<Guid, LinkedAccountState?> resolve)
     {
         ArgumentNullException.ThrowIfNull(live);
-        ArgumentNullException.ThrowIfNull(resolveUsername);
+        ArgumentNullException.ThrowIfNull(resolve);
 
         var document = new LinkRosterDocument();
-        var byUser = new Dictionary<Guid, LinkedAccount>();
+        var byUser = new Dictionary<Guid, (LinkedAccount Account, bool IsDisabled)>();
 
         foreach (var row in LinkExport.Rows(live))
         {
-            if (!byUser.TryGetValue(row.UserId, out var account))
+            if (!byUser.TryGetValue(row.UserId, out var entry))
             {
                 // Resolved once per account rather than once per link: an account linked to four providers
                 // is one user-manager read, and the answer cannot differ between its own rows.
-                var username = resolveUsername(row.UserId);
-                account = new LinkedAccount
+                var state = resolve(row.UserId);
+                var account = new LinkedAccount
                 {
                     UserId = row.UserId,
-                    Username = username,
-                    AccountExists = username is not null,
+                    Username = state?.Username,
+                    AccountExists = state is not null,
                 };
-                byUser[row.UserId] = account;
+                entry = (account, state is { IsDisabled: true });
+                byUser[row.UserId] = entry;
 
                 // Added on first sight, so the accounts come out in the order their first link is walked
                 // and a reader gets a stable list rather than a dictionary's enumeration order.
                 document.Accounts.Add(account);
             }
 
-            account.Links.Add(new LinkedAccountEntry
+            entry.Account.Links.Add(new LinkedAccountEntry
             {
                 Protocol = row.Protocol,
                 Provider = row.Provider,
                 CanonicalName = row.CanonicalName,
                 LastSsoLoginUtc = row.LastSsoLoginUtc,
-                PendingApprovalSinceUtc = row.PendingApprovalSinceUtc,
+
+                // OFFERED ONLY WHILE THE ACCOUNT IS STILL DISABLED (#1637). The record says what this plugin
+                // did at provisioning; the flag says what is true now, and an account somebody has since
+                // enabled is not waiting for anything. The approve action reads the same flag before it
+                // acts, so this is the page agreeing with the action rather than a rule of its own - and
+                // it keeps a working account off a list of accounts that cannot sign in. An orphan row
+                // resolves to no state and is offered nothing: there is no account left to enable.
+                PendingApprovalSinceUtc = entry.IsDisabled ? row.PendingApprovalSinceUtc : null,
             });
         }
 

--- a/SSO-Auth/Config/LinkRosterDocument.cs
+++ b/SSO-Auth/Config/LinkRosterDocument.cs
@@ -96,7 +96,10 @@ public class LinkedAccountEntry
     /// this plugin's own create arm recorded, and that is the point: a disabled account whose link carries no
     /// record was disabled by somebody else, for a reason this plugin does not know and must not undo. Null
     /// again when the record names an account other than the one the link now points at, because a subject
-    /// whose account was deleted is re-linked at another account and the record is about neither.
+    /// whose account was deleted is re-linked at another account and the record is about neither. And null
+    /// once more when the account is no longer disabled: it was enabled outside this plugin, and a working
+    /// account is not waiting for anything. Non-null therefore means exactly one thing to the page that
+    /// reads it - this row may be offered for approval, and the approve action will accept it.
     /// <para>
     /// It is the PROVISIONING instant rather than the approval's, so a reader can see how long somebody has
     /// been waiting - which is the question an approval list is opened with.

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -515,5 +515,20 @@
   "config.linked_accounts_filter_placeholder": "Konto, Anbieter oder Subjekt",
   "config.linked_accounts_filter_help": "Engt die Tabelle auf die Zeilen ein, deren Kontoname, Anbieter, Protokoll oder Subjekt beim Identitätsanbieter enthält, was Sie eingeben. Gefiltert wird, was bereits geladen ist; der Server wird dabei nicht gefragt.",
   "config.linked_accounts_filter_empty": "Kein verknüpftes Konto passt zum Filter. Geladen sind {total}.",
-  "config.linked_accounts_filter_count": "Gezeigt werden {shown} von {total} verknüpften Konten."
+  "config.linked_accounts_filter_count": "Gezeigt werden {shown} von {total} verknüpften Konten.",
+  "config.pending_approvals_title": "Warten auf Freigabe",
+  "config.pending_approvals_help": "Konten, die dieses Plugin deaktiviert angelegt hat, weil ihr Anbieter neue Benutzer deaktiviert anlegt, und die noch warten. Die Freigabe aktiviert das Konto und ändert sonst nichts: Seine Berechtigungen sind die, die es beim Anlegen bekommen hat. Ein Konto, das ein Administrator deaktiviert hat, erscheint hier nicht, in welchem Zustand auch immer, und wird im Jellyfin-Dashboard aktiviert. Wird zusammen mit den verknüpften Konten oben gelesen; Verknüpfte Konten neu laden liest beides neu.",
+  "config.pending_approvals_loading": "Die wartenden Konten werden geladen…",
+  "config.pending_approvals_empty": "Kein Konto wartet auf Freigabe.",
+  "config.pending_approvals_column_identity": "Identität",
+  "config.pending_approvals_column_since": "Wartet seit",
+  "config.pending_approvals_identity_line": "{provider} ({protocol}) - {canonical}",
+  "config.pending_approvals_truncated": "Gezeigt werden die ersten {shown} von {total} wartenden Konten. Geben Sie einige frei oder widerrufen Sie sie, um die übrigen zu sehen.",
+  "config.pending_approvals_approve": "Freigeben",
+  "config.pending_approvals_confirm": "{user} freigeben? Das aktiviert das Konto, sodass es sich über {provider} anmelden kann. Sonst ändert sich nichts: Die Berechtigungen bleiben so, wie das Anlegen sie gesetzt hat.",
+  "config.pending_approvals_approving": "{user} wird freigegeben…",
+  "config.pending_approvals_approved": "Freigegeben. {user} kann sich jetzt anmelden.",
+  "config.pending_approvals_refused_administrator": "Dieses Konto ist ein Administrator und wird nicht von hier freigegeben. Aktivieren Sie es im Jellyfin-Dashboard.",
+  "config.pending_approvals_not_pending": "Dieses Konto wartet nicht mehr auf Freigabe. Die Liste wurde neu gelesen.",
+  "config.pending_approvals_failed": "Das Konto konnte nicht freigegeben werden. Stellen Sie sicher, dass Sie als Administrator angemeldet sind, und versuchen Sie es erneut."
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -515,5 +515,20 @@
   "config.linked_accounts_filter_placeholder": "account, provider or subject",
   "config.linked_accounts_filter_help": "Narrows the table to the rows whose account name, provider, protocol or identity-provider subject contains what you type. It filters what is already loaded and asks the server for nothing.",
   "config.linked_accounts_filter_empty": "No linked account matches the filter. {total} are loaded.",
-  "config.linked_accounts_filter_count": "Showing {shown} of {total} linked accounts."
+  "config.linked_accounts_filter_count": "Showing {shown} of {total} linked accounts.",
+  "config.pending_approvals_title": "Waiting for Approval",
+  "config.pending_approvals_help": "Accounts this plugin created disabled because their provider provisions new users disabled, and that are still waiting. Approving enables the account and changes nothing else: its permissions are the ones the provisioning gave it. An account that an administrator disabled is not listed here, whatever its state, and is enabled in the Jellyfin dashboard. Read together with the linked accounts above; Refresh Linked Accounts re-reads both.",
+  "config.pending_approvals_loading": "Loading the accounts waiting for approval…",
+  "config.pending_approvals_empty": "No account is waiting for approval.",
+  "config.pending_approvals_column_identity": "Identity",
+  "config.pending_approvals_column_since": "Waiting since",
+  "config.pending_approvals_identity_line": "{provider} ({protocol}) - {canonical}",
+  "config.pending_approvals_truncated": "Showing the first {shown} of {total} accounts waiting for approval. Approve or revoke some to see the rest.",
+  "config.pending_approvals_approve": "Approve",
+  "config.pending_approvals_confirm": "Approve {user}? This enables the account so it can sign in through {provider}. Nothing else changes: its permissions stay as the provisioning set them.",
+  "config.pending_approvals_approving": "Approving {user}…",
+  "config.pending_approvals_approved": "Approved. {user} can sign in now.",
+  "config.pending_approvals_refused_administrator": "That account is an administrator and is not approved from here. Enable it in the Jellyfin dashboard.",
+  "config.pending_approvals_not_pending": "That account is no longer waiting for approval. The list has been re-read.",
+  "config.pending_approvals_failed": "Could not approve the account. Make sure you are signed in as an administrator, then try again."
 }

--- a/SSO-Auth/Web/accountsPage.html
+++ b/SSO-Auth/Web/accountsPage.html
@@ -191,6 +191,45 @@
               </form>
 
               <!--
+            Pending approvals (#1529). Presentation only, over the same elevation-gated roster the panel
+            above reads: a row appears here for exactly the links the server reports as waiting - this
+            plugin's own record of having provisioned the account disabled, still naming the account the
+            link points at, on an account that is still disabled. An account somebody else disabled has no
+            record and is not here, and the help text says so, because the one mistake this panel must not
+            invite is undoing a sanction from a page about SSO. The button drives the elevation-gated,
+            rate-limited approve endpoint, which re-reads the state and enables the account and nothing
+            else. Every cell is written with textContent, never innerHTML (#221). The list is bounded and
+            says when it is cut, so a provider with a wide audience cannot make this the page that breaks.
+          -->
+              <form id="sso-pending-approvals" class="esqConfigurationForm">
+                <div
+                  class="verticalSection"
+                  is="emby-collapse"
+                  title="Waiting for Approval"
+                  data-i18n-title="config.pending_approvals_title"
+                >
+                  <div class="collapseContent">
+                    <div
+                      class="fieldDescription"
+                      data-i18n="config.pending_approvals_help"
+                    >
+                      Accounts this plugin created disabled because their
+                      provider provisions new users disabled, and that are still
+                      waiting. Approving enables the account and changes nothing
+                      else: its permissions are the ones the provisioning gave
+                      it. An account that an administrator disabled is not
+                      listed here, whatever its state, and is enabled in the
+                      Jellyfin dashboard. Read together with the linked accounts
+                      above; Refresh Linked Accounts re-reads both.
+                    </div>
+
+                    <div id="PendingApprovalsActionResult"></div>
+                    <div id="PendingApprovalsResult"></div>
+                  </div>
+                </div>
+              </form>
+
+              <!--
             Account-link transfer (#1131), on the Accounts tab since #1527. It used to sit in the same
             section as the configuration transfer so an administrator met both together; the two are now one
             tab apart, and this is the half that belongs beside the accounts it names. The other half stayed

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -3935,23 +3935,37 @@ const ssoConfigurationPage = {
   // administrator opens.
   loadLinkedAccounts: (page) => {
     const container = page.querySelector("#LinkedAccountsResult");
+    // The pending list (#1529) is a second view of the SAME roster read, never a second request: the
+    // roster is elevation-gated and rate-limited, and the two panels answer one question each about one
+    // document. Both containers are written on both arms, so neither panel is left showing "loading"
+    // when the other has an answer.
+    const pending = page.querySelector("#PendingApprovalsResult");
     ssoConfigurationPage.renderTransferMessage(
       container,
       tr("config.linked_accounts_loading", "Loading the linked accounts…"),
     );
+    ssoConfigurationPage.renderTransferMessage(
+      pending,
+      tr(
+        "config.pending_approvals_loading",
+        "Loading the accounts waiting for approval…",
+      ),
+    );
 
     return ApiClient.getJSON(ApiClient.getUrl("sso/Links/Roster")).then(
-      (roster) =>
-        ssoConfigurationPage.renderLinkedAccounts(page, container, roster),
+      (roster) => {
+        ssoConfigurationPage.renderLinkedAccounts(page, container, roster);
+        ssoConfigurationPage.renderPendingApprovals(page, pending);
+      },
       // Generic and input-independent, like the neighbouring admin actions: it never reflects a server value.
-      () =>
-        ssoConfigurationPage.renderTransferMessage(
-          container,
-          tr(
-            "config.linked_accounts_failed",
-            "Could not load the linked accounts. Make sure you are signed in as an administrator, then try again.",
-          ),
-        ),
+      () => {
+        const failed = tr(
+          "config.linked_accounts_failed",
+          "Could not load the linked accounts. Make sure you are signed in as an administrator, then try again.",
+        );
+        ssoConfigurationPage.renderTransferMessage(container, failed);
+        ssoConfigurationPage.renderTransferMessage(pending, failed);
+      },
     );
   },
   // THE ROSTER IS KEPT so the filter can re-render without asking the server again (#1529). Held on the
@@ -4213,6 +4227,228 @@ const ssoConfigurationPage = {
             "Could not revoke the SSO links. Make sure you are signed in as an administrator, then try again.",
           ),
         ),
+    );
+  },
+  // THE BOUND on the pending list (#1529). A provider whose audience is wider than the one meant for
+  // Jellyfin - the case the feature exists for - fills this list as fast as it can log in, and a table
+  // of ten thousand rows is the page that breaks under the load it was built to absorb. So the first
+  // hundred are drawn and a line says what was cut; nothing is hidden silently.
+  PENDING_APPROVALS_BOUND: 100,
+  // Every link the server reports as waiting, as (account, link) pairs in roster order. The SERVER
+  // decides what waiting means - this plugin's own record of having provisioned the account inert, still
+  // naming the account the link points at, on an account that is still disabled - and this reads only
+  // the one field that carries its answer. Nothing here infers a pending account from a disabled flag,
+  // because the flag does not say who set it, and the account somebody disabled on purpose is exactly
+  // the row this list must not contain.
+  pendingApprovals: (roster) => {
+    const accounts =
+      roster && Array.isArray(roster.Accounts) ? roster.Accounts : [];
+    return accounts.flatMap((account) =>
+      (account && Array.isArray(account.Links) ? account.Links : [])
+        .filter((link) => link && link.PendingApprovalSinceUtc)
+        .map((link) => ({ account, link })),
+    );
+  },
+  renderPendingApprovals: (page, container) => {
+    const waiting = ssoConfigurationPage.pendingApprovals(
+      ssoConfigurationPage.linkedAccountRoster,
+    );
+    container.replaceChildren();
+
+    // Its own sentence, and not the linked-accounts one: "no account holds a link" and "no account is
+    // waiting" are different facts about the server, and a reader who came to approve somebody must not
+    // be told the links are gone.
+    if (waiting.length === 0) {
+      ssoConfigurationPage.renderTransferMessage(
+        container,
+        tr(
+          "config.pending_approvals_empty",
+          "No account is waiting for approval.",
+        ),
+      );
+      return;
+    }
+
+    const shown = waiting.slice(
+      0,
+      ssoConfigurationPage.PENDING_APPROVALS_BOUND,
+    );
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const head_row = document.createElement("tr");
+    [
+      tr("config.linked_accounts_column_account", "Account"),
+      tr("config.pending_approvals_column_identity", "Identity"),
+      tr("config.pending_approvals_column_since", "Waiting since"),
+      tr("config.linked_accounts_column_action", "Action"),
+    ].forEach((label) => {
+      const cell = document.createElement("th");
+      cell.textContent = label;
+      head_row.appendChild(cell);
+    });
+    head.appendChild(head_row);
+    table.appendChild(head);
+
+    const body = document.createElement("tbody");
+    shown.forEach(({ account, link }) => {
+      body.appendChild(
+        ssoConfigurationPage.renderPendingApprovalRow(page, account, link),
+      );
+    });
+    table.appendChild(body);
+    container.appendChild(table);
+
+    if (shown.length !== waiting.length) {
+      const note = document.createElement("div");
+      note.className = "fieldDescription";
+      note.textContent = tr(
+        "config.pending_approvals_truncated",
+        "Showing the first {shown} of {total} accounts waiting for approval. Approve or revoke some to see the rest.",
+        { shown: String(shown.length), total: String(waiting.length) },
+      );
+      container.appendChild(note);
+    }
+  },
+  renderPendingApprovalRow: (page, account, link) => {
+    const row = document.createElement("tr");
+    const username =
+      account && account.Username ? String(account.Username) : "";
+
+    // Every value on a row is attacker-influenced - the subject is whatever the identity provider put in
+    // its claim - so the whole row is textContent, the same line the linked-accounts table holds (#221).
+    const name_cell = document.createElement("td");
+    name_cell.textContent = username;
+    row.appendChild(name_cell);
+
+    const identity_cell = document.createElement("td");
+    identity_cell.textContent = tr(
+      "config.pending_approvals_identity_line",
+      "{provider} ({protocol}) - {canonical}",
+      {
+        provider: String((link && link.Provider) || ""),
+        protocol: String((link && link.Protocol) || ""),
+        canonical: String((link && link.CanonicalName) || ""),
+      },
+    );
+    row.appendChild(identity_cell);
+
+    // The PROVISIONING instant, which is what the column heading says: how long somebody has been
+    // waiting is the question this list is opened with.
+    const since_cell = document.createElement("td");
+    since_cell.textContent = ssoConfigurationPage.formatLastSsoLogin(
+      link && link.PendingApprovalSinceUtc,
+    );
+    row.appendChild(since_cell);
+
+    // Always a button: the server withholds the pending instant from an orphan row and from an account
+    // that is already enabled, so a row that reaches here is one the approve action will accept.
+    const action_cell = document.createElement("td");
+    const button = document.createElement("button");
+    button.setAttribute("is", "emby-button");
+    button.setAttribute("type", "button");
+    button.classList.add("raised", "button-submit", "emby-button");
+    button.textContent = tr("config.pending_approvals_approve", "Approve");
+    button.addEventListener("click", (e) => {
+      ssoConfigurationPage.approvePendingAccount(page, username, link);
+      e.preventDefault();
+      return false;
+    });
+    action_cell.appendChild(button);
+    row.appendChild(action_cell);
+
+    return row;
+  },
+  // The approve (#1529). It drives POST sso/Links/Approve/{mode}/{provider} exactly as it stands - the
+  // elevation policy, the link rate-limit class, the record check, the administrator refusal and the
+  // audit line are all the endpoint's, and none of them is re-implemented or bypassed here. The
+  // confirmation NAMES what the button does and what it does not: the account is enabled, and nothing
+  // else about it changes.
+  approvePendingAccount: (page, username, link) => {
+    const result = page.querySelector("#PendingApprovalsActionResult");
+    const provider = String((link && link.Provider) || "");
+    if (
+      !window.confirm(
+        tr(
+          "config.pending_approvals_confirm",
+          "Approve {user}? This enables the account so it can sign in through {provider}. Nothing else changes: its permissions stay as the provisioning set them.",
+          { user: username, provider },
+        ),
+      )
+    ) {
+      return Promise.resolve();
+    }
+
+    ssoConfigurationPage.renderTransferMessage(
+      result,
+      tr("config.pending_approvals_approving", "Approving {user}…", {
+        user: username,
+      }),
+    );
+
+    // The route's mode token is the protocol's short name, not the roster's display name; the canonical
+    // name travels in the body because a subject may contain a slash.
+    const mode = link && link.Protocol === "SAML" ? "SAML" : "OID";
+    return ApiClient.fetch({
+      type: "POST",
+      url: ApiClient.getUrl(
+        "sso/Links/Approve/" + mode + "/" + encodeURIComponent(provider),
+      ),
+      data: JSON.stringify(String((link && link.CanonicalName) || "")),
+      contentType: "application/json",
+    }).then(
+      () =>
+        // Re-read rather than editing the rendered table: the roster is the server's answer, and the row
+        // must disappear because the server no longer reports it, not because the page assumed so.
+        ssoConfigurationPage
+          .loadLinkedAccounts(page)
+          .then(() =>
+            ssoConfigurationPage.renderTransferMessage(
+              result,
+              tr(
+                "config.pending_approvals_approved",
+                "Approved. {user} can sign in now.",
+                { user: username },
+              ),
+            ),
+          ),
+      (e) => {
+        // ApiClient.fetch rejects with the Response on a non-2xx status. Two refusals mean something to
+        // the reader and get their own sentence; everything else is the generic one, which never reflects
+        // a server value. The administrator refusal is told apart from an elevation refusal - both are
+        // 403 - by the body the endpoint writes for it, which an elevation refusal leaves empty.
+        const status = e && typeof e.status === "number" ? e.status : 0;
+        const body =
+          e && typeof e.text === "function"
+            ? Promise.resolve(e.text()).catch(() => "")
+            : Promise.resolve("");
+        return body.then((text) => {
+          const administrator =
+            status === 403 && /administrator/i.test(String(text || ""));
+          const stale = status === 404;
+          const message = administrator
+            ? tr(
+                "config.pending_approvals_refused_administrator",
+                "That account is an administrator and is not approved from here. Enable it in the Jellyfin dashboard.",
+              )
+            : stale
+              ? tr(
+                  "config.pending_approvals_not_pending",
+                  "That account is no longer waiting for approval. The list has been re-read.",
+                )
+              : tr(
+                  "config.pending_approvals_failed",
+                  "Could not approve the account. Make sure you are signed in as an administrator, then try again.",
+                );
+          // A stale row is re-read rather than left standing: the server no longer offers it, and a
+          // list that kept showing it would offer the same press again.
+          const refresh = stale
+            ? ssoConfigurationPage.loadLinkedAccounts(page)
+            : Promise.resolve();
+          const say = () =>
+            ssoConfigurationPage.renderTransferMessage(result, message);
+          return refresh.then(say, say);
+        });
+      },
     );
   },
   renderTransferMessage: (container, message) => {

--- a/tools/ui-pending-approvals.js
+++ b/tools/ui-pending-approvals.js
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2026 iderex
+
+/*
+ * Drives the REAL pending-approvals panel of the shipped sso-core.js and
+ * refuses each way it can grant the wrong thing or say the wrong thing (#1529).
+ *
+ * WHY THIS IS A RUNNING PROOF. The panel decides which accounts an
+ * administrator is offered to ENABLE, and every property that matters is a
+ * decision rather than a string: which rows are built, what the button sends,
+ * and what the page says when the server refuses. None of that is visible to
+ * a rule that reads the assets as text, and all of it fails silently.
+ *
+ * THE ROWS ARE THE SERVER'S ANSWER AND NOTHING ELSE. A row is built for
+ * exactly the links whose pending instant the roster carries. The page never
+ * infers a waiting account from anything - not from a disabled flag, not from
+ * a missing login - because the one row this panel must never contain is the
+ * account somebody disabled on purpose, and the server is the only party that
+ * can tell that account from one this plugin created inert.
+ *
+ * THE BUTTON SENDS EXACTLY THE REQUEST THE ENDPOINT PARSES: the mode token
+ * the route reads, the provider in the path, and the canonical name as the
+ * JSON body, so a subject with a slash in it reaches the server whole.
+ *
+ * THE LIST IS BOUNDED AND SAYS SO. A provider with a wide audience fills the
+ * list as fast as it can log in, and a panel that drew every row would be the
+ * page that breaks under the load the feature was built to absorb; a panel
+ * that cut silently would be lying about how many are waiting.
+ *
+ * WHAT THE STUB CAN AND CANNOT SAY. The DOM below is the smallest one the
+ * renderer touches, and ApiClient is a recorder that answers what a test
+ * tells it to. It is not a browser: it cannot say what the table looks like,
+ * only which rows were built, what was sent, and which sentence was written -
+ * which is what the properties above are about.
+ *
+ * Node is preinstalled on the runner and this tool has no dependencies, in the
+ * same terms as tools/ui-account-filter.js.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CORE = path.join(HERE, "..", "SSO-Auth", "Web", "sso-core.js");
+
+// ---------------------------------------------------------------------------
+// The stub.
+// ---------------------------------------------------------------------------
+
+class Element {
+  constructor(tag) {
+    this.tag = tag;
+    this.children = [];
+    this.attributes = {};
+    this.classes = new Set();
+    this.listeners = {};
+    this.value = "";
+    this.text = "";
+    this.classList = {
+      add: (...names) => names.forEach((name) => this.classes.add(name)),
+    };
+  }
+
+  set className(value) {
+    this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+  }
+
+  set textContent(value) {
+    this.text = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    return this.children.length
+      ? this.children.map((child) => child.textContent).join(" ")
+      : this.text;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+
+  addEventListener(name, handler) {
+    (this.listeners[name] ??= []).push(handler);
+  }
+
+  /** Fires the handlers a test wants to press, with the event shape they read. */
+  click() {
+    (this.listeners.click ?? []).forEach((handler) =>
+      handler({ preventDefault() {} }),
+    );
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...nodes) {
+    this.children = nodes;
+    this.text = "";
+  }
+
+  /** Every element under this one with the given tag, at any depth. */
+  all(tag) {
+    return this.children.flatMap((child) => [
+      ...(child.tag === tag ? [child] : []),
+      ...child.all(tag),
+    ]);
+  }
+}
+
+function pageWith() {
+  const nodes = {
+    LinkedAccountsFilter: new Element("input"),
+    LinkedAccountsResult: new Element("div"),
+    PendingApprovalsResult: new Element("div"),
+    PendingApprovalsActionResult: new Element("div"),
+  };
+  return {
+    page: { querySelector: (selector) => nodes[selector.slice(1)] ?? null },
+    nodes,
+  };
+}
+
+globalThis.document = {
+  createElement: (tag) => new Element(tag),
+};
+
+// The confirmation is answered by whatever the arm set, and the recorder holds
+// every request the panel made so an arm can read back what was sent.
+const answers = { confirm: true, fetch: () => Promise.resolve() };
+const sent = [];
+globalThis.window = {
+  document: globalThis.document,
+  confirm: () => answers.confirm,
+};
+globalThis.ApiClient = {
+  getUrl: (route) => "/" + route,
+  getJSON: () => Promise.resolve(current.roster),
+  fetch: (request) => {
+    sent.push(request);
+    return answers.fetch(request);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// The fixture and the legs.
+// ---------------------------------------------------------------------------
+
+const SINCE = "2026-09-11T09:00:00Z";
+
+function link(provider, protocol, canonical, pending) {
+  return {
+    Provider: provider,
+    Protocol: protocol,
+    CanonicalName: canonical,
+    LastSsoLoginUtc: null,
+    PendingApprovalSinceUtc: pending ? SINCE : null,
+  };
+}
+
+/** Three accounts: two waiting on different protocols, one that merely holds a link. */
+const ROSTER = {
+  Accounts: [
+    {
+      Username: "alice",
+      UserId: "1",
+      AccountExists: true,
+      Links: [link("keycloak", "OpenID", "alice@example.com", true)],
+    },
+    {
+      Username: "bob",
+      UserId: "2",
+      AccountExists: true,
+      Links: [link("authentik", "OpenID", "bob@example.com", false)],
+    },
+    {
+      Username: "carol",
+      UserId: "3",
+      AccountExists: true,
+      Links: [link("adfs", "SAML", "S-1-5-21/carol", true)],
+    },
+  ],
+};
+
+const current = { roster: ROSTER };
+
+async function loadCore() {
+  const source = fs.readFileSync(CORE, "utf8");
+  const url =
+    "data:text/javascript;base64," +
+    Buffer.from(source, "utf8").toString("base64");
+  return (await import(url)).default;
+}
+
+const core = await loadCore();
+const faults = [];
+const refuse = (leg, detail) => faults.push(leg + ": " + detail);
+
+/** Holds a roster the way the load does, then draws the pending panel from it. */
+function render(roster) {
+  current.roster = roster;
+  const { page, nodes } = pageWith();
+  core.renderLinkedAccounts(page, nodes.LinkedAccountsResult, roster);
+  core.renderPendingApprovals(page, nodes.PendingApprovalsResult);
+  const rows = nodes.PendingApprovalsResult.all("tbody").flatMap(
+    (body) => body.children,
+  );
+  const notes = nodes.PendingApprovalsResult.children
+    .filter((child) => child.tag !== "table")
+    .map((child) => child.textContent);
+  return { page, nodes, rows, notes };
+}
+
+// ---- Arm: a row for exactly the links the server reports as waiting ----
+{
+  const { rows } = render(ROSTER);
+  const names = rows.map((row) => row.children[0].textContent);
+  if (names.join(",") !== "alice,carol") {
+    refuse(
+      "rows",
+      `the panel drew rows for "${names.join(",")}" where the server reported alice and carol waiting; a row the server did not report is an offer to enable an account nobody provisioned inert`,
+    );
+  }
+  const identity = rows[1] && rows[1].children[1].textContent;
+  if (!/adfs/.test(identity || "") || !/S-1-5-21\/carol/.test(identity || "")) {
+    refuse(
+      "rows",
+      `a row must name the provider and the subject it is about; it said "${identity}"`,
+    );
+  }
+}
+
+// ---- Arm: nothing waiting says so, and does not say the links are gone ----
+{
+  const { nodes } = render({
+    Accounts: [ROSTER.Accounts[1]],
+  });
+  const said = nodes.PendingApprovalsResult.textContent;
+  if (!/waiting for approval/i.test(said)) {
+    refuse(
+      "empty",
+      `a panel with nothing waiting said "${said}", which does not say that nothing is waiting`,
+    );
+  }
+  if (/holds an SSO link/.test(said)) {
+    refuse(
+      "empty",
+      "a panel with nothing waiting claimed the server holds no linked account, which is the other panel's sentence and a statement about the links",
+    );
+  }
+}
+
+// ---- Arm: the list is bounded, and says how many it cut ----
+{
+  const many = {
+    Accounts: Array.from({ length: 150 }, (_, i) => ({
+      Username: "user" + i,
+      UserId: String(i),
+      AccountExists: true,
+      Links: [link("keycloak", "OpenID", "user" + i + "@example.com", true)],
+    })),
+  };
+  const { rows, notes } = render(many);
+  if (rows.length !== 100) {
+    refuse(
+      "bound",
+      `${rows.length} rows drawn for 150 waiting accounts; the list is bounded at 100 so a wide audience cannot make this the page that breaks`,
+    );
+  }
+  if (notes.length !== 1 || !/100/.test(notes[0]) || !/150/.test(notes[0])) {
+    refuse(
+      "bound",
+      `a cut list must say how many of how many it shows; it said "${notes.join(" ")}"`,
+    );
+  }
+}
+
+// ---- Arm: an uncut list carries no count line ----
+{
+  const { notes } = render(ROSTER);
+  if (notes.length !== 0) {
+    refuse(
+      "uncut",
+      `an uncut list carries the line "${notes.join(" ")}", and furniture that is always there stops being read`,
+    );
+  }
+}
+
+// ---- Arm: the button sends exactly the request the endpoint parses ----
+{
+  sent.length = 0;
+  answers.confirm = true;
+  answers.fetch = () => Promise.resolve();
+  const { rows } = render(ROSTER);
+  rows[1].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const request = sent[0];
+  if (!request) {
+    refuse("request", "pressing Approve sent nothing");
+  } else {
+    if (request.type !== "POST") {
+      refuse("request", `the approve was sent as ${request.type}, not POST`);
+    }
+    if (request.url !== "/sso/Links/Approve/SAML/adfs") {
+      refuse(
+        "request",
+        `the approve was sent to "${request.url}"; the route is Links/Approve/{mode}/{provider} with the protocol's short token`,
+      );
+    }
+    if (request.data !== JSON.stringify("S-1-5-21/carol")) {
+      refuse(
+        "request",
+        `the body was ${request.data}; the canonical name travels as the JSON body so a slash in a subject reaches the server whole`,
+      );
+    }
+    if (request.contentType !== "application/json") {
+      refuse("request", `the body was sent as ${request.contentType}`);
+    }
+  }
+}
+
+// ---- Arm: declining the confirmation sends nothing ----
+{
+  sent.length = 0;
+  answers.confirm = false;
+  const { rows } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (sent.length !== 0) {
+    refuse(
+      "declined",
+      "the confirmation was declined and the approve was sent anyway",
+    );
+  }
+  answers.confirm = true;
+}
+
+// ---- Arm: the administrator refusal is told apart and says where to go ----
+{
+  sent.length = 0;
+  answers.fetch = () =>
+    Promise.reject({
+      status: 403,
+      text: () =>
+        Promise.resolve(
+          "That account is an administrator. Enable an administrator account in the Jellyfin dashboard, not from here.",
+        ),
+    });
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (!/administrator/i.test(said) || !/dashboard/i.test(said)) {
+    refuse(
+      "administrator",
+      `a refused administrator must be sent to the dashboard; the page said "${said}"`,
+    );
+  }
+  if (/can sign in now/i.test(said)) {
+    refuse("administrator", "a refusal was reported as an approval");
+  }
+}
+
+// ---- Arm: an elevation refusal is NOT read as the administrator one ----
+{
+  answers.fetch = () =>
+    Promise.reject({ status: 403, text: () => Promise.resolve("") });
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (/is an administrator/i.test(said)) {
+    refuse(
+      "elevation",
+      `a bare 403 - the elevation policy's refusal - was reported as "that account is an administrator": "${said}"`,
+    );
+  }
+  if (!/signed in as an administrator/i.test(said)) {
+    refuse(
+      "elevation",
+      `a bare 403 must fall to the generic sentence naming the elevation; the page said "${said}"`,
+    );
+  }
+}
+
+// ---- Arm: a stale row is re-read rather than left standing ----
+{
+  const reads = [];
+  globalThis.ApiClient.getJSON = () => {
+    reads.push(1);
+    return Promise.resolve(current.roster);
+  };
+  answers.fetch = () =>
+    Promise.reject({ status: 404, text: () => Promise.resolve("no record") });
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (!/no longer waiting/i.test(said)) {
+    refuse(
+      "stale",
+      `a 404 means the server no longer offers the row; the page said "${said}"`,
+    );
+  }
+  if (reads.length !== 1) {
+    refuse(
+      "stale",
+      `a stale row must re-read the roster once; it read ${reads.length} times`,
+    );
+  }
+}
+
+// ---- Arm: a success re-reads the roster and reports the approval ----
+{
+  const reads = [];
+  globalThis.ApiClient.getJSON = () => {
+    reads.push(1);
+    return Promise.resolve({ Accounts: [] });
+  };
+  answers.fetch = () => Promise.resolve();
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (!/alice/.test(said) || !/can sign in now/i.test(said)) {
+    refuse(
+      "approved",
+      `a successful approve must say so; the page said "${said}"`,
+    );
+  }
+  if (reads.length !== 1) {
+    refuse(
+      "approved",
+      `a successful approve must re-read the roster once rather than editing its own table; it read ${reads.length} times`,
+    );
+  }
+  const remaining = nodes.PendingApprovalsResult.all("tbody").flatMap(
+    (body) => body.children,
+  );
+  if (remaining.length !== 0) {
+    refuse(
+      "approved",
+      `${remaining.length} rows survived a re-read that reported nothing waiting`,
+    );
+  }
+}
+
+if (faults.length) {
+  faults.forEach((fault) => console.error(fault));
+  console.error(
+    faults.length + " refusal(s) in the pending-approvals panel (#1529)",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "pending approvals: ten arms run against the shipped sso-core.js panel",
+);
+console.log(
+  "  rows             a row for exactly the links the server reports as waiting, naming provider and subject",
+);
+console.log(
+  "  empty            nothing waiting says so, and never that the links are gone",
+);
+console.log(
+  "  bound / uncut    the first hundred are drawn and a cut list says how many of how many",
+);
+console.log(
+  "  request          Approve posts the mode token, the provider and the canonical name as the JSON body",
+);
+console.log("  declined         a declined confirmation sends nothing");
+console.log(
+  "  administrator    the administrator refusal is told apart and points at the dashboard",
+);
+console.log(
+  "  elevation        a bare 403 falls to the generic sentence, never to the administrator one",
+);
+console.log(
+  "  stale / approved a 404 and a success both re-read the roster rather than editing the table",
+);


### PR DESCRIPTION
# What & why

Stage 3 of #1529: the Accounts page lists the accounts this plugin provisioned disabled and still waiting, with an Approve button beside each name. The surface half of the pending-approval bullet, over the record (#1639) and the action (#1642).

The rows are the server's answer and nothing else. The roster reports a link as waiting only when three things hold at once: this plugin's own record says it provisioned the account inert, the record still names the account the link points at, and the account is still disabled. The page infers nothing from a disabled flag or a missing login, because the one row it must never contain is the account an administrator disabled on purpose - and the help text says so, and says where that account is enabled instead.

The third condition is new here and closes the page half of #1637: the roster withholds the row for an account somebody has since enabled, so a working account never sits on a list of accounts that cannot sign in - and, once such an account is later disabled as a sanction, never sits there with a button that undoes it. The disabled flag rides along with the username in the one resolver the roster already had.

The button sends exactly the request the endpoint parses and the confirmation names what it does and what it does not. A success re-reads the roster rather than editing the table. The two 403s - the endpoint's administrator refusal and the elevation policy's - are told apart by the body the endpoint writes for its own, and no other server value is reflected anywhere. The list is bounded at a hundred rows and says how many were cut.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here decides; the page renders
      what the server reports and drives an endpoint that re-reads the state.
      The one new server-side read, the disabled flag on the roster, only ever
      withholds a row.
- [x] No secrets logged; secrets are redacted on config export. The roster
      gains a boolean; nothing new is logged.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Not one of the four, but the
      page drives a grant, so it had an adversarial pass of its own; record
      below.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

### Review record

**An adversarial pass over the panel and the roster's new condition** - the sinks every rendered value reaches, the request the button builds for each protocol, whether the page infers "pending" from anything but the server's field, the two 403s, the bound, the held roster, both catalogs, the gate's own arms, and any change to what a non-pending row reports - is running as this PR opens. Its record follows as a comment before the merge, and the merge waits for it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The roster's condition lives in `LinkRoster.Build`; the
      page reads one field.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The page's properties are decisions rather than structure, and the
      running proof in `tools/ui-pending-approvals.js` is their rule: which
      rows are built, what the button sends, and which sentence is written for
      a success, a cut list, a stale row, an administrator and a bare 403.
- [x] Docs impact considered: the panel's help text carries the whole of what a
      reader needs at the point of use, and the wiki's Accounts page needs a
      paragraph for the new panel - filed as its own `documentation` issue on
      this milestone, linked in Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3918 on net9.0 and 3919 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows), on
      an idle machine.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Every UI gate passes, including the new one: the string ratchet stays at zero on all six templates, the field register still counts 124 (the panel adds no form control), and the pending-approvals proof runs its ten arms against the shipped renderer.

## German

The new rows, quoted for the reading. The word that carries the panel is the one the existing provider option already uses for the same act, and the remaining short rows are each shaped on their linked-accounts neighbour.

```text
config.pending_approvals_title:  Warten auf Freigabe
config.pending_approvals_help:   Konten, die dieses Plugin deaktiviert angelegt hat, weil ihr Anbieter neue Benutzer deaktiviert anlegt, und die noch warten. Die Freigabe aktiviert das Konto und ändert sonst nichts: Seine Berechtigungen sind die, die es beim Anlegen bekommen hat. Ein Konto, das ein Administrator deaktiviert hat, erscheint hier nicht, in welchem Zustand auch immer, und wird im Jellyfin-Dashboard aktiviert. Wird zusammen mit den verknüpften Konten oben gelesen; Verknüpfte Konten neu laden liest beides neu.
config.pending_approvals_empty:  Kein Konto wartet auf Freigabe.
config.pending_approvals_column_identity / _since:  Identität / Wartet seit
config.pending_approvals_truncated:  Gezeigt werden die ersten {shown} von {total} wartenden Konten. Geben Sie einige frei oder widerrufen Sie sie, um die übrigen zu sehen.
config.pending_approvals_approve:  Freigeben
config.pending_approvals_confirm:  {user} freigeben? Das aktiviert das Konto, sodass es sich über {provider} anmelden kann. Sonst ändert sich nichts: Die Berechtigungen bleiben so, wie das Anlegen sie gesetzt hat.
config.pending_approvals_approving / _approved:  {user} wird freigegeben… / Freigegeben. {user} kann sich jetzt anmelden.
config.pending_approvals_refused_administrator:  Dieses Konto ist ein Administrator und wird nicht von hier freigegeben. Aktivieren Sie es im Jellyfin-Dashboard.
config.pending_approvals_not_pending:  Dieses Konto wartet nicht mehr auf Freigabe. Die Liste wurde neu gelesen.
config.pending_approvals_failed:  Das Konto konnte nicht freigegeben werden. Stellen Sie sicher, dass Sie als Administrator angemeldet sind, und versuchen Sie es erneut.
```

## Notes

- #1643 carries the wiki paragraph for the panel, on this milestone; the dashboard-only instruction the wiki holds today is no longer the whole truth.
- The residual on #1637 is unchanged by this change: an account enabled by hand that never signs in and is then disabled by hand again still carries a live record and will be listed. It is narrower than before and still open.
- Next: the self-service page walk as a non-admin user, and the Server page's export and import in one place, which are the last two bullets of the stage.

Catalogue-Vouch: de read by iderex
