### PR TITLE
Let the approvals panel say what the answer was, and count what it says

### DIFF
--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -528,6 +528,7 @@
   "config.pending_approvals_confirm": "{user} freigeben? Das aktiviert das Konto, sodass es sich über {provider} anmelden kann. Sonst ändert sich nichts: Die Berechtigungen bleiben so, wie das Anlegen sie gesetzt hat.",
   "config.pending_approvals_approving": "{user} wird freigegeben…",
   "config.pending_approvals_approved": "Freigegeben. {user} kann sich jetzt anmelden.",
+  "config.pending_approvals_account_gone": "Dieses Konto existiert nicht mehr, es wurde also nichts aktiviert. Die Liste wurde neu gelesen.",
   "config.pending_approvals_refused_administrator": "Dieses Konto ist ein Administrator und wird nicht von hier freigegeben. Aktivieren Sie es im Jellyfin-Dashboard.",
   "config.pending_approvals_not_pending": "Dieses Konto wartet nicht mehr auf Freigabe. Die Liste wurde neu gelesen.",
   "config.pending_approvals_failed": "Das Konto konnte nicht freigegeben werden. Stellen Sie sicher, dass Sie als Administrator angemeldet sind, und versuchen Sie es erneut."

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -528,6 +528,7 @@
   "config.pending_approvals_confirm": "Approve {user}? This enables the account so it can sign in through {provider}. Nothing else changes: its permissions stay as the provisioning set them.",
   "config.pending_approvals_approving": "Approving {user}…",
   "config.pending_approvals_approved": "Approved. {user} can sign in now.",
+  "config.pending_approvals_account_gone": "That account no longer exists, so nothing was enabled. The list has been re-read.",
   "config.pending_approvals_refused_administrator": "That account is an administrator and is not approved from here. Enable it in the Jellyfin dashboard.",
   "config.pending_approvals_not_pending": "That account is no longer waiting for approval. The list has been re-read.",
   "config.pending_approvals_failed": "Could not approve the account. Make sure you are signed in as an administrator, then try again."

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -3936,7 +3936,7 @@ const ssoConfigurationPage = {
   loadLinkedAccounts: (page) => {
     const container = page.querySelector("#LinkedAccountsResult");
     // The pending list (#1529) is a second view of the SAME roster read, never a second request: the
-    // roster is elevation-gated and rate-limited, and the two panels answer one question each about one
+    // roster is elevation-gated, and the two panels answer one question each about one
     // document. Both containers are written on both arms, so neither panel is left showing "loading"
     // when the other has an answer.
     const pending = page.querySelector("#PendingApprovalsResult");
@@ -3952,10 +3952,15 @@ const ssoConfigurationPage = {
       ),
     );
 
+    // Resolves to whether the roster was actually read, because a caller that re-reads after an action
+    // must not word its result off the OLD held roster when the re-read failed: the panels then show the
+    // failure sentence, and the action's own line has to agree with them rather than claim a state it
+    // could not confirm.
     return ApiClient.getJSON(ApiClient.getUrl("sso/Links/Roster")).then(
       (roster) => {
         ssoConfigurationPage.renderLinkedAccounts(page, container, roster);
         ssoConfigurationPage.renderPendingApprovals(page, pending);
+        return true;
       },
       // Generic and input-independent, like the neighbouring admin actions: it never reflects a server value.
       () => {
@@ -3965,12 +3970,13 @@ const ssoConfigurationPage = {
         );
         ssoConfigurationPage.renderTransferMessage(container, failed);
         ssoConfigurationPage.renderTransferMessage(pending, failed);
+        return false;
       },
     );
   },
   // THE ROSTER IS KEPT so the filter can re-render without asking the server again (#1529). Held on the
   // module rather than on the page because the page is a DOM node the client may replace, and a filter
-  // keystroke must not turn into a request: the roster is elevation-gated and rate-limited, and typing six
+  // keystroke must not turn into a request: the roster is elevation-gated and read under the config lock, and typing six
   // characters would spend six calls on data that has not changed.
   linkedAccountRoster: null,
   // Everything on one row that a reader might search by. The Jellyfin username, the provider name, the
@@ -4243,11 +4249,16 @@ const ssoConfigurationPage = {
   pendingApprovals: (roster) => {
     const accounts =
       roster && Array.isArray(roster.Accounts) ? roster.Accounts : [];
-    return accounts.flatMap((account) =>
-      (account && Array.isArray(account.Links) ? account.Links : [])
-        .filter((link) => link && link.PendingApprovalSinceUtc)
-        .map((link) => ({ account, link })),
-    );
+    return accounts.flatMap((account) => {
+      // ONE ROW PER ACCOUNT, on its first waiting link, so the count the panel reports is a count of
+      // accounts - which is what its sentences say. An account cannot in practice carry two records,
+      // because a record is written only by the create arm and an account is created once; the dedupe
+      // is what keeps the sentence true even if that ever changed.
+      const waiting = (
+        account && Array.isArray(account.Links) ? account.Links : []
+      ).find((link) => link && link.PendingApprovalSinceUtc);
+      return waiting ? [{ account, link: waiting }] : [];
+    });
   },
   renderPendingApprovals: (page, container) => {
     const waiting = ssoConfigurationPage.pendingApprovals(
@@ -4349,7 +4360,7 @@ const ssoConfigurationPage = {
     button.classList.add("raised", "button-submit", "emby-button");
     button.textContent = tr("config.pending_approvals_approve", "Approve");
     button.addEventListener("click", (e) => {
-      ssoConfigurationPage.approvePendingAccount(page, username, link);
+      ssoConfigurationPage.approvePendingAccount(page, account, link);
       e.preventDefault();
       return false;
     });
@@ -4363,8 +4374,11 @@ const ssoConfigurationPage = {
   // audit line are all the endpoint's, and none of them is re-implemented or bypassed here. The
   // confirmation NAMES what the button does and what it does not: the account is enabled, and nothing
   // else about it changes.
-  approvePendingAccount: (page, username, link) => {
+  approvePendingAccount: (page, account, link) => {
     const result = page.querySelector("#PendingApprovalsActionResult");
+    const username =
+      account && account.Username ? String(account.Username) : "";
+    const userId = account && account.UserId;
     const provider = String((link && link.Provider) || "");
     if (
       !window.confirm(
@@ -4399,23 +4413,52 @@ const ssoConfigurationPage = {
       () =>
         // Re-read rather than editing the rendered table: the roster is the server's answer, and the row
         // must disappear because the server no longer reports it, not because the page assumed so.
-        ssoConfigurationPage
-          .loadLinkedAccounts(page)
-          .then(() =>
+        ssoConfigurationPage.loadLinkedAccounts(page).then((read) => {
+          // A re-read that failed leaves the OLD roster held, and a sentence chosen from it would claim a
+          // state nobody confirmed - for a 204 that cleared a record because the account had gone, it
+          // would say a deleted account can sign in. The panels show the failure; this line agrees.
+          if (!read) {
             ssoConfigurationPage.renderTransferMessage(
               result,
               tr(
-                "config.pending_approvals_approved",
-                "Approved. {user} can sign in now.",
-                { user: username },
+                "config.linked_accounts_failed",
+                "Could not load the linked accounts. Make sure you are signed in as an administrator, then try again.",
               ),
-            ),
-          ),
+            );
+            return;
+          }
+
+          // A 204 is also the endpoint's answer for a record it cleared because the account had gone,
+          // and the reader must not be told a deleted account can sign in. The re-read roster is the
+          // server's word on whether the account still exists, so the sentence is chosen from it.
+          const held = ssoConfigurationPage.linkedAccountRoster;
+          const rows =
+            held && Array.isArray(held.Accounts) ? held.Accounts : [];
+          const gone = rows.some(
+            (row) =>
+              row && row.UserId === userId && row.AccountExists === false,
+          );
+          ssoConfigurationPage.renderTransferMessage(
+            result,
+            gone
+              ? tr(
+                  "config.pending_approvals_account_gone",
+                  "That account no longer exists, so nothing was enabled. The list has been re-read.",
+                )
+              : tr(
+                  "config.pending_approvals_approved",
+                  "Approved. {user} can sign in now.",
+                  { user: username },
+                ),
+          );
+        }),
       (e) => {
         // ApiClient.fetch rejects with the Response on a non-2xx status. Two refusals mean something to
         // the reader and get their own sentence; everything else is the generic one, which never reflects
         // a server value. The administrator refusal is told apart from an elevation refusal - both are
-        // 403 - by the body the endpoint writes for it, which an elevation refusal leaves empty.
+        // 403 - by the sentence the endpoint writes for it, matched on its own words rather than on the
+        // bare word: an elevation refusal leaves the body empty, and a proxy's own 403 page can say
+        // "administrator" about something else entirely.
         const status = e && typeof e.status === "number" ? e.status : 0;
         const body =
           e && typeof e.text === "function"
@@ -4423,7 +4466,7 @@ const ssoConfigurationPage = {
             : Promise.resolve("");
         return body.then((text) => {
           const administrator =
-            status === 403 && /administrator/i.test(String(text || ""));
+            status === 403 && /is an administrator/i.test(String(text || ""));
           const stale = status === 404;
           const message = administrator
             ? tr(

--- a/tools/ui-pending-approvals.js
+++ b/tools/ui-pending-approvals.js
@@ -323,6 +323,40 @@ function render(roster) {
   }
 }
 
+// ---- Arm: an OpenID row sends the OID token, not the roster's display name ----
+{
+  sent.length = 0;
+  answers.confirm = true;
+  answers.fetch = () => Promise.resolve();
+  const { rows } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const request = sent[0];
+  if (!request || request.url !== "/sso/Links/Approve/OID/keycloak") {
+    refuse(
+      "openid-token",
+      `an OpenID row was sent to "${request && request.url}"; the route reads the short token OID, and the roster's "OpenID" would be refused`,
+    );
+  }
+}
+
+// ---- Arm: a 204 followed by a failed re-read is not reported as an approval ----
+{
+  globalThis.ApiClient.getJSON = () => Promise.reject(new Error("offline"));
+  answers.fetch = () => Promise.resolve();
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (/can sign in now/i.test(said) || !/could not load/i.test(said)) {
+    refuse(
+      "unread",
+      `a 204 whose re-read failed must not word its result off the old roster; the page said "${said}"`,
+    );
+  }
+  globalThis.ApiClient.getJSON = () => Promise.resolve(current.roster);
+}
+
 // ---- Arm: declining the confirmation sends nothing ----
 {
   sent.length = 0;
@@ -414,6 +448,81 @@ function render(roster) {
   }
 }
 
+// ---- Arm: one row per account, whatever the links say ----
+{
+  const twice = {
+    Accounts: [
+      {
+        Username: "dora",
+        UserId: "4",
+        AccountExists: true,
+        Links: [
+          link("keycloak", "OpenID", "dora@example.com", true),
+          link("adfs", "SAML", "S-1-5-21/dora", true),
+        ],
+      },
+    ],
+  };
+  const { rows } = render(twice);
+  if (rows.length !== 1) {
+    refuse(
+      "one-per-account",
+      `${rows.length} rows drawn for one account waiting through two providers; the panel counts accounts, and its sentences say so`,
+    );
+  }
+}
+
+// ---- Arm: a 403 with some other body is NOT the administrator refusal ----
+{
+  answers.fetch = () =>
+    Promise.reject({
+      status: 403,
+      text: () =>
+        Promise.resolve(
+          "Forbidden by policy: the administrator of this proxy has blocked the request.",
+        ),
+    });
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (/is an administrator/i.test(said)) {
+    refuse(
+      "other-403",
+      `a 403 whose body merely contains the word was reported as the endpoint's administrator refusal: "${said}"`,
+    );
+  }
+}
+
+// ---- Arm: a 204 for an account that is gone is not reported as an approval ----
+{
+  const reads = [];
+  globalThis.ApiClient.getJSON = () => {
+    reads.push(1);
+    return Promise.resolve({
+      Accounts: [
+        {
+          Username: null,
+          UserId: "1",
+          AccountExists: false,
+          Links: [link("keycloak", "OpenID", "alice@example.com", false)],
+        },
+      ],
+    });
+  };
+  answers.fetch = () => Promise.resolve();
+  const { rows, nodes } = render(ROSTER);
+  rows[0].all("button")[0].click();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const said = nodes.PendingApprovalsActionResult.textContent;
+  if (/can sign in now/i.test(said) || !/no longer exists/i.test(said)) {
+    refuse(
+      "gone",
+      `a 204 for an account the re-read reports as deleted must say so and never that it can sign in; the page said "${said}"`,
+    );
+  }
+}
+
 // ---- Arm: a success re-reads the roster and reports the approval ----
 {
   const reads = [];
@@ -458,7 +567,19 @@ if (faults.length) {
 }
 
 console.log(
-  "pending approvals: ten arms run against the shipped sso-core.js panel",
+  "pending approvals: fifteen arms run against the shipped sso-core.js panel",
+);
+console.log(
+  "  openid-token     an OpenID row sends OID in the route, never the roster's display name",
+);
+console.log(
+  "  unread           a 204 whose re-read failed is not worded off the old roster",
+);
+console.log(
+  "  one-per-account  one row per account, however many links are waiting",
+);
+console.log(
+  "  other-403 / gone a 403 with another body stays generic, and a 204 for a deleted account is not an approval",
 );
 console.log(
   "  rows             a row for exactly the links the server reports as waiting, naming provider and subject",


### PR DESCRIPTION
# What & why

Three sentences the adversarial pass on #1644 caught saying the wrong thing, on the Waiting for Approval panel of #1529. None of them made the page send a wrong request; each told a reader something untrue.

- A 204 is also the endpoint's answer for a record it cleared because the account had gone, and the panel said a deleted account could sign in now. The sentence is now chosen from the re-read roster, which is the server's word on whether the account still exists: an account the re-read reports as gone gets its own line, and only an account still there is reported as approved.
- The bound and the count were over links while the sentence said accounts. One row per account now, on its first waiting link.
- The administrator refusal was told apart from a bare 403 by the word "administrator" alone, which a proxy's own 403 page can carry about something else. It is matched on the endpoint's own sentence now.
- A second, focused pass over the same tree found one more: the load swallowed its own failure, so after a 204 the success arm ran against the roster held before the click, and for a record cleared because the account was gone plus a re-read that failed, the page said a deleted account could sign in while both panels showed the failure. The load now says whether it read, and the action's line agrees with the panels when it did not. The same pass found nothing pinned an OpenID row to the OID token in the route; an arm does now.

This PR replaces #1645, which carried the first three fixes without the fourth; it was not merged and is closed by being superseded here. The one German sentence is unchanged.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing server-side changes; the page
      still sends the same request and the endpoint still decides.
- [x] No secrets logged; secrets are redacted on config export. Nothing new is
      logged.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Not one of the four; these
      are the fixes that review asked for, recorded on #1644.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. The three findings are the LOW notes on #1644,
      each **FIX** here; the fourth stays **DEFER** on #1637.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The properties are decisions of the page, and the running proof in
      `tools/ui-pending-approvals.js` gains an arm for each: one account waiting
      through two providers draws one row; a 403 whose body merely contains the
      word stays the generic sentence; a 204 for an account the re-read reports
      as deleted says so and never that it can sign in; an OpenID row sends OID
      in the route; and a 204 whose re-read failed is not reported as an
      approval. Fifteen arms.
- [x] Docs impact considered: no README or wiki text describes these sentences;
      #1643 carries the wiki paragraph for the panel.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green. The catalogue rules pass on both catalogs; the
      change is otherwise browser-side.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Every UI gate passes, the string ratchet stays at zero, and the field register still counts 124.

## German

One new sentence, quoted for the reading:

```text
config.pending_approvals_account_gone:  Dieses Konto existiert nicht mehr, es wurde also nichts aktiviert. Die Liste wurde neu gelesen.
```

## Notes

- The vouch line below was added on the reading of the sentence above.

Catalogue-Vouch: de read by iderex
