### PR TITLE
Let a rebound key forget its previous holder's deadline and last login

### DIFF
--- a/SSO-Auth.Tests/Linking/ReboundKeyTests.cs
+++ b/SSO-Auth.Tests/Linking/ReboundKeyTests.cs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A canonical key that changes hands forgets its previous holder (#1638). The two server-managed maps
+/// beside the links - the provisioned access deadlines (#1146) and the last-SSO-login stamps (#1120) - were
+/// pruned on every route that removes a link and by none of the routes that write one over a key already
+/// holding an entry. A key can change hands without ever being removed: a link whose target account was
+/// deleted counts as absent, so the next login for that subject writes the key again at a different
+/// account, and what the key held before followed it there.
+/// <para>
+/// The deadline is the one with teeth. The sweep reads a deadline's account off the CURRENT link map, so an
+/// inherited past deadline disables the account that just arrived, for an expiry nobody granted it. The
+/// stamp is one account's data on another's roster row. Each write route is driven below rather than read,
+/// because a removal-only rule looks correct right up to the write that inherits, which is how the first
+/// version of the pending-approval record shipped and was caught (#1529).
+/// </para>
+/// </summary>
+public class ReboundKeyTests
+{
+    private static readonly Guid Deleted = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly Guid Other = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid Created = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Past = new(2026, 9, 10, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AnAdoptionOverADanglingLink_ForgetsTheDeadlineAndTheStamp()
+    {
+        // THE CHAIN #1638 NAMES. A guest account was provisioned with four hours, expired, was swept
+        // disabled, and then deleted by an administrator. Its link dangles and its past deadline stands.
+        // The same subject logs in again and is adopted into an existing account; that account must not
+        // inherit an expiry that already passed.
+        var (service, config, users) = Build();
+        Dangling(config, users);
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public async Task TheSweepNoLongerSeesTheInheritedDeadline()
+    {
+        // The consequence, driven end to end: after the adoption above, the sweep's own read names nothing,
+        // where before it named the new account under the old deadline.
+        var (service, config, users) = Build();
+        Dangling(config, users);
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Empty(service.ExpiredLinks(Now));
+        Assert.NotNull(config);
+    }
+
+    [Fact]
+    public async Task AProvisioningWithADuration_OverADanglingLink_ReplacesTheDeadline()
+    {
+        // The positive direction of the set-or-clear: a fresh provisioning that DOES carry a duration writes
+        // its own deadline over the stale one, anchored now, rather than keeping the previous holder's.
+        var (service, config, users) = Build();
+        Dangling(config, users);
+        Provisionable(users);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisionedAccessDuration: TimeSpan.FromHours(4));
+
+        Assert.Equal(Created, config.CanonicalLinks["sub-1"]);
+        Assert.Equal(Now + TimeSpan.FromHours(4), config.CanonicalLinkDeadlines["sub-1"]);
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public async Task AProvisioningWithoutADuration_OverADanglingLink_LeavesNoDeadline()
+    {
+        // The negative that carries the fix: a fresh provisioning with no duration removes the stale
+        // deadline rather than returning early past it, which is what the stamp used to do.
+        var (service, config, users) = Build();
+        Dangling(config, users);
+        Provisionable(users);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Created, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public void AManualLink_ForgetsBothForTheKeyItRepoints()
+    {
+        // The self-service and administrator link write repoints a key on purpose, so it is the second route
+        // that can land on a key carrying both entries; neither is this account's.
+        var (service, config, users) = Build();
+        config.CanonicalLinks["sub-1"] = Deleted;
+        config.CanonicalLinkDeadlines["sub-1"] = Past;
+        config.CanonicalLinkLastLogins["sub-1"] = Past;
+        users.GetUserById(Arg.Any<Guid>()).Returns(TestUsers.Named("alice", Other));
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Other));
+
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void AManualLinkRepeatingTheSameMapping_KeepsEverythingTheAccountHad()
+    {
+        // THE ROW THE SECURITY REVIEW ASKED FOR. A time-limited account can reach the self-service link
+        // write for its OWN subject and its OWN account; if that write took the deadline with it, a guest
+        // could shed their time limit by re-linking themselves, and the sweep would never name them again.
+        // The key does not change hands here, so nothing the account had goes: not the deadline, not the
+        // last login, not a pending-approval record.
+        var (service, config, users) = Build();
+        config.CanonicalLinks["sub-1"] = Other;
+        config.CanonicalLinkDeadlines["sub-1"] = Now + TimeSpan.FromHours(2);
+        config.CanonicalLinkLastLogins["sub-1"] = Past;
+        config.CanonicalLinkPendingApprovals["sub-1"] = new PendingApproval { UserId = Other, SinceUtc = Past };
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Other));
+        Assert.Equal(CanonicalLinkWriteResult.Created, service.TryPreprovisionLink(ProviderMode.Oid, "kc", "sub-1", Other));
+
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.Equal(Now + TimeSpan.FromHours(2), config.CanonicalLinkDeadlines["sub-1"]);
+        Assert.Equal(Past, config.CanonicalLinkLastLogins["sub-1"]);
+        Assert.Equal(Other, config.CanonicalLinkPendingApprovals["sub-1"].UserId);
+        Assert.Single(service.ExpiredLinks(Now + TimeSpan.FromHours(3)));
+    }
+
+    [Fact]
+    public async Task ALegacyMigration_ForgetsBothOnBothKeys()
+    {
+        // The #155 re-key moves the link off the legacy username key onto the subject key, overwriting the
+        // subject key only when it dangles. Both keys lose both entries: the dangling one's were a deleted
+        // account's, and the legacy key has no link left to explain an entry.
+        var (service, config, users) = Build();
+        Dangling(config, users);
+        config.CanonicalLinks["alice"] = Other;
+        config.CanonicalLinkDeadlines["alice"] = Past;
+        config.CanonicalLinkLastLogins["alice"] = Past;
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Other, config.CanonicalLinks["sub-1"]);
+        Assert.False(config.CanonicalLinks.ContainsKey("alice"));
+        Assert.Empty(config.CanonicalLinkDeadlines);
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public async Task ASecondLoginOfALinkedAccount_LeavesBothExactlyWhereTheyWere()
+    {
+        // The bound the fix must not cross: an established account's repeat login resolves its live link and
+        // never enters the write, so neither its deadline nor its stamp moves. The sliding deadline is the
+        // one defect the other direction of this change could have.
+        var (service, config, users) = Build();
+        config.CanonicalLinks["sub-1"] = Other;
+        config.CanonicalLinkDeadlines["sub-1"] = Now + TimeSpan.FromDays(3);
+        config.CanonicalLinkLastLogins["sub-1"] = Past;
+        users.GetUserById(Other).Returns(TestUsers.Named("alice", Other));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, provisionedAccessDuration: TimeSpan.FromHours(1));
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(Now + TimeSpan.FromDays(3), config.CanonicalLinkDeadlines["sub-1"]);
+        Assert.Equal(Past, config.CanonicalLinkLastLogins["sub-1"]);
+    }
+
+    // A link whose account was deleted, with the entries the deleted account left behind under its key.
+    private static void Dangling(OidConfig config, IUserManager users)
+    {
+        config.CanonicalLinks["sub-1"] = Deleted;
+        config.CanonicalLinkDeadlines["sub-1"] = Past;
+        config.CanonicalLinkLastLogins["sub-1"] = Past;
+        users.GetUserById(Deleted).Returns((User?)null);
+    }
+
+    // An account the provisioning arm can create: no existing user answers the name, and the created one
+    // comes back by id.
+    private static void Provisionable(IUserManager users)
+    {
+        var created = TestUsers.Named("alice", Created);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        users.GetUserById(Created).Returns(created);
+        users.CreateUserAsync(Arg.Any<string>()).Returns(Task.FromResult(created));
+    }
+
+    private static (CanonicalLinkService Service, OidConfig Config, IUserManager Users) Build()
+    {
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true, AllowExistingAccountLink = true };
+        configuration.OidConfigs["kc"] = config;
+        var users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now), config, users);
+    }
+}

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1565,7 +1565,15 @@ internal sealed class CanonicalLinkService
             // controls, so the pre-provision entry point refuses it and leaves the existing link intact.
             // Repeating the SAME mapping is not a rebind and stays a success, so a tool that retries a
             // request whose response it never saw does not have to distinguish the two.
-            if (refuseRebind && links.TryGetValue(providerUserId, out var held) && held != jellyfinUserId)
+            // WHETHER THE KEY CHANGES HANDS is read once, before the write, and decides two things below: the
+            // rebind refusal, and what the write leaves of the entries the key carried. A repeat of the SAME
+            // mapping - the pre-provision retry after a lost response, or a user re-linking their own
+            // subject to their own account from the self-service page - changes nothing about who holds
+            // the key, and must not be told apart from a repoint by what it takes away.
+            var holds = links.TryGetValue(providerUserId, out var held);
+            var sameHolder = holds && held == jellyfinUserId;
+
+            if (refuseRebind && holds && !sameHolder)
             {
                 return CanonicalLinkWriteResult.ConflictingUser;
             }
@@ -1573,12 +1581,21 @@ internal sealed class CanonicalLinkService
             links[providerUserId] = jellyfinUserId;
             StampIssuerInPlace(configuration, mode, provider, providerUserId, issuer);
 
-            // A manual link is not this plugin provisioning an account inert, so any pending-approval
-            // record under this key is about the account the key held before and goes with it (#1529).
-            // TryCreateLink repoints on purpose, so this is the one of the two entry points that can land
-            // on a key that carries one; the clear is written for both, because a rule that only holds on
-            // the arm somebody remembered is not a rule.
-            RemovePendingApproval(configuration, mode, provider, providerUserId);
+            // THE ENTRIES THE KEY CARRIED GO ONLY WHEN THE KEY CHANGES HANDS (#1529, #1638). A repoint puts a
+            // different account behind the key, and whatever the key held was the previous account's: a
+            // pending-approval record about it, a deadline that would have the sweep disable the newly
+            // linked account at the previous holder's expiry, a last-login stamp that would put the previous
+            // holder's sign-in on the new account's roster row. A same-mapping write keeps all three, because
+            // they are this account's - and the deadline in particular is the one thing a time-limited user
+            // must not be able to shed by re-linking themselves. TryCreateLink repoints on purpose, so it is
+            // the entry point that can land on another account's entries; the rule is written for both.
+            if (!sameHolder)
+            {
+                RemovePendingApproval(configuration, mode, provider, providerUserId);
+                RemoveDeadline(configuration, mode, provider, providerUserId);
+                RemoveLastSsoLogin(configuration, mode, provider, providerUserId);
+            }
+
             return CanonicalLinkWriteResult.Created;
         });
     }
@@ -2120,7 +2137,14 @@ internal sealed class CanonicalLinkService
                 // link, never re-enters this branch, and leaves the recorded deadline exactly where it is. A
                 // sliding deadline is the one defect this direction of the feature can have, and this is the
                 // single place it is prevented rather than a rule restated at each caller.
-                StampProvisionedDeadlineInPlace(configuration, mode, provider, canonicalKey, provisionedAccessDuration);
+                RecordProvisionedDeadlineInPlace(configuration, mode, provider, canonicalKey, provisionedAccessDuration);
+
+                // And the last-SSO-login stamp goes (#1638), for the same reason the deadline is a set-or-clear:
+                // a key written here held no live link, so a stamp still under it is the previous holder's,
+                // and the roster would show that account's last sign-in on the row of the account that just
+                // arrived - one account's data on another's row. The link written here has had no login yet;
+                // the stamp is written after the mint, by the login that earns it.
+                RemoveLastSsoLogin(configuration, mode, provider, canonicalKey);
 
                 // A link written by a login that provisioned its account INERT carries the pending-approval
                 // record (#1529), written in the same transaction as the link for the same reason the
@@ -2185,6 +2209,15 @@ internal sealed class CanonicalLinkService
                 // account inert, which is the only thing that may leave a record behind.
                 RemovePendingApproval(configuration, mode, provider, canonicalKey);
                 RemovePendingApproval(configuration, mode, provider, legacyKey);
+
+                // The deadline and the last-login stamp as well, on both keys (#1638). The subject key is
+                // overwritten here only when it dangles, so anything under it was a deleted account's; the
+                // legacy key has no link left to explain an entry, and a deadline stranded there would be
+                // inert only until something wrote that key again.
+                RemoveDeadline(configuration, mode, provider, canonicalKey);
+                RemoveDeadline(configuration, mode, provider, legacyKey);
+                RemoveLastSsoLogin(configuration, mode, provider, canonicalKey);
+                RemoveLastSsoLogin(configuration, mode, provider, legacyKey);
                 return legacyUserId;
             }
 
@@ -2424,19 +2457,30 @@ internal sealed class CanonicalLinkService
     // and a value hand-edited into the config XML reaches this line without passing the save path at all. A
     // duration outside the bounds stamps NOTHING rather than throwing, so the login still succeeds and the
     // account simply carries no deadline - which is exactly what the same provider does today.
-    private void StampProvisionedDeadlineInPlace(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, TimeSpan? provisionedAccessDuration)
+    private void RecordProvisionedDeadlineInPlace(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, TimeSpan? provisionedAccessDuration)
     {
-        if (provisionedAccessDuration is not { } duration
-            || duration <= TimeSpan.Zero
-            || duration > TimeSpan.FromHours(GuestAccessDurationRoleMap.MaxDurationHours))
+        if (!TryGetProvider(configuration, mode, provider, out var config))
         {
             return;
         }
 
-        if (TryGetProvider(configuration, mode, provider, out var config))
+        // A SET-OR-CLEAR, not a stamp (#1638). This runs inside the branch that has just written the link,
+        // and a link is written over a key only when the key held no LIVE link - which includes a link whose
+        // account was deleted. That account's deadline is still in the map, and left there a login that
+        // carried no duration would inherit it: the sweep reads a deadline's account off the CURRENT link
+        // map, so the next tick would disable an account that is minutes old for an expiry nobody granted
+        // it. A write with no usable duration therefore removes what it found, and a write with one
+        // replaces it; a second login of a linked account never reaches this branch and leaves the recorded
+        // deadline exactly where it is.
+        if (provisionedAccessDuration is not { } duration
+            || duration <= TimeSpan.Zero
+            || duration > TimeSpan.FromHours(GuestAccessDurationRoleMap.MaxDurationHours))
         {
-            config.CanonicalLinkDeadlines[canonicalKey] = _clock().ToUniversalTime() + duration;
+            config.CanonicalLinkDeadlines.Remove(canonicalKey);
+            return;
         }
+
+        config.CanonicalLinkDeadlines[canonicalKey] = _clock().ToUniversalTime() + duration;
     }
 
     // Drops an OpenID link's issuer entry within the caller's already-held config transaction (#186), called


### PR DESCRIPTION
# What & why

A canonical key that changes hands now forgets its previous holder's deadline and last login (#1638). The two server-managed maps beside the links, the provisioned access deadlines (#1146) and the last-SSO-login stamps (#1120), were pruned by every route that removes a link and by none of the routes that write one over a key already holding an entry. A link whose target account was deleted counts as absent, so the next login for that subject wrote the key again at a different account, and what the key held before followed it there.

The deadline is the one with teeth: the sweep reads a deadline's account off the CURRENT link map, so an inherited past deadline disabled an account that was minutes old, for an expiry nobody granted it. The stamp is one account's data on another's roster row.

The deadline stamp is now a set-or-clear inside the branch that writes a link, the same branch removes the stamp, the legacy re-key drops both maps for both keys, and the manual link drops them only when the key changes hands - the last of those being the condition the security review put there, below.

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here grants; every new line
      removes an entry that belonged to an account the key no longer names, and
      the one route a user can reach for their own key removes nothing when the
      key stays theirs.
- [x] No secrets logged; secrets are redacted on config export. No new log call.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      1 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

### Review record

**Pass 1, the security review of the first cut**, and **pass 2, an adversarial verification** run independently on the same tree, found the same thing: the manual link write dropped the deadline unconditionally, and that write is the one a time-limited user can reach for their OWN key. The self-service page re-links the caller's own subject to the caller's own account after a live round trip at the identity provider, so a guest could have shed their own time limit by re-linking themselves; the sweep would never have named them again, because the role-mapped duration is written only on the create arm. The pre-provision retry, documented as safe to repeat, carried the same shape for an administrator. **CONFIRMED** (a reproduction exists and is now a test: `AManualLinkRepeatingTheSameMapping_KeepsEverythingTheAccountHad` fails against the first cut). **FIX**: the manual link reads whether the key changes hands, once, before the write, and only a repoint takes the entries away; a same-mapping write keeps the deadline, the stamp and any pending-approval record.

Both passes held every other lens SAFE: the login write branch is reachable only when the key holds no live link, so an established account's repeat login never enters it (pinned by a test that passes a duration and asserts the recorded deadline does not move); the sweep gains no new target and loses no true one; the legacy re-key removes only entries no reachable state can hold; the link import refuses a key held by another account, dangling or not, so it inherits nothing; the two arms of the configuration save carry or drop all three maps together.

**Pass 3, the re-verification of the fixed lens** on the amended tree: **FIXED**, at 9 of 10. A variant key is an absent key and clears only its own empty entries while the original link keeps its deadline; the pre-provision refusal keeps its meaning on a different holder, a same holder and an absent key; a dangling holder repointed to another account is cleared, and a dangling holder that equals the target removes nothing and dereferences nothing; the login write branch and the re-key cannot be reached with the key still held by the same live account; and the same-mapping test drives both entry points through the same-holder arm and fails the moment the condition is removed or computed after the write.

One residual outside the lens, pre-existing and not made worse here: a time-limited account can still shed its deadline by unlinking itself and signing in again, because the self-service unlink prunes the deadline with the link and a re-login is adopted by username with no duration wherever the provider allows adoption. Which of three shapes closes it is a decision, so it is **DEFER**, #1647. A second, LOW: a user holding two authenticated accounts can repoint a subject from one to the other and back and lose the deadline on the way, which is the manual link's deliberate repoint and needs two accounts.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The set-or-clear is the deadline helper's own body; the
      removals are the existing helpers, called where a link is written.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No new structure; the state exemptions for both maps already describe the
      bound, which now holds over the account behind the key and not only over
      the key.
- [x] Docs impact considered: no README or wiki text describes either map's
      lifetime beyond "removed with the link", which stays true.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3926 on net9.0 and 3927 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Eight tests drive the routes rather than read them, and each was run against a build broken in its own way before being trusted - the clear removed, the write branch's stamp removal removed, the manual link's removals removed, the re-key's removals removed, and the manual link's changes-hands condition removed - with each break failing the rows that name it and no other.

## Notes

- Found by the adversarial pass on the pending-approval record (#1639) as the sibling shape that record no longer has. The record got the stronger binding, its value naming its account; these two maps get the write-time rule, because an inherited deadline disables and an inherited stamp misattributes, and neither needs a reader to compare an account to be made safe.
