### PR TITLE
Refuse the holder's unlink of a link that carries an access deadline

### DIFF
--- a/SSO-Auth.Tests/Config/AccountExpiryDeadlineStoreTests.cs
+++ b/SSO-Auth.Tests/Config/AccountExpiryDeadlineStoreTests.cs
@@ -138,7 +138,7 @@ public class AccountExpiryDeadlineStoreTests
         config.CanonicalLinkDeadlines["sub-1"] = Deadline;
         var service = LinkService(configuration);
 
-        service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", User);
+        service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", User, callerIsAdministrator: true);
 
         Assert.Empty(config.CanonicalLinkDeadlines);
     }
@@ -212,7 +212,7 @@ public class AccountExpiryDeadlineStoreTests
         service.RecordAccountDeadline(ProviderMode.Saml, "idp", "nameid-1", Deadline);
         Assert.Equal(Deadline, config.CanonicalLinkDeadlines["nameid-1"]);
 
-        service.TryRemoveLink(ProviderMode.Saml, "idp", "nameid-1", User);
+        service.TryRemoveLink(ProviderMode.Saml, "idp", "nameid-1", User, callerIsAdministrator: true);
         Assert.Empty(config.CanonicalLinkDeadlines);
     }
 

--- a/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
@@ -65,6 +65,66 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task DeleteCanonicalLink_TheHolderOfATimeLimitedLink_IsRefused_AndKeepsTheLink()
+    {
+        // #1647. The deadline lives on the link and the unlink prunes it with the link; a re-login then
+        // adopts the account by name with no duration wherever adoption is allowed. So the holder's own
+        // unlink was an exit from the very limit that admitted them, and it is refused with its reason,
+        // before anything is touched: no link removed, no deadline dropped, no token revoked.
+        var harness = ForCaller(isAdmin: false, callerId: Target, configure: TimeLimited);
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        var refused = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(403, refused.StatusCode);
+        Assert.Contains("deadline", Assert.IsType<string>(refused.Value), StringComparison.OrdinalIgnoreCase);
+        var config = harness.Configuration.OidConfigs["keycloak"];
+        Assert.Equal(Target, config.CanonicalLinks["sub-1"]);
+        Assert.True(config.CanonicalLinkDeadlines.ContainsKey("sub-1"));
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AnAdministrator_RemovesATimeLimitedLink()
+    {
+        // The administrator keeps the route the holder lost: the refusal is about who asks, not about the
+        // link, and an administrator ending a guest's access early is the ordinary use of the unlink.
+        var harness = ForCaller(isAdmin: true, callerId: Other, configure: TimeLimited);
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+        var config = harness.Configuration.OidConfigs["keycloak"];
+        Assert.False(config.CanonicalLinks.ContainsKey("sub-1"));
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_TheHolderOfAnOrdinaryLink_StillRemovesIt()
+    {
+        // The bound of #1647: a link with no deadline is the holder's to remove, exactly as before.
+        var harness = ForCaller(isAdmin: false, callerId: Target, configure: c =>
+        {
+            TimeLimited(c);
+            c.OidConfigs["keycloak"].CanonicalLinkDeadlines.Clear();
+        });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+        Assert.False(harness.Configuration.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    // One provider holding Target's link with a provisioned access deadline still ahead of it.
+    private static void TimeLimited(PluginConfiguration configuration)
+    {
+        var config = new OidConfig { Enabled = true };
+        config.CanonicalLinks["sub-1"] = Target;
+        config.CanonicalLinkDeadlines["sub-1"] = DateTime.UtcNow.AddHours(4);
+        configuration.OidConfigs["keycloak"] = config;
+    }
+
+    [Fact]
     public async Task AddCanonicalLink_AdminWithoutPreferenceAccess_Returns403()
     {
         // Pins the EnableUserPreferenceAccess term of AssertCanUpdateUser (#397 folded it from an

--- a/SSO-Auth.Tests/Linking/TimeLimitedUnlinkTests.cs
+++ b/SSO-Auth.Tests/Linking/TimeLimitedUnlinkTests.cs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A time-limited link is not its holder's to remove (#1647). The provisioned access deadline (#1146) lives
+/// on the link and the unlink prunes it with the link; a re-login then adopts the account by name with no
+/// duration wherever the provider allows adoption. Left open, the self-service unlink was a guest's exit
+/// from the very limit that admitted them. So the removal asks who is asking, inside the transaction that
+/// removes, and a link carrying a deadline goes only on an administrator's word.
+/// </summary>
+public class TimeLimitedUnlinkTests
+{
+    private static readonly Guid Holder = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void TheHolder_IsRefused_AndNothingIsTouched()
+    {
+        var (service, config) = Build(deadline: true);
+
+        var removal = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Holder);
+
+        Assert.Equal(CanonicalLinkRemoveResult.TimeLimited, removal.Result);
+        // A no-op outcome, so the retains flag is the undefined-and-false the record's contract names for
+        // every outcome but Removed; the controller reads it only on Removed, and this pins that shape.
+        Assert.False(removal.UserRetainsAnyLink);
+        Assert.Equal(Holder, config.CanonicalLinks["sub-1"]);
+        Assert.True(config.CanonicalLinkDeadlines.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void AnAdministrator_RemovesIt_AndTheDeadlineWithIt()
+    {
+        var (service, config) = Build(deadline: true);
+
+        var removal = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Holder, callerIsAdministrator: true);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, removal.Result);
+        Assert.Empty(config.CanonicalLinks);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public void TheHolderOfAnOrdinaryLink_StillRemovesIt()
+    {
+        // The bound: a link with no deadline is the holder's to remove, exactly as before this rule.
+        var (service, config) = Build(deadline: false);
+
+        var removal = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Holder);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, removal.Result);
+        Assert.Empty(config.CanonicalLinks);
+    }
+
+    [Fact]
+    public void TheRefusalComesAfterTheOwnershipCheck()
+    {
+        // A caller who does not own the link is told so, not told about a deadline they cannot see: the
+        // deadline is a fact about somebody else's link, and the ownership refusal already fails closed.
+        var (service, config) = Build(deadline: true);
+
+        var removal = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Guid.NewGuid());
+
+        Assert.Equal(CanonicalLinkRemoveResult.Mismatch, removal.Result);
+        Assert.Equal(Holder, config.CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public void ADisabledProvider_StillRefusesTheHolder()
+    {
+        // The removal keeps working on a disabled provider on purpose (#380: disable-then-clean-up), and so
+        // must the refusal: the deadline is read through the provider lookup that ignores Enabled, so a
+        // provider switched off does not turn into the holder's exit. This is the one arm a later edit to
+        // the lookup could open without a test noticing.
+        var (service, config) = Build(deadline: true, enabled: false);
+
+        var removal = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Holder);
+
+        Assert.Equal(CanonicalLinkRemoveResult.TimeLimited, removal.Result);
+        Assert.Equal(Holder, config.CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public void TheSamlArm_RefusesTheHolderIdentically()
+    {
+        // Both protocols funnel through the one removal; the deadline map exists on SAML too (#1146), so
+        // the refusal has to as well.
+        var configuration = new PluginConfiguration();
+        var config = new SamlConfig { Enabled = true };
+        config.CanonicalLinks["nameid-1"] = Holder;
+        config.CanonicalLinkDeadlines["nameid-1"] = Now + TimeSpan.FromHours(4);
+        configuration.SamlConfigs["idp"] = config;
+        var users = Substitute.For<IUserManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+
+        Assert.Equal(CanonicalLinkRemoveResult.TimeLimited, service.TryRemoveLink(ProviderMode.Saml, "idp", "nameid-1", Holder).Result);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, service.TryRemoveLink(ProviderMode.Saml, "idp", "nameid-1", Holder, callerIsAdministrator: true).Result);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    private static (CanonicalLinkService Service, OidConfig Config) Build(bool deadline, bool enabled = true)
+    {
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = enabled };
+        config.CanonicalLinks["sub-1"] = Holder;
+        if (deadline)
+        {
+            config.CanonicalLinkDeadlines["sub-1"] = Now + TimeSpan.FromHours(4);
+        }
+
+        configuration.OidConfigs["kc"] = config;
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Holder).Returns(TestUsers.Named("alice", Holder));
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        return (new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now), config);
+    }
+}

--- a/SSO-Auth/Api/Http/RequestHelpers.cs
+++ b/SSO-Auth/Api/Http/RequestHelpers.cs
@@ -54,4 +54,24 @@ internal static class RequestHelpers
         return (userId.Equals(auth.UserId) || authenticatedUser.HasPermission(PermissionKind.IsAdministrator))
             && authenticatedUser.EnableUserPreferenceAccess;
     }
+
+    /// <summary>
+    /// Whether the caller behind the request is an administrator, read from the resolved account and never
+    /// from anything the request asserts about itself (#1647). Fail-closed on an unresolved caller, for the
+    /// same reason <see cref="AssertCanUpdateUser"/> is: the answer gates a removal a non-administrator may
+    /// not make, so an ambiguous caller is not one.
+    /// </summary>
+    /// <param name="authContext">Instance of the <see cref="IAuthorizationContext"/> interface.</param>
+    /// <param name="requestContext">The <see cref="HttpRequest"/>.</param>
+    /// <returns>A <see cref="bool"/> whether the caller holds <see cref="PermissionKind.IsAdministrator"/>.</returns>
+    internal static async Task<bool> IsAdministrator(IAuthorizationContext authContext, HttpRequest requestContext)
+    {
+        if (authContext is null)
+        {
+            return false;
+        }
+
+        var auth = await authContext.GetAuthorizationInfo(requestContext).ConfigureAwait(false);
+        return auth?.User is { } authenticatedUser && authenticatedUser.HasPermission(PermissionKind.IsAdministrator);
+    }
 }

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -2408,7 +2408,13 @@ public class SSOController : ControllerBase
             return unknownMode;
         }
 
-        var removal = _canonicalLinks.TryRemoveLink(parsed, provider, canonicalName, jellyfinUserId);
+        // Whether the caller is an administrator decides one thing inside the removal (#1647): a link that
+        // carries a provisioned access deadline is removed only on an administrator's word, because the
+        // holder's own unlink followed by a re-login is otherwise an exit from the limit that admitted
+        // them. Read from the resolved account, never from the request, and passed in rather than decided
+        // here so the check sits in the same transaction as the removal it gates.
+        var callerIsAdministrator = await RequestHelpers.IsAdministrator(_authContext, HttpContext.Request).ConfigureAwait(false);
+        var removal = _canonicalLinks.TryRemoveLink(parsed, provider, canonicalName, jellyfinUserId, callerIsAdministrator);
 
         // Terminate the user's already-issued tokens ONLY when this unlink removed their LAST canonical SSO
         // link (#468) - the terminal "can no longer SSO in at all" state that matches the hard-lockdown
@@ -2439,6 +2445,7 @@ public class SSOController : ControllerBase
             CanonicalLinkRemoveResult.NotFound => NotFound("No SSO link is registered for that canonical name."),
             CanonicalLinkRemoveResult.Mismatch => StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name."),
             CanonicalLinkRemoveResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
+            CanonicalLinkRemoveResult.TimeLimited => StatusCode(StatusCodes.Status403Forbidden, "This SSO link carries an access deadline and can be removed only by an administrator."),
             _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {removal.Result}"),
         };
     }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -60,6 +60,9 @@ internal enum CanonicalLinkRemoveResult
 
     /// <summary>No provider of that mode/name exists; nothing was removed.</summary>
     UnknownProvider,
+
+    /// <summary>The link carries a provisioned access deadline and the caller is not an administrator; nothing was removed (#1647).</summary>
+    TimeLimited,
 }
 
 /// <summary>
@@ -1610,8 +1613,9 @@ internal sealed class CanonicalLinkService
     /// <param name="provider">The provider the link belongs to.</param>
     /// <param name="canonicalName">The provider-side identity key whose link is removed.</param>
     /// <param name="jellyfinUserId">The Jellyfin user the link must belong to.</param>
+    /// <param name="callerIsAdministrator">Whether the caller is an administrator, read from the resolved account (#1647). A link that carries a provisioned access deadline is removed only when this is true; the default refuses, so a caller that does not say is treated as the holder.</param>
     /// <returns>The remove outcome, plus whether the user retains any other link (#468).</returns>
-    internal CanonicalLinkRemoval TryRemoveLink(ProviderMode mode, string provider, string canonicalName, Guid jellyfinUserId)
+    internal CanonicalLinkRemoval TryRemoveLink(ProviderMode mode, string provider, string canonicalName, Guid jellyfinUserId, bool callerIsAdministrator = false)
     {
         // Kept as ONE Mutate (find, ownership check, remove, and the last-link check cannot interleave). A
         // no-result outcome still persists the unchanged config. For NotFound / Mismatch that already
@@ -1640,6 +1644,22 @@ internal sealed class CanonicalLinkService
             if (linkedId != jellyfinUserId)
             {
                 return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.Mismatch, UserRetainsAnyLink: false);
+            }
+
+            // A TIME-LIMITED LINK IS NOT ITS HOLDER'S TO REMOVE (#1647). The provisioned access deadline
+            // (#1146) lives on the link, and the unlink prunes it with the link; a re-login then adopts the
+            // account by name with no duration wherever the provider allows adoption. Left open, the self-
+            // service unlink was a guest's exit from the very limit that admitted them: unlink, sign in
+            // again, unlimited. So a link that carries a deadline is removed only on an administrator's
+            // word; the holder is refused before anything is touched, and the refusal is its own answer so
+            // the caller is told why rather than shown a link that will not go. Decided in the same
+            // transaction as the removal, because a deadline written between a read and this write is the
+            // one this rule exists for.
+            if (!callerIsAdministrator
+                && TryGetProvider(configuration, mode, provider, out var config)
+                && config.CanonicalLinkDeadlines.ContainsKey(canonicalName))
+            {
+                return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.TimeLimited, UserRetainsAnyLink: false);
             }
 
             links.Remove(canonicalName);


### PR DESCRIPTION
# What & why

A time-limited account could shed its provisioned access deadline (#1146) by unlinking itself and signing in again: the self-service unlink prunes the deadline with the link, and a re-login adopts the account by username with no duration wherever the provider allows adoption. Unlink, sign in again, unlimited. Found by the re-verification of #1648 as the route that change does not cover (#1647), and decided as the smallest of three shapes: a link that carries a deadline is not its holder's to remove.

The rule sits inside the removal, in the same transaction, after the ownership check and before anything is touched: a link carrying a deadline is removed only on an administrator's word. Who is asking is read from the resolved account, never from the request, and handed in as one flag whose default refuses. The refusal is its own answer, a 403 that names the deadline and where the removal is made instead. An administrator keeps the route the holder lost; a link with no deadline is the holder's to remove exactly as before.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The flag defaults to the refusing value,
      an unresolved caller is not an administrator, and the check runs on a
      disabled provider too.
- [x] No secrets logged; secrets are redacted on config export. No new log call.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

### Review record

**Pass 1, the security review of the commit**, and **pass 2, an adversarial verification** run independently on the same tree, raised nothing at the bar. Both enumerated every route that removes a link or a deadline or makes a link absent, with who reaches each: the self-service unlink is now gated; the bulk revoke, the provider purge, the link import and both arms of the configuration save are elevation-only; the login write branch is entered only when the key holds no live link, and a same-mapping self re-link keeps the deadline since #1648; the legacy re-key touches only a dangling subject key; a second provider's link carries no duration, and the sweep disables by account, so a second link extends nothing. The flag is derived from the account the host resolved from the bearer token and from nothing the request carries; a null context, a null authorization or a null user all refuse. The ownership refusal still precedes the deadline read, so a non-owner learns nothing about another account's deadline, and the holder learns one bit about their own admission condition. An administrator is never blocked: the only callers without a resolved user were already refused by the ownership guard before this change.

Two LOW notes from pass 2, both **FIX** here: the removal record's contract says the retains-flag is false on every outcome but Removed, and the new arm returned true - it returns false now, and the test pins that shape; and two arms had no row, the disabled provider (the one arm a later edit to the lookup could open silently) and the SAML protocol, which have rows now.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. One check inside the existing transaction, one helper that
      reads the caller's permission the way the ownership guard already does.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No new structure; the endpoint, its policy and its limiter class are
      unchanged, and the rosters that pin them still hold.
- [x] Docs impact considered: the self-service page shows its generic banner on
      any rejected removal and never a server sentence, by that page's own rule,
      so nothing on the page changes; the wiki's linking page needs one sentence
      saying a time-limited link is removed by an administrator, folded into
      #1643's documentation pass for this milestone rather than filed twice.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3935 on net9.0 and 3936 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Nine tests, each proven against its own broken build before being trusted: with the rule removed the holder's rows fail, and with the administrator's word ignored the administrator's rows fail, and no other.

## Notes

- The two shapes not chosen stay on #1647 as the record of the decision: a deadline kept across adoption, which reopens #1146, and a deadline recorded per account rather than per link.
- #1649 (pruning on the host's user-deleted event) removes the dangling-link root under the first step of this chain as well; this change stands on its own without it.
