### PR TITLE
Take a deleted account's links with it, on the host's own event

### DIFF
--- a/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerTests.cs
+++ b/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerTests.cs
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A deleted Jellyfin account takes its links with it (#1649). The host publishes its deletion, and this
+/// plugin's consumer removes every link the account held on both protocols, with the deadline, the stamp
+/// and the pending-approval record that hung off them, and writes one audit line naming the providers and
+/// the account id and never the subject. Nothing it does may reach the host's delete: a store that throws
+/// is a warning, not a failure the host sees.
+/// </summary>
+public class DeletedAccountLinkPrunerTests
+{
+    private static readonly Guid Gone = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task ADeletedAccount_LosesEveryLinkAndEverythingThatHungOffThem()
+    {
+        var (pruner, configuration, audit) = Build();
+        var oid = configuration.OidConfigs["kc"];
+        var saml = configuration.SamlConfigs["idp"];
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        Assert.False(oid.CanonicalLinks.ContainsKey("sub-gone"));
+        Assert.False(saml.CanonicalLinks.ContainsKey("nameid-gone"));
+        Assert.Empty(oid.CanonicalLinkDeadlines);
+        Assert.Empty(oid.CanonicalLinkLastLogins);
+        Assert.Empty(oid.CanonicalLinkPendingApprovals);
+        Assert.Empty(oid.CanonicalLinkIssuers);
+
+        // The neighbour is untouched: this is keyed on the deleted account, not a sweep.
+        Assert.Equal(Other, oid.CanonicalLinks["sub-other"]);
+        Assert.NotNull(audit);
+    }
+
+    [Fact]
+    public async Task TheAuditLine_NamesTheProvidersAndTheAccount_AndNotTheSubject()
+    {
+        var (pruner, _, audit) = Build();
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        var entry = Assert.Single(audit.Entries, e => e.Message.Contains("was deleted", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(Gone.ToString(), entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("OpenID 'kc'", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("SAML 'idp'", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-gone", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("nameid-gone", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("alice", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AnAccountWithNoLinks_LeavesNoLine()
+    {
+        var (pruner, configuration, audit) = Build();
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("nobody", Guid.NewGuid())));
+
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
+        Assert.Equal(Gone, configuration.OidConfigs["kc"].CanonicalLinks["sub-gone"]);
+    }
+
+    [Fact]
+    public async Task AStoreThatThrows_IsAWarning_AndNeverReachesTheHost()
+    {
+        // The host's delete has already happened. A persist that fails is bookkeeping the next login of
+        // the same subject cleans up on its own, and the warning names the account id and nothing else.
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var store = new ProviderConfigStore(() => configuration, _ => throw new System.IO.IOException("disk full"), new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var pruner = new DeletedAccountLinkPruner(() => links, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        var warning = Assert.Single(audit.Entries, e => e.Message.Contains("Could not remove", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.DoesNotContain("alice", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-gone", warning.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WhileThePluginIsNotUp_NothingHappens()
+    {
+        var audit = new CapturingLogger();
+        var pruner = new DeletedAccountLinkPruner(() => null, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        Assert.Empty(audit.Entries);
+    }
+
+    // One OpenID and one SAML provider, the deleted account linked on both with everything a link can
+    // carry, and a neighbour on the OpenID provider that must survive.
+    private static PluginConfiguration Seeded()
+    {
+        var configuration = new PluginConfiguration();
+        var oid = new OidConfig { Enabled = true };
+        oid.CanonicalLinks["sub-gone"] = Gone;
+        oid.CanonicalLinks["sub-other"] = Other;
+        oid.CanonicalLinkIssuers["sub-gone"] = "https://id.example.com";
+        oid.CanonicalLinkDeadlines["sub-gone"] = Now + TimeSpan.FromHours(4);
+        oid.CanonicalLinkLastLogins["sub-gone"] = Now;
+        oid.CanonicalLinkPendingApprovals["sub-gone"] = new PendingApproval { UserId = Gone, SinceUtc = Now };
+        configuration.OidConfigs["kc"] = oid;
+        var saml = new SamlConfig { Enabled = true };
+        saml.CanonicalLinks["nameid-gone"] = Gone;
+        configuration.SamlConfigs["idp"] = saml;
+        return configuration;
+    }
+
+    private static (DeletedAccountLinkPruner Pruner, PluginConfiguration Configuration, CapturingLogger Audit) Build()
+    {
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        return (new DeletedAccountLinkPruner(() => links, audit), configuration, audit);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -714,6 +714,35 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records the links of a deleted Jellyfin account being removed with it (#1649), on the host's own
+    /// deletion event. Warned rather than informed, because it is the line that replaces the roster's orphan
+    /// row: an operator who used to find a dead link on the Accounts page finds this instead.
+    /// </summary>
+    /// <remarks>
+    /// The providers are named and the subject is not (T-I1): protocol and provider say where the account
+    /// was linked, the id says which account, and the subject is the one value that names a person at the
+    /// identity provider. The account's username is not carried either; the account is gone, and the id is
+    /// what every other line about it used.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="jellyfinUserId">The deleted account.</param>
+    /// <param name="removed">How many links were removed.</param>
+    /// <param name="providers">The providers that held them, each labelled by protocol.</param>
+    internal static void DeletedAccountUnlinked(ILogger logger, Guid jellyfinUserId, int removed, IReadOnlyList<string> providers)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Jellyfin user {UserId} was deleted; removed its {Count} SSO link(s) from {Providers}. Any deadline, last-login stamp and pending-approval record went with them.",
+            jellyfinUserId,
+            removed,
+            string.Join(", ", providers ?? Array.Empty<string>()).ReplaceLineEndings(string.Empty).Replace('[', '('));
+    }
+
+    /// <summary>
     /// Records an administrator removing every canonical link one provider holds (#1519). One line for the
     /// act, at Warning, because a bulk removal of a thousand links must not reach an operator as a thousand
     /// indistinguishable per-user lines with no statement of what was done - the per-account detail is

--- a/SSO-Auth/Api/Linking/DeletedAccountLinkPruner.cs
+++ b/SSO-Auth/Api/Linking/DeletedAccountLinkPruner.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// Takes a deleted Jellyfin account's links with it, the moment the host reports the deletion (#1649).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A link whose target account was deleted counts as absent everywhere in this plugin, so the next login
+/// for the same subject writes the key again at another account. That dangling link was the root under
+/// three things found on one day: a pending-approval record that followed the key (#1637), a deadline that
+/// disabled the account that inherited it (#1638), and the first step of a guest's exit from their own
+/// limit (#1647). Each map now guards itself on rebind; this removes the state that made a rebind possible.
+/// </para>
+/// <para>
+/// The host publishes <see cref="UserDeletedEventArgs"/> from its own delete, and its event manager hands it
+/// to every registered consumer of that closed type - the same mechanism the webhook plugin listens on.
+/// Enabling or disabling an account publishes nothing (checked against the host's source), which is why
+/// this is the one transition the plugin can observe and the enable is not.
+/// </para>
+/// <para>
+/// WHAT IT COSTS is the roster's orphan row: a link whose account is gone was kept on purpose (#1119) so an
+/// administrator could find it. Pruned here, that row does not appear for an account deleted while the
+/// plugin was loaded; the fact goes to the audit trail instead, one line per deleted account naming the
+/// protocol and provider of every link removed and the account id, never the subject (T-I1). An account
+/// deleted while the plugin was not loaded still leaves an orphan, and the roster still shows it.
+/// </para>
+/// <para>
+/// NOTHING HERE MAY REACH THE HOST'S DELETE. The host's event manager catches a consumer's exception, but
+/// the rule is kept on this side as well: a failure to prune is logged at Warning and swallowed, because a
+/// deletion that already happened must not be reported as failed over bookkeeping the next login would
+/// otherwise have to clean up on its own.
+/// </para>
+/// </remarks>
+internal sealed class DeletedAccountLinkPruner : IEventConsumer<UserDeletedEventArgs>
+{
+    private readonly Func<CanonicalLinkService?> _links;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeletedAccountLinkPruner"/> class for the host's
+    /// container: the link service is built per event over the plugin's live configuration store, the way
+    /// the expiry sweep builds its own, and is null while the plugin instance is not up.
+    /// </summary>
+    /// <param name="userManager">Jellyfin user manager.</param>
+    /// <param name="cryptoProvider">Jellyfin crypto provider, for the link service's provisioning arm.</param>
+    /// <param name="logger">The logger.</param>
+    public DeletedAccountLinkPruner(IUserManager userManager, ICryptoProvider cryptoProvider, ILogger<DeletedAccountLinkPruner> logger)
+        : this(
+            () => SSOPlugin.Instance is { } plugin ? new CanonicalLinkService(userManager, cryptoProvider, plugin.ConfigStore, logger) : null,
+            logger)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeletedAccountLinkPruner"/> class over an explicit link
+    /// service factory, which is what the tests hand it.
+    /// </summary>
+    /// <param name="links">Yields the link service to prune through, or null when the plugin is not up.</param>
+    /// <param name="logger">The logger.</param>
+    internal DeletedAccountLinkPruner(Func<CanonicalLinkService?> links, ILogger logger)
+    {
+        _links = links ?? throw new ArgumentNullException(nameof(links));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task OnEvent(UserDeletedEventArgs eventArgs)
+    {
+        if (eventArgs?.Argument is not { } user)
+        {
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            if (_links() is not { } links)
+            {
+                return Task.CompletedTask;
+            }
+
+            // The providers are read before the removal so the audit line can name them; the removal
+            // itself is the existing revoke seam, in its own transaction, which prunes every map that
+            // hangs off the links it removes. A link that arrives between the two reads is removed and
+            // goes unnamed, which is the harmless direction.
+            var providers = HoldingLinksFor(links, user.Id);
+            var removed = links.RemoveUserEverywhere(user.Id);
+            if (removed > 0)
+            {
+                SsoAudit.DeletedAccountUnlinked(_logger, user.Id, removed, providers);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The account id only, never a name or a subject, and line endings stripped at the call as
+            // the audit trail requires. Swallowed on purpose: see the class remarks.
+            _logger.LogWarning(ex, "[SSO] Could not remove the SSO links of deleted user {UserId}; its links stay until the next login of the same subject clears them.", user.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // Every provider, labelled by protocol, that holds at least one link for the account.
+    private static List<string> HoldingLinksFor(CanonicalLinkService links, Guid userId)
+    {
+        return links.LinksByUser(ProviderMode.Oid, userId).Where(entry => entry.Value.Any()).Select(entry => "OpenID '" + entry.Key + "'")
+            .Concat(links.LinksByUser(ProviderMode.Saml, userId).Where(entry => entry.Value.Any()).Select(entry => "SAML '" + entry.Key + "'"))
+            .ToList();
+    }
+}

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -24,9 +24,11 @@ internal readonly record struct LinkedAccountState(string Username, bool IsDisab
 /// It walks the same <see cref="LinkExport.Rows"/> sequence the portable export does, so the two cannot
 /// disagree about which providers are readable or which links exist. What differs is what each does with a
 /// link whose user id resolves to no account: the export drops it, because nothing could restore it, and
-/// this keeps it, because an orphaned link is exactly what an administrator opens the roster to find. As
-/// with the export, no provider configuration field is copied, so no client secret, signing key or
-/// certificate can reach the output by construction.
+/// this keeps it, because an orphaned link is exactly what an administrator opens the roster to find. Since
+/// #1649 such a link is removed the moment the host reports the account deleted and the fact goes to the
+/// audit trail, so an orphan row appears only for an account deleted while the plugin was not loaded - and
+/// then it is still the row to find. As with the export, no provider configuration field is copied, so no
+/// client secret, signing key or certificate can reach the output by construction.
 /// </remarks>
 internal static class LinkRoster
 {

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Threading;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -39,6 +42,14 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // (#1145). Login-time enforcement (#1144) never fires for a guest who simply stops coming back, so
         // without a timer the deadline binds only those who return.
         serviceCollection.AddHostedService<AccountExpirySweepService>();
+
+        // Takes a deleted Jellyfin account's links with it, on the host's own deletion event (#1649). A
+        // link whose account is gone counts as absent, and the next login for its subject wrote the key
+        // again at another account with whatever the key still carried; removing the links at the source
+        // removes the state that made that possible. The host's event manager resolves every registered
+        // consumer of the closed event type from the container, which is why this is a registration and
+        // not a subscription.
+        serviceCollection.AddScoped<IEventConsumer<UserDeletedEventArgs>, DeletedAccountLinkPruner>();
 
         // Keeps the login-page "Sign in with …" buttons (#722) in sync with the configured providers by
         // splicing a managed block into the server's branding login disclaimer on every config change.


### PR DESCRIPTION
# What & why

A deleted Jellyfin account takes its links with it, the moment the host reports the deletion (#1649). A link whose target account was deleted counts as absent everywhere in this plugin, so the next login for the same subject wrote the key again at another account with whatever the key still carried. That dangling link was the root under three things found on one day: the pending-approval residual (#1637), the inherited deadline (#1638), and the first step of #1647. Each map now guards itself on rebind; this removes the state that made a rebind possible.

The host publishes `UserDeletedEventArgs` from its own delete, after its commit, and its event manager hands it to every registered consumer of that closed type. The consumer builds the link service per event over the plugin's live store, the way the expiry sweep does, and drives the existing revoke seam the elevation-gated Unregister uses: every link on both protocols, and with them the issuer binding, the deadline, the last-login stamp and the pending-approval record, in one transaction. One audit line at Warning names the protocol and provider of every link removed and the account id, never the subject and not the username either.

What it costs was decided on the issue: the roster's orphan row does not appear for an account deleted while the plugin was loaded; the audit line is what replaces it. An account deleted while the plugin was not loaded still leaves an orphan, and the roster still shows it; its remark says so now.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here grants; a failure to prune
      leaves every link exactly as it was, and the next login of the same subject
      clears it as before.
- [x] No secrets logged; secrets are redacted on config export. The audit line
      carries the account id, a count and administrator-typed provider names,
      sanitized inline at the log call; the warning carries the id alone.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP value
      reaches either line.

### Review record

**Pass 1, the security review of the commit**, raised nothing at the bar and answered the question the change turns on from the host's own source: `UserManager.DeleteUserAsync` removes the row and saves inside its lock and publishes the event only after both are disposed, so the plugin never prunes the links of an account that still exists; the only callers of that delete are the host's elevation-only user endpoint and this plugin's own rollback of an account the same login had just created, whose id is fresh. No HTTP or webhook path publishes host events, and the plugin's own publisher carries a different closed type. The removal matches by user id, which the host never reuses, and the follow-on prunes drop only entries whose key holds no link at all, so nothing here can disable a live account. The prune and a login of the same subject run under the same store lock, and in either order the new account's link survives. The audit line and the warning carry the id, a count and provider labels; the sanitizers sit inline at the log call, the shape every helper in that file takes. The registration matches the host's own consumers, the scope exists per publish, and the loggers and services the constructor asks for are ones the registrator's neighbours already take. The consumer runs after the commit inside the host's awaited publish with exceptions caught on both sides, and a failed persist restores the snapshot.

**Pass 2, an adversarial verification of the same tree** attacking each of those claims independently, is running as this PR opens; its record follows as a comment before the merge, and the merge waits for it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The consumer is one class over the existing revoke seam
      and one audit helper; the DI shell and the testable core are the two
      constructors the expiry sweep already uses.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The consumer lives in Linking, whose module edges already allow what it
      imports; the host's event types are host types, not Api modules.
- [x] Docs impact considered: the roster's own remark carries the change in what
      an orphan row now means; the wiki's Accounts page sentence about orphan
      rows is folded into #1643's documentation pass for this milestone.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3931 on net9.0 and 3932 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Five tests drive the consumer, each proven against its own broken build before being trusted: with the removal skipped, the audit dropped, and the failure rethrown, each break fails the rows that name it.

## Notes

- Enabling or disabling an account publishes nothing in the host (checked against its source), which is why this is the one transition the plugin can observe and why #1637's remaining window is closed by the readers checking what is true now rather than by an event.
- The walk server can show this live: delete a linked account in the dashboard and the roster row is gone on the next read, with the audit line in the log.
