### PR TITLE
Take a deleted account's links with it, on the host's own event

### DIFF
--- a/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerTests.cs
+++ b/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerTests.cs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A deleted Jellyfin account takes its links with it (#1649). The host publishes its deletion, and this
+/// plugin's consumer removes every link the account held on both protocols, with the deadline, the stamp
+/// and the pending-approval record that hung off them, and writes one audit line naming the providers and
+/// the account id and never the subject. Nothing it does may reach the host's delete: a store that throws
+/// is a warning, not a failure the host sees.
+/// </summary>
+public class DeletedAccountLinkPrunerTests
+{
+    private static readonly Guid Gone = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime Now = new(2026, 9, 11, 9, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task ADeletedAccount_LosesEveryLinkAndEverythingThatHungOffThem()
+    {
+        var (pruner, configuration, _) = Build();
+        var oid = configuration.OidConfigs["kc"];
+        var saml = configuration.SamlConfigs["idp"];
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        Assert.False(oid.CanonicalLinks.ContainsKey("sub-gone"));
+        Assert.False(saml.CanonicalLinks.ContainsKey("nameid-gone"));
+        Assert.Empty(oid.CanonicalLinkDeadlines);
+        Assert.Empty(oid.CanonicalLinkLastLogins);
+        Assert.Empty(oid.CanonicalLinkPendingApprovals);
+        Assert.Empty(oid.CanonicalLinkIssuers);
+
+        // The neighbour is untouched: this is keyed on the deleted account, not a sweep.
+        Assert.Equal(Other, oid.CanonicalLinks["sub-other"]);
+    }
+
+    [Fact]
+    public async Task TheAuditLine_NamesTheProvidersAndTheAccount_AndNotTheSubject()
+    {
+        var (pruner, _, audit) = Build();
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        var entry = Assert.Single(audit.Entries, e => e.Message.Contains("was deleted", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(Gone.ToString(), entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("its 2 SSO link(s) from", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID 'kc'", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("SAML 'idp'", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-gone", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("nameid-gone", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("alice", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheAuditLine_NamesWhatTheRemovalRemoved_NotWhatTheReadBeforeItSaw()
+    {
+        // The read before the removal is only the no-write guard; the names come from inside the removal's
+        // own lock. Proven by moving the ground between the two: the store hands the configuration out once
+        // per lock acquisition, the guard's read is the first, and every acquisition after it finds the
+        // OpenID link gone - the way an administrator's Unregister racing the host's delete would take it.
+        // The removal then finds one link, and that is the one the line must name; a line built from the
+        // guard's read would name both providers here.
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var acquisitions = 0;
+        var store = new ProviderConfigStore(
+            () =>
+            {
+                if (++acquisitions > 1)
+                {
+                    configuration.OidConfigs["kc"].CanonicalLinks.Remove("sub-gone");
+                }
+
+                return configuration;
+            },
+            _ => { },
+            new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var pruner = new DeletedAccountLinkPruner(() => links, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        // One read for the guard and one acquisition for the removal, and none of its own for the names: a
+        // build that read them in between would produce this very line, and only the count tells it apart.
+        Assert.Equal(2, acquisitions);
+        var entry = Assert.Single(audit.Entries, e => e.Message.Contains("was deleted", StringComparison.Ordinal));
+        Assert.Contains("its 1 SSO link(s) from SAML 'idp'.", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("kc", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AnAccountWithNoLinks_LeavesNoLineAndWritesNothing()
+    {
+        // Most deleted accounts never had an SSO link, and this plugin's own create arm deletes the account
+        // it just made when a login fails after creating it. Neither may cost a configuration write, and
+        // neither may leave a line: the store here throws on persist, so a write would surface as the
+        // warning, and the assertion is on EVERY entry rather than on the audit marker alone.
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var store = new ProviderConfigStore(() => configuration, _ => throw new System.IO.IOException("disk full"), new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var pruner = new DeletedAccountLinkPruner(() => links, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("nobody", Guid.NewGuid())));
+
+        Assert.Empty(audit.Entries);
+        Assert.Equal(Gone, configuration.OidConfigs["kc"].CanonicalLinks["sub-gone"]);
+    }
+
+    [Fact]
+    public async Task AStoreThatThrows_IsAWarning_AndNeverReachesTheHost()
+    {
+        // The host's delete has already happened. A persist that fails is bookkeeping the next login of
+        // the same subject cleans up on its own, and the warning names the account id and nothing else.
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var store = new ProviderConfigStore(() => configuration, _ => throw new System.IO.IOException("disk full"), new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        var pruner = new DeletedAccountLinkPruner(() => links, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        var warning = Assert.Single(audit.Entries, e => e.Message.Contains("Could not remove", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.DoesNotContain("alice", warning.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-gone", warning.Message, StringComparison.Ordinal);
+
+        // Nothing was reported as removed, and the link is where it was: the store put its snapshot back
+        // before rethrowing, which is what makes the warning's "its links stay" true.
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
+        Assert.Equal(Gone, configuration.OidConfigs["kc"].CanonicalLinks["sub-gone"]);
+    }
+
+    [Fact]
+    public async Task WhileThePluginIsNotUp_NothingHappens()
+    {
+        var audit = new CapturingLogger();
+        var pruner = new DeletedAccountLinkPruner(() => null, audit);
+
+        await pruner.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", Gone)));
+
+        Assert.Empty(audit.Entries);
+    }
+
+    // One OpenID and one SAML provider, the deleted account linked on both with everything a link can
+    // carry, and a neighbour on the OpenID provider that must survive.
+    private static PluginConfiguration Seeded()
+    {
+        var configuration = new PluginConfiguration();
+        var oid = new OidConfig { Enabled = true };
+        oid.CanonicalLinks["sub-gone"] = Gone;
+        oid.CanonicalLinks["sub-other"] = Other;
+        oid.CanonicalLinkIssuers["sub-gone"] = "https://id.example.com";
+        oid.CanonicalLinkDeadlines["sub-gone"] = Now + TimeSpan.FromHours(4);
+        oid.CanonicalLinkLastLogins["sub-gone"] = Now;
+        oid.CanonicalLinkPendingApprovals["sub-gone"] = new PendingApproval { UserId = Gone, SinceUtc = Now };
+        configuration.OidConfigs["kc"] = oid;
+        var saml = new SamlConfig { Enabled = true };
+        saml.CanonicalLinks["nameid-gone"] = Gone;
+        configuration.SamlConfigs["idp"] = saml;
+        return configuration;
+    }
+
+    private static (DeletedAccountLinkPruner Pruner, PluginConfiguration Configuration, CapturingLogger Audit) Build()
+    {
+        var audit = new CapturingLogger();
+        var configuration = Seeded();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var links = new CanonicalLinkService(Substitute.For<IUserManager>(), new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => Now);
+        return (new DeletedAccountLinkPruner(() => links, audit), configuration, audit);
+    }
+}

--- a/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerWiringTests.cs
+++ b/SSO-Auth.Tests/Linking/DeletedAccountLinkPrunerWiringTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The one host-facing seam of #1649, read back the way the host reads it: the event manager resolves every
+/// <see cref="IEventConsumer{T}"/> from a scope of the container the registrator filled, through the public
+/// constructor no other test runs, and the resolved instance prunes the plugin's LIVE store. It runs in the
+/// non-parallel collection because it stands a real plugin instance up, which makes the plugin being up a
+/// fact of this test rather than of whatever ran before it in the process.
+/// </summary>
+[Collection("SSOController")]
+public class DeletedAccountLinkPrunerWiringTests
+{
+    [Fact]
+    public async Task TheHostResolvesTheConsumer_FromWhatTheRegistratorRegistered_AndItPrunesTheLiveStore()
+    {
+        // Built the way the outbound-client test builds it, with the host services the constructor asks for
+        // supplied as the host supplies them. The link is seeded in the plugin instance's own store, so what
+        // the event removes is what a real deletion would find, not a fixture handed to a constructor.
+        var gone = Guid.NewGuid();
+        _ = new SsoControllerHarness(configuration =>
+        {
+            var oid = new OidConfig { Enabled = true };
+            oid.CanonicalLinks["sub-gone"] = gone;
+            configuration.OidConfigs["kc"] = oid;
+        });
+        var log = new CapturingLogger();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ILogger<DeletedAccountLinkPruner>>(new TypedLogger<DeletedAccountLinkPruner>(log));
+        services.AddSingleton(Substitute.For<MediaBrowser.Controller.Library.IUserManager>());
+        services.AddSingleton<ICryptoProvider>(new FakeCryptoProvider());
+        new SsoOnlyServiceRegistrator().RegisterServices(services, Substitute.For<IServerApplicationHost>());
+        await using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var consumer = Assert.Single(scope.ServiceProvider.GetServices<IEventConsumer<UserDeletedEventArgs>>());
+        Assert.IsType<DeletedAccountLinkPruner>(consumer);
+
+        await consumer.OnEvent(new UserDeletedEventArgs(TestUsers.Named("alice", gone)));
+
+        // The link is gone from the live store, and the one line about it came through the logger the
+        // container wired: the wiring claim made real, not inferred from a type check.
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-gone")));
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID 'kc'", entry.Message, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -714,6 +714,35 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records the links of a deleted Jellyfin account being removed with it (#1649), on the host's own
+    /// deletion event. Warned rather than informed, because it is the line that replaces the roster's orphan
+    /// row: an operator who used to find a dead link on the Accounts page finds this instead.
+    /// </summary>
+    /// <remarks>
+    /// The providers are named and the subject is not (T-I1): protocol and provider say where the account
+    /// was linked, the id says which account, and the subject is the one value that names a person at the
+    /// identity provider. The account's username is not carried either; the account is gone, and the id is
+    /// what every other line about it used.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="jellyfinUserId">The deleted account.</param>
+    /// <param name="removed">How many links were removed.</param>
+    /// <param name="providers">The providers that held them, each labelled by protocol.</param>
+    internal static void DeletedAccountUnlinked(ILogger logger, Guid jellyfinUserId, int removed, IReadOnlyList<string> providers)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Jellyfin user {UserId} was deleted; removed its {Count} SSO link(s) from {Providers}. Any deadline, last-login stamp and pending-approval record went with them.",
+            jellyfinUserId,
+            removed,
+            string.Join(", ", providers ?? Array.Empty<string>()).ReplaceLineEndings(string.Empty).Replace('[', '('));
+    }
+
+    /// <summary>
     /// Records an administrator removing every canonical link one provider holds (#1519). One line for the
     /// act, at Warning, because a bulk removal of a thousand links must not reach an operator as a thousand
     /// indistinguishable per-user lines with no statement of what was done - the per-account detail is

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1739,21 +1739,30 @@ internal sealed class CanonicalLinkService
     /// of links removed.
     /// </summary>
     /// <param name="userId">The Jellyfin user whose links are revoked.</param>
+    /// <param name="removedFrom">When given, receives every provider a link was removed from, labelled by protocol. Filled inside the same lock as the removal, so a line built from it names what this call removed and nothing a read before it saw (#1649).</param>
     /// <returns>The number of links removed.</returns>
-    internal int RemoveUserEverywhere(Guid userId)
+    internal int RemoveUserEverywhere(Guid userId, ICollection<string>? removedFrom = null)
     {
         return _configStore.Mutate(configuration =>
         {
             int removed = 0;
 
-            // One loop over both protocols' providers (covariant Concat over the shared base). Skip a
-            // provider stored with a null config object (reachable via #350); it holds no links to revoke,
-            // and dereferencing it would NRE into a 500 - the same fail-closed skip TryGetLinks uses.
-            foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
+            // One loop over both protocols' providers, each with its name and protocol so the caller's audit
+            // line can say where a link was removed from. Skip a provider stored with a null config object
+            // (reachable via #350); it holds no links to revoke, and dereferencing it would NRE into a 500 -
+            // the same fail-closed skip TryGetLinks uses.
+            var providers = configuration.SamlConfigs.Select(p => (p.Key, Protocol: "SAML", Config: (ProviderConfigBase?)p.Value))
+                .Concat(configuration.OidConfigs.Select(p => (p.Key, Protocol: "OpenID", Config: (ProviderConfigBase?)p.Value)));
+            foreach (var (name, protocol, config) in providers)
             {
                 if (config?.CanonicalLinks is { } links)
                 {
-                    removed += CanonicalLinkRevoker.RemoveUser(links, userId);
+                    var here = CanonicalLinkRevoker.RemoveUser(links, userId);
+                    removed += here;
+                    if (here > 0)
+                    {
+                        removedFrom?.Add(protocol + " '" + name + "'");
+                    }
                 }
 
                 // Prune orphaned OpenID issuer entries (#186): after the revoke, any issuer keyed on a sub

--- a/SSO-Auth/Api/Linking/DeletedAccountLinkPruner.cs
+++ b/SSO-Auth/Api/Linking/DeletedAccountLinkPruner.cs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using MediaBrowser.Controller.Events;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// Takes a deleted Jellyfin account's links with it, the moment the host reports the deletion (#1649).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A link whose target account was deleted counts as absent everywhere in this plugin, so the next login
+/// for the same subject writes the key again at another account. That dangling link was the root under
+/// three things found on one day: a pending-approval record that followed the key (#1637), a deadline that
+/// disabled the account that inherited it (#1638), and the first step of a guest's exit from their own
+/// limit (#1647). Each map now guards itself on rebind; this removes the state that made a rebind possible.
+/// </para>
+/// <para>
+/// The host publishes <see cref="UserDeletedEventArgs"/> from its own delete, and its event manager hands it
+/// to every registered consumer of that closed type - the same mechanism the webhook plugin listens on.
+/// Enabling or disabling an account publishes nothing (checked against the host's source), which is why
+/// this is the one transition the plugin can observe and the enable is not.
+/// </para>
+/// <para>
+/// WHAT IT COSTS is the roster's orphan row: a link whose account is gone was kept on purpose (#1119) so an
+/// administrator could find it. Pruned here, that row does not appear for an account deleted while the
+/// plugin was loaded; the fact goes to the audit trail instead, one line per deleted account naming the
+/// protocol and provider of every link removed and the account id, never the subject (T-I1). An account
+/// deleted while the plugin was not loaded still leaves an orphan, and the roster still shows it.
+/// </para>
+/// <para>
+/// NOTHING HERE MAY REACH THE HOST'S DELETE. The host's event manager catches a consumer's exception, but
+/// the rule is kept on this side as well: a failure to prune is logged at Warning and swallowed, because a
+/// deletion that already happened must not be reported as failed over bookkeeping the next login would
+/// otherwise have to clean up on its own.
+/// </para>
+/// </remarks>
+internal sealed class DeletedAccountLinkPruner : IEventConsumer<UserDeletedEventArgs>
+{
+    private readonly Func<CanonicalLinkService?> _links;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeletedAccountLinkPruner"/> class for the host's
+    /// container: the link service is built per event over the plugin's live configuration store, the way
+    /// the expiry sweep builds its own, and is null while the plugin instance is not up.
+    /// </summary>
+    /// <param name="userManager">Jellyfin user manager.</param>
+    /// <param name="cryptoProvider">Jellyfin crypto provider, for the link service's provisioning arm.</param>
+    /// <param name="logger">The logger.</param>
+    public DeletedAccountLinkPruner(IUserManager userManager, ICryptoProvider cryptoProvider, ILogger<DeletedAccountLinkPruner> logger)
+        : this(
+            () => SSOPlugin.Instance is { } plugin ? new CanonicalLinkService(userManager, cryptoProvider, plugin.ConfigStore, logger) : null,
+            logger)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeletedAccountLinkPruner"/> class over an explicit link
+    /// service factory, which is what the tests hand it.
+    /// </summary>
+    /// <param name="links">Yields the link service to prune through, or null when the plugin is not up.</param>
+    /// <param name="logger">The logger.</param>
+    internal DeletedAccountLinkPruner(Func<CanonicalLinkService?> links, ILogger logger)
+    {
+        _links = links ?? throw new ArgumentNullException(nameof(links));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task OnEvent(UserDeletedEventArgs eventArgs)
+    {
+        if (eventArgs?.Argument is not { } user)
+        {
+            return Task.CompletedTask;
+        }
+
+        try
+        {
+            if (_links() is not { } links)
+            {
+                return Task.CompletedTask;
+            }
+
+            // The read before the removal is the no-write guard and nothing more: the revoke seam persists
+            // the configuration whenever it runs, and most deleted accounts never had an SSO link -
+            // including the one this plugin's own create arm rolls back when a login fails after creating
+            // it, where a persist on a full disk would otherwise warn that links stayed which never existed.
+            // The names the audit line carries are not taken from that read. The removal is the existing
+            // revoke seam, in its own transaction, which prunes every map that hangs off the links it
+            // removes and collects the providers it removed from inside that same lock - so the line says
+            // what this removal removed, whatever moved between the guard and the removal. A link that
+            // arrives after an empty read is left to the next login of its subject, which treats a dangling
+            // link as absent, exactly as before this consumer existed.
+            if (!HoldsAnyLink(links, user.Id))
+            {
+                return Task.CompletedTask;
+            }
+
+            var providers = new List<string>();
+            var removed = links.RemoveUserEverywhere(user.Id, providers);
+            if (removed > 0)
+            {
+                SsoAudit.DeletedAccountUnlinked(_logger, user.Id, removed, providers);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The account id only, never a name or a subject: a Guid carries nothing a log line can be
+            // forged through, so no sanitizer is needed here. Swallowed on purpose: see the class remarks.
+            _logger.LogWarning(ex, "[SSO] Could not remove the SSO links of deleted user {UserId}; its links stay until the next login of the same subject clears them.", user.Id);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    // Whether any provider on either protocol holds a link for the account.
+    private static bool HoldsAnyLink(CanonicalLinkService links, Guid userId)
+    {
+        return links.LinksByUser(ProviderMode.Oid, userId).Any(entry => entry.Value.Any())
+            || links.LinksByUser(ProviderMode.Saml, userId).Any(entry => entry.Value.Any());
+    }
+}

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -24,9 +24,11 @@ internal readonly record struct LinkedAccountState(string Username, bool IsDisab
 /// It walks the same <see cref="LinkExport.Rows"/> sequence the portable export does, so the two cannot
 /// disagree about which providers are readable or which links exist. What differs is what each does with a
 /// link whose user id resolves to no account: the export drops it, because nothing could restore it, and
-/// this keeps it, because an orphaned link is exactly what an administrator opens the roster to find. As
-/// with the export, no provider configuration field is copied, so no client secret, signing key or
-/// certificate can reach the output by construction.
+/// this keeps it, because an orphaned link is exactly what an administrator opens the roster to find. Since
+/// #1649 such a link is removed the moment the host reports the account deleted and the fact goes to the
+/// audit trail, so an orphan row appears only for an account deleted while the plugin was not loaded, or
+/// whose prune could not be persisted - and then it is still the row to find. As with the export, no provider configuration field is copied, so no
+/// client secret, signing key or certificate can reach the output by construction.
 /// </remarks>
 internal static class LinkRoster
 {

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System.Threading;
+using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -39,6 +42,14 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // (#1145). Login-time enforcement (#1144) never fires for a guest who simply stops coming back, so
         // without a timer the deadline binds only those who return.
         serviceCollection.AddHostedService<AccountExpirySweepService>();
+
+        // Takes a deleted Jellyfin account's links with it, on the host's own deletion event (#1649). A
+        // link whose account is gone counts as absent, and the next login for its subject wrote the key
+        // again at another account with whatever the key still carried; removing the links at the source
+        // removes the state that made that possible. The host's event manager resolves every registered
+        // consumer of the closed event type from the container, which is why this is a registration and
+        // not a subscription.
+        serviceCollection.AddScoped<IEventConsumer<UserDeletedEventArgs>, DeletedAccountLinkPruner>();
 
         // Keeps the login-page "Sign in with …" buttons (#722) in sync with the configured providers by
         // splicing a managed block into the server's branding login disclaimer on every config change.


### PR DESCRIPTION
# What & why

A deleted Jellyfin account takes its links with it, the moment the host reports the deletion (#1649). A link whose target account was deleted counts as absent everywhere in this plugin, so the next login for the same subject wrote the key again at another account with whatever the key still carried. That dangling link was the root under three things found on one day: the pending-approval residual (#1637), the inherited deadline (#1638), and the first step of #1647. Each map now guards itself on rebind; this removes the state that made a rebind possible.

The host publishes `UserDeletedEventArgs` from its own delete, after its commit, and its event manager hands it to every registered consumer of that closed type. The consumer builds the link service per event over the plugin's live store, the way the expiry sweep does, and drives the existing revoke seam the elevation-gated Unregister uses: every link on both protocols, and with them the issuer binding, the deadline, the last-login stamp and the pending-approval record, in one transaction. One audit line at Warning names the protocol and provider of every link removed and the account id, never the subject and not the username either.

What it costs was decided on the issue: the roster's orphan row does not appear for an account deleted while the plugin was loaded; the audit line is what replaces it. An account deleted while the plugin was not loaded still leaves an orphan, and the roster still shows it; its remark says so now.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here grants; a failure to prune
      leaves every link exactly as it was, and the next login of the same subject
      clears it as before.
- [x] No secrets logged; secrets are redacted on config export. The audit line
      carries the account id, a count and administrator-typed provider names,
      sanitized inline at the log call; the warning carries the id alone.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP value
      reaches either line.

### Review record

**Pass 1, the security review of the commit**, raised nothing at the bar and answered the question the change turns on from the host's own source: `UserManager.DeleteUserAsync` removes the row and saves inside its lock and publishes the event only after both are disposed, so the plugin never prunes the links of an account that still exists; the only callers of that delete are the host's elevation-only user endpoint and this plugin's own rollback of an account the same login had just created, whose id is fresh. No HTTP or webhook path publishes host events, and the plugin's own publisher carries a different closed type. The removal matches by user id, which the host never reuses, and the follow-on prunes drop only entries whose key holds no link at all, so nothing here can disable a live account. The prune and a login of the same subject run under the same store lock, and in either order the new account's link survives. The audit line and the warning carry the id, a count and provider labels; the sanitizers sit inline at the log call, the shape every helper in that file takes. The registration matches the host's own consumers, the scope exists per publish, and the loggers and services the constructor asks for are ones the registrator's neighbours already take. The consumer runs after the commit inside the host's awaited publish with exceptions caught on both sides, and a failed persist restores the snapshot.

**Pass 2, an adversarial verification of the same tree** attacking each of those claims independently: every lens SAFE, on the same evidence and one more - the plugin's own rollback of a just-created account is the one non-elevated path to the host's delete, and the id it deletes holds no link by construction. It raised three notes, none a security finding, all **FIX** here: the revoke seam persisted the configuration on every deletion, including the many accounts that never had a link and the plugin's own rollback, where a full disk would have warned that links stayed which never existed - an account with no link now returns before the seam runs, driven over a store that throws; the no-links test asserted only the audit marker's absence and would have passed had that path thrown - it asserts every entry now; and the wiring, the one host-facing seam, ran in no test - a real container filled by the registrator now resolves the consumer from a scope through the public constructor and drives an event through it. A wording note on the roster's remark is corrected as well: an orphan row also appears when the prune's persist failed.

**Pass 3, a focused re-verification of that fixed tree**, every lens SAFE on the host's source: the sole publisher of the event and its elevation-only caller, the plugin's own rollback as the one non-elevated path whose fresh id holds no link, the match by Guid value under the one static lock, the DI shape against the host's own consumers, the consumer inside the awaited publish after the commit. Two notes, none a security finding, both **FIX** here: the providers the audit line named were read in lock acquisitions of their own before the removal's, so an administrator's Unregister racing the host's delete could have left a line naming a provider nothing was removed from - the revoke seam now takes an optional collector it fills inside the same lock as the removal, only where a link came out, the Unregister passes none and is unchanged, and a row moves the ground between the guard's read and the removal and asserts the line names one link on one provider; and the DI-resolution test claimed to run with no plugin instance up, which no test can promise (`SSOPlugin.Instance` is process-wide and no harness resets it) - it now carries an id no test links, hands the container a typed logger, and asserts the outcome both states share. Two weak assertions went with it: a vacuous `NotNull` on a logger dropped, the count the line carries asserted.

**Pass 4, the lenses those notes came from re-run on that tree**: the seam change, the atomicity, the sanitizers and the analyzers all SAFE, with the count and the labels shown to come from the one acquisition that removes and persists, a failed persist discarding the filled collector with the restore, and the closed `ILogger<T>` registration shown to win over `AddLogging()` in either order. Three notes on the tests, none on the code, all **FIX** here: the DI-resolution row's "both states" premise was false for two harness shapes that leave a plugin with a null configuration behind, where the row's event drive logs the very warning it forbids (reproduced end to end) - the row now stands a real plugin instance up in the non-parallel collection, seeds a link in its live store and asserts the link gone and the one line through the logger the container wired; the race row could not tell names read inside the removal's lock from names read in acquisitions of their own between guard and removal - it pins the acquisition count now; and the store-throws row did not pin what its warning claims - it asserts no line reporting a removal and the link still in place.

**Pass 5, the test lens re-run on this tree**: its record follows as a comment before the merge, and the merge waits for it.

This PR replaces #1653 (#1652 and #1651 before it), each carrying the consumer without the fixes of the pass that reviewed it; none was merged, all closed by being superseded here.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. The consumer is one class over the existing revoke seam
      and one audit helper; the DI shell and the testable core are the two
      constructors the expiry sweep already uses.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The consumer lives in Linking, whose module edges already allow what it
      imports; the host's event types are host types, not Api modules.
- [x] Docs impact considered: the roster's own remark carries the change in what
      an orphan row now means; the wiki's Accounts page sentence about orphan
      rows is folded into #1643's documentation pass for this milestone.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3942 on net9.0 and 3943 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Seven tests drive the consumer, each proven against its own broken build before being trusted: with the removal skipped, the audit dropped, the failure rethrown, the seam naming every provider it touched, the event path throwing, the registration missing, a read of its own before the removal, and a line reported from the failure path, each break fails the rows that name it.

## Notes

- Enabling or disabling an account publishes nothing in the host (checked against its source), which is why this is the one transition the plugin can observe and why #1637's remaining window is closed by the readers checking what is true now rather than by an event.
- The walk server can show this live: delete a linked account in the dashboard and the roster row is gone on the next read, with the audit line in the log.
