### PR TITLE
Say how long a browser may keep a plugin asset, on both routes that serve one

### DIFF
--- a/SSO-Auth.Tests/Http/PluginAssetVersionTests.cs
+++ b/SSO-Auth.Tests/Http/PluginAssetVersionTests.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The one lifetime answer both asset routes give (#1627), pinned independently of either route: the tag is
+/// the plugin's file version, which the release build stamps per release, and the header is the one that
+/// makes a browser ask.
+/// </summary>
+public class PluginAssetVersionTests
+{
+    [Fact]
+    public void TheTag_IsThePluginsFileVersion_Quoted_AndStrong()
+    {
+        // Recomputed here from the same source, the SSO-Auth assembly's FILE version, so a regression to
+        // the assembly version (static across releases, #253) or to a weak tag is caught.
+        var fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(SSOPlugin).Assembly.Location).FileVersion;
+
+        Assert.Equal("\"" + fileVersion + "\"", PluginAssetVersion.ETag.ToString());
+        Assert.False(PluginAssetVersion.ETag.IsWeak);
+    }
+
+    [Fact]
+    public void TheHeader_MakesABrowserAsk_NotForget()
+    {
+        // no-cache keeps the asset and revalidates it; no-store would throw it away and re-download 300 KB
+        // of core script on every page load, and a max-age would only bound the stale window.
+        Assert.Equal("no-cache", PluginAssetVersion.CacheControl);
+    }
+}

--- a/SSO-Auth.Tests/Http/PluginPageCacheFilterTests.cs
+++ b/SSO-Auth.Tests/Http/PluginPageCacheFilterTests.cs
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The filter that gives the host-served plugin pages a lifetime (#1627). It runs on every action of the
+/// server, so most of these rows are about what it must NOT touch: another plugin's page, another action,
+/// a result that is not a file, and any request at all when something inside it throws. The rows that are
+/// about what it does pin the tag, the header and the 304, that an older tag is served in full and that a
+/// weakened one still validates.
+/// </summary>
+public class PluginPageCacheFilterTests
+{
+    private const string OurPage = "SSO-Auth-core.js";
+    private static readonly string CurrentTag = PluginAssetVersion.ETag.ToString();
+
+    [Fact]
+    public void OurPage_IsStampedWithTheVersionTagAndNoCache()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out _));
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        Assert.Same(served, context.Result);
+        Assert.Equal(CurrentTag, context.HttpContext.Response.Headers.ETag.ToString());
+        Assert.Equal("no-cache", context.HttpContext.Response.Headers.CacheControl.ToString());
+    }
+
+    [Fact]
+    public void OurPage_HeldAtTheCurrentVersion_IsA304_AndTheStreamIsReleased()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out var stream), ifNoneMatch: CurrentTag);
+
+        filter.OnResultExecuting(context);
+
+        var status = Assert.IsType<StatusCodeResult>(context.Result);
+        Assert.Equal(StatusCodes.Status304NotModified, status.StatusCode);
+        Assert.False(stream.CanRead);
+        // A 304 carries the validators the 200 would have, so the client keeps the same tag.
+        Assert.Equal(CurrentTag, context.HttpContext.Response.Headers.ETag.ToString());
+        Assert.Equal("no-cache", context.HttpContext.Response.Headers.CacheControl.ToString());
+    }
+
+    [Fact]
+    public void AnyVersion_CountsAsHeld()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out _), ifNoneMatch: "*");
+
+        filter.OnResultExecuting(context);
+
+        Assert.Equal(StatusCodes.Status304NotModified, Assert.IsType<StatusCodeResult>(context.Result).StatusCode);
+    }
+
+    [Fact]
+    public void OurPage_HeldAtAnOlderVersion_IsServedInFull()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out var stream), ifNoneMatch: "\"4.9.9.9\"");
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        Assert.Same(served, context.Result);
+        Assert.True(stream.CanRead);
+        Assert.Equal(CurrentTag, context.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    [Fact]
+    public void AWeakTag_Validates_AsTheStandardRequiresForIfNoneMatch()
+    {
+        // RFC 9110 requires the weak comparison for If-None-Match, and the plugin's own route answers that
+        // way through MVC. The tag is the version, so equal tags mean equal bytes; a W/ prefix arrives from
+        // an intermediary that recompressed the body, not from a different asset.
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out var stream), ifNoneMatch: "W/" + CurrentTag);
+
+        filter.OnResultExecuting(context);
+
+        Assert.Equal(StatusCodes.Status304NotModified, Assert.IsType<StatusCodeResult>(context.Result).StatusCode);
+        Assert.False(stream.CanRead);
+    }
+
+    [Fact]
+    public void TheHostsNameMatching_IsCaseInsensitive_AndSoIsThis()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage.ToUpperInvariant(), File(out _));
+
+        filter.OnResultExecuting(context);
+
+        Assert.Equal(CurrentTag, context.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    [Fact]
+    public void AnotherPluginsPage_PassesUntouched()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", "Some-Other-Plugin", File(out var stream));
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+        Assert.True(stream.CanRead);
+    }
+
+    [Fact]
+    public void AnotherAction_PassesUntouched_EvenWithOurName()
+    {
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetConfigurationPages", OurPage, File(out _));
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+    }
+
+    [Fact]
+    public void AnotherController_PassesUntouched_EvenWithTheHostsActionName()
+    {
+        var (filter, _) = Build();
+        var context = Context("SSOViews", "GetDashboardConfigurationPage", OurPage, File(out _));
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+    }
+
+    [Fact]
+    public void AResultThatIsNotAFile_PassesUntouched()
+    {
+        // The host answers 404 for a name nothing registers; a validator on that would be a lie.
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, new NotFoundResult(), ifNoneMatch: CurrentTag);
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+    }
+
+    [Fact]
+    public void WhileThePluginRegistersNoPage_NothingIsStamped()
+    {
+        var log = new CapturingLogger();
+        var filter = new PluginPageCacheFilter(() => Enumerable.Empty<string>(), log);
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out _), ifNoneMatch: CurrentTag);
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+        Assert.Empty(log.Entries);
+    }
+
+    [Fact]
+    public void APageListThatThrows_LeavesTheHostsResponseAsBuilt_AndWarns()
+    {
+        // The one property that makes a global filter safe to register: whatever fails inside it, the
+        // request it runs on is served exactly as the host built it.
+        var log = new CapturingLogger();
+        var filter = new PluginPageCacheFilter(() => throw new InvalidOperationException("boom"), log);
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out var stream), ifNoneMatch: CurrentTag);
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        AssertUntouched(context, served);
+        Assert.True(stream.CanRead);
+        var entry = Assert.Single(log.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("stands as it was", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheHostResolvesTheFilter_FromWhatTheRegistratorRegistered()
+    {
+        // The wiring is the one host-facing seam: the host builds its MVC options from every registration
+        // in the container, and resolves a service filter from the container per request. Built the way
+        // the outbound-client test builds it, this reads both back and drives one request through the
+        // resolved instance - a request for another action, which the filter answers before it asks the
+        // plugin instance for anything, so the outcome does not depend on whether one is up.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSingleton(Substitute.For<IUserManager>());
+        services.AddSingleton(Substitute.For<ICryptoProvider>());
+        new SsoOnlyServiceRegistrator().RegisterServices(services, Substitute.For<IServerApplicationHost>());
+        using var provider = services.BuildServiceProvider();
+
+        var filters = provider.GetRequiredService<IOptions<MvcOptions>>().Value.Filters;
+        Assert.Single(filters, f => f is ServiceFilterAttribute service && service.ServiceType == typeof(PluginPageCacheFilter));
+        var filter = provider.GetRequiredService<PluginPageCacheFilter>();
+
+        var context = Context("Dashboard", "GetConfigurationPages", OurPage, File(out _));
+        var served = context.Result;
+        filter.OnResultExecuting(context);
+        AssertUntouched(context, served);
+    }
+
+    private static void AssertUntouched(ResultExecutingContext context, IActionResult served)
+    {
+        Assert.Same(served, context.Result);
+        Assert.Empty(context.HttpContext.Response.Headers.ETag.ToString());
+        Assert.Empty(context.HttpContext.Response.Headers.CacheControl.ToString());
+    }
+
+    private static (PluginPageCacheFilter Filter, CapturingLogger Log) Build()
+    {
+        var log = new CapturingLogger();
+        return (new PluginPageCacheFilter(() => new[] { "SSO-Auth", "SSO-Auth.js", OurPage, "SSO-Auth.css" }, log), log);
+    }
+
+    // The host's result for a page: a stream over the embedded resource, which is what the filter must
+    // release when it answers 304 instead.
+    private static FileStreamResult File(out MemoryStream stream)
+    {
+        stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        return new FileStreamResult(stream, "application/javascript");
+    }
+
+    private static ResultExecutingContext Context(string controller, string action, string name, IActionResult result, string? ifNoneMatch = null)
+    {
+        var http = new DefaultHttpContext();
+        http.Request.QueryString = new QueryString("?name=" + Uri.EscapeDataString(name));
+        if (ifNoneMatch is not null)
+        {
+            http.Request.Headers.IfNoneMatch = ifNoneMatch;
+        }
+
+        var descriptor = new ControllerActionDescriptor { ControllerName = controller, ActionName = action };
+        var actionContext = new ActionContext(http, new RouteData(), descriptor);
+        return new ResultExecutingContext(actionContext, new List<IFilterMetadata>(), result, controller: new object());
+    }
+}

--- a/SSO-Auth.Tests/Http/PluginPageCacheFilterWiringTests.cs
+++ b/SSO-Auth.Tests/Http/PluginPageCacheFilterWiringTests.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The filter's one host-facing seam read back the way the host reads it (#1627): the instance the container
+/// resolves, through the public constructor, stamps the pages the LIVE plugin instance registers. It runs
+/// in the non-parallel collection because it stands a real plugin instance up, which makes the plugin being
+/// up a fact of this test rather than of whatever ran before it in the process.
+/// </summary>
+[Collection("SSOController")]
+public class PluginPageCacheFilterWiringTests
+{
+    [Fact]
+    public void TheResolvedFilter_StampsAPageTheLivePluginRegisters_AndNotOneItDoesNot()
+    {
+        _ = new SsoControllerHarness();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSingleton(Substitute.For<IUserManager>());
+        services.AddSingleton(Substitute.For<ICryptoProvider>());
+        new SsoOnlyServiceRegistrator().RegisterServices(services, Substitute.For<IServerApplicationHost>());
+        using var provider = services.BuildServiceProvider();
+        var filter = provider.GetRequiredService<PluginPageCacheFilter>();
+
+        // The core script is a registered PAGE and not a view: a source wired to the wrong list would
+        // leave it unstamped, and the 304 proves the tag came through the same source.
+        var page = Context("SSO-Auth-core.js", PluginAssetVersion.ETag.ToString());
+        filter.OnResultExecuting(page);
+        Assert.Equal(StatusCodes.Status304NotModified, Assert.IsType<StatusCodeResult>(page.Result).StatusCode);
+        Assert.Equal(PluginAssetVersion.ETag.ToString(), page.HttpContext.Response.Headers.ETag.ToString());
+
+        var other = Context("Some-Other-Plugin", PluginAssetVersion.ETag.ToString());
+        var served = other.Result;
+        filter.OnResultExecuting(other);
+        Assert.Same(served, other.Result);
+        Assert.Empty(other.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    private static ResultExecutingContext Context(string name, string ifNoneMatch)
+    {
+        var http = new DefaultHttpContext();
+        http.Request.QueryString = new QueryString("?name=" + name);
+        http.Request.Headers.IfNoneMatch = ifNoneMatch;
+        var descriptor = new ControllerActionDescriptor { ControllerName = "Dashboard", ActionName = "GetDashboardConfigurationPage" };
+        var result = new FileStreamResult(new System.IO.MemoryStream(new byte[] { 1 }), "application/javascript");
+        return new ResultExecutingContext(new ActionContext(http, new RouteData(), descriptor), new List<IFilterMetadata>(), result, controller: new object());
+    }
+}

--- a/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
+++ b/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
@@ -18,10 +18,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// Tests for <see cref="SSOViewsController.GetView"/> - the endpoint that serves the plugin's embedded
 /// view assets (the linking page, its stylesheet and scripts). The action itself resolves the requested
 /// name against <see cref="SSOPlugin.GetViews"/>, streams the matching embedded resource, and tags the
-/// response with the version-derived <c>AssetETag</c> so clients can 304-revalidate (#253). These tests
+/// response with the version-derived tag of <c>PluginAssetVersion</c> so clients can 304-revalidate (#253)
+/// and, since #1627, with no-cache so that they ask. These tests
 /// pin exactly that action-level behavior: an unknown name 404s, a known name streams the resource with
 /// the content type derived from the embedded resource path and the version ETag. The conditional
-/// <c>If-None-Match</c> → 304 negotiation is ASP.NET middleware, not this action, so it is out of scope.
+/// <c>If-None-Match</c> → 304 negotiation is MVC's file-result executor, not this action, so it is out of scope.
 ///
 /// Constructing an <see cref="SSOPlugin"/> sets the static <see cref="SSOPlugin.Instance"/> the
 /// controller reads, so these run in the non-parallel <c>SSOController</c> collection.
@@ -37,7 +38,11 @@ public class SSOViewsControllerTests
         var xml = Substitute.For<IXmlSerializer>();
         // Constructing the plugin sets the static SSOPlugin.Instance the controller reads for GetViews().
         _ = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
-        return new SSOViewsController(Substitute.For<ILogger<SSOViewsController>>());
+        return new SSOViewsController(Substitute.For<ILogger<SSOViewsController>>())
+        {
+            // The action writes a response header (#1627), so it needs a response to write it on.
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
     }
 
     // The version-derived ETag the action stamps on every asset, recomputed here from the same source the
@@ -48,6 +53,20 @@ public class SSOViewsControllerTests
         var fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(
             typeof(SSOPlugin).Assembly.Location).FileVersion;
         return "\"" + fileVersion + "\"";
+    }
+
+    [Fact]
+    public void GetView_KnownView_SaysABrowserMustAskBeforeReusingIt()
+    {
+        // The tag alone left the decision to the browser's heuristics (#1627): a client that never asked
+        // could run a previous release's asset for as long as it liked. no-cache is what makes it ask,
+        // and with the tag the answer is a 304 until the plugin changes.
+        var controller = CreateController();
+
+        var result = controller.GetView("style.css");
+
+        Assert.IsType<FileStreamResult>(result);
+        Assert.Equal("no-cache", controller.Response.Headers.CacheControl.ToString());
     }
 
     [Fact]
@@ -154,7 +173,7 @@ public class SSOViewsControllerTests
     {
         var controller = CreateController();
 
-        // The comment on AssetETag documents that one tag for every asset is intentional: a client sends
+        // The remarks on PluginAssetVersion document that one tag for every asset is intentional: a client sends
         // back the tag it cached for a given URL and the server compares it against that URL's tag.
         var html = Assert.IsType<FileStreamResult>(controller.GetView("linking"));
         var css = Assert.IsType<FileStreamResult>(controller.GetView("style.css"));

--- a/SSO-Auth/Api/Http/PluginAssetVersion.cs
+++ b/SSO-Auth/Api/Http/PluginAssetVersion.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
+
+/// <summary>
+/// The one answer to "how long may a browser keep one of this plugin's assets" (#1627), shared by the two
+/// routes that serve them: the plugin's own <see cref="SSOViewsController"/>, and the host's
+/// <c>web/ConfigurationPage</c> action through <see cref="PluginPageCacheFilter"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The assets are embedded in the assembly, so they change exactly when the plugin's file version does,
+/// and the file version is what the build stamps per release; the assembly version can stay static across
+/// releases and would then validate stale assets after an upgrade (#253). One tag for every asset is
+/// correct: a client sends the tag it cached for a URL, and the server compares it against that URL's
+/// current tag.
+/// </para>
+/// <para>
+/// <c>no-cache</c> rather than a lifetime: a browser may keep the asset but must ask before using it, and
+/// with the tag the answer is a 304 until the plugin changes. Without the header a browser falls back to
+/// heuristic freshness and can run the previous release's script for as long as it likes after an
+/// upgrade, with nothing on the page saying so; a fixed lifetime would only bound that, not end it.
+/// </para>
+/// </remarks>
+internal static class PluginAssetVersion
+{
+    /// <summary>
+    /// The <c>Cache-Control</c> value every plugin asset carries: keep it, but ask before using it.
+    /// </summary>
+    internal const string CacheControl = "no-cache";
+
+    /// <summary>
+    /// Gets the strong entity tag every plugin asset carries: the plugin's file version, quoted.
+    /// </summary>
+    internal static EntityTagHeaderValue ETag { get; } = new(
+        "\"" + System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(PluginAssetVersion).Assembly.Location).FileVersion + "\"");
+}

--- a/SSO-Auth/Api/Http/PluginPageCacheFilter.cs
+++ b/SSO-Auth/Api/Http/PluginPageCacheFilter.cs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
+
+/// <summary>
+/// Gives the plugin's pages and page scripts, which the host serves from its own <c>web/ConfigurationPage</c>
+/// action, the lifetime answer the plugin's own asset route gives (#1627): the version tag and
+/// <c>no-cache</c>, and a 304 for a browser that already holds the current version.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The host serves a plugin's registered pages with no validator and no lifetime, and its web client loads
+/// a page and its script under the registered name, so nothing on the plugin side can put a version into
+/// those URLs. What a plugin can do is register a result filter with the host's MVC options and act on that
+/// one action, for its own names only: every other action, and every other plugin's page, passes through
+/// exactly as the host built it.
+/// </para>
+/// <para>
+/// NOTHING HERE MAY FAIL A REQUEST. A filter registered with the options runs on every action of the
+/// server, so a failure inside it would fail responses that are not this plugin's to fail. The predicate
+/// and the stamping are wrapped: on any exception the response stands as it was at that moment, as the
+/// host built it or, once the 304 has been chosen, that 304, and the failure is logged at Warning.
+/// </para>
+/// <para>
+/// The action is reachable without authentication today, so the 304 grants nothing a 200 would not, and
+/// the tag is the plugin's file version, which <see cref="SSOViewsController"/> has exposed the same way
+/// since #253 (T-I, decided on #1627).
+/// </para>
+/// </remarks>
+internal sealed class PluginPageCacheFilter : IResultFilter
+{
+    // The host's action, named the way MVC names it: the controller's class name without its suffix, and
+    // the method name. A rename in the host turns this filter into a no-op, never into a wrong stamp.
+    private const string HostController = "Dashboard";
+    private const string HostAction = "GetDashboardConfigurationPage";
+
+    private readonly Func<IEnumerable<string>> _pageNames;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginPageCacheFilter"/> class for the host's container:
+    /// the names it stamps are the pages the live plugin instance registers, and none while the plugin
+    /// instance is not up.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public PluginPageCacheFilter(ILogger<PluginPageCacheFilter> logger)
+        : this(() => SSOPlugin.Instance is { } plugin ? plugin.GetPages().Select(page => page.Name) : Enumerable.Empty<string>(), logger)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginPageCacheFilter"/> class over an explicit source
+    /// of page names, which is what the tests hand it.
+    /// </summary>
+    /// <param name="pageNames">Yields the registered page names this filter stamps.</param>
+    /// <param name="logger">The logger.</param>
+    internal PluginPageCacheFilter(Func<IEnumerable<string>> pageNames, ILogger logger)
+    {
+        _pageNames = pageNames ?? throw new ArgumentNullException(nameof(pageNames));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        try
+        {
+            if (context.ActionDescriptor is not ControllerActionDescriptor { ControllerName: HostController, ActionName: HostAction }
+                || context.Result is not FileStreamResult file)
+            {
+                return;
+            }
+
+            // The host matches the name without regard to case, so this does too: a name the host serves
+            // under this plugin's registration is a name this plugin stamps.
+            var name = context.HttpContext.Request.Query["name"].ToString();
+            if (!_pageNames().Any(registered => string.Equals(registered, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            var headers = context.HttpContext.Response.Headers;
+            headers.ETag = PluginAssetVersion.ETag.ToString();
+            headers.CacheControl = PluginAssetVersion.CacheControl;
+
+            if (HoldsCurrentVersion(context.HttpContext.Request))
+            {
+                // The 304 is in place before the stream the host opened over the embedded resource is
+                // released, so a release that failed would leave the right answer behind, not a
+                // half-released file result for the executor.
+                context.Result = new StatusCodeResult(StatusCodes.Status304NotModified);
+                file.FileStream.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[SSO] Could not finish deciding the cache lifetime of a plugin page; the response stands as it was at that moment.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void OnResultExecuted(ResultExecutedContext context)
+    {
+    }
+
+    // The weak comparison, as RFC 9110 requires for If-None-Match and as the plugin's own route answers
+    // through MVC: the tag is the version, so equal tags mean equal bytes, and a W/ prefix arrives from an
+    // intermediary that recompressed the body, not from a different asset. `*` is a client asking for
+    // anything the server holds, which for a stored asset is the current one.
+    private static bool HoldsCurrentVersion(HttpRequest request)
+    {
+        return EntityTagHeaderValue.TryParseList(request.Headers.IfNoneMatch, out var tags)
+            && tags.Any(tag => tag.Equals(EntityTagHeaderValue.Any) || tag.Compare(PluginAssetVersion.ETag, useStrongComparison: false));
+    }
+}

--- a/SSO-Auth/Api/Http/SSOViewsController.cs
+++ b/SSO-Auth/Api/Http/SSOViewsController.cs
@@ -21,16 +21,6 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
 [Route("[controller]")]
 public class SSOViewsController : ControllerBase
 {
-    // The embedded view assets only change with the plugin version, so a version-derived ETag lets clients
-    // 304-revalidate instead of re-downloading jellyfin-apiClient.esm.min.js (~79 KB) + emby-restyle.css on
-    // every linking-page load (#253). Derived from the FILE version (set per release by the build), not the
-    // AssemblyVersion (which can stay static across releases and would then serve stale assets after an
-    // update). The same tag across assets is correct: a client sends the ETag it cached for a given URL, and
-    // the server compares it against that URL's current tag.
-    private static readonly EntityTagHeaderValue AssetETag = new EntityTagHeaderValue(
-        "\"" + System.Diagnostics.FileVersionInfo.GetVersionInfo(
-            typeof(SSOViewsController).Assembly.Location).FileVersion + "\"");
-
     private readonly ILogger<SSOViewsController> _logger;
 
     /// <summary>
@@ -71,7 +61,11 @@ public class SSOViewsController : ControllerBase
             return NotFound();
         }
 
-        return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath), lastModified: null, entityTag: AssetETag);
+        // The version tag lets a client 304-revalidate instead of re-downloading jellyfin-apiClient.esm.min.js
+        // (~79 KB) and emby-restyle.css on every linking-page load (#253); no-cache is what makes it ask
+        // (#1627). Both are PluginAssetVersion's, the one answer both asset routes give.
+        Response.Headers.CacheControl = PluginAssetVersion.CacheControl;
+        return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath), lastModified: null, entityTag: PluginAssetVersion.ETag);
     }
 
     /// <summary>

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using Jellyfin.Data.Events.Users;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
@@ -10,6 +11,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Plugins;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Jellyfin.Plugin.SSO_Auth;
@@ -17,10 +19,12 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// <summary>
 /// Registers the plugin's host-side services with Jellyfin's DI container (#165). Jellyfin discovers
 /// <see cref="IPluginServiceRegistrator"/> implementations in plugin assemblies (via a parameterless
-/// constructor) and calls <see cref="RegisterServices"/> while building the generic host. Two things are
-/// registered: the boot-time SSO-only reconciliation (<see cref="SsoOnlyReconciliationService"/>), which
-/// makes the documented <c>config.xml</c> total-lockout recovery genuinely restore password login; and the
-/// SSRF-hardened outbound HTTP client the OpenID backchannel uses (#755).
+/// constructor) and calls <see cref="RegisterServices"/> while building the generic host. Registered here,
+/// each with its reason beside it: the hosted services (the boot-time SSO-only reconciliation, which makes
+/// the documented <c>config.xml</c> total-lockout recovery genuinely restore password login; the
+/// passwordless-link sweep; the account-expiry sweep; the login-button manager), the consumer of the host's
+/// user-deleted event, the page-cache filter, and the two tiers of the SSRF-hardened outbound HTTP client
+/// the OpenID backchannel uses (#755).
 /// </summary>
 public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
 {
@@ -50,6 +54,15 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // consumer of the closed event type from the container, which is why this is a registration and
         // not a subscription.
         serviceCollection.AddScoped<IEventConsumer<UserDeletedEventArgs>, DeletedAccountLinkPruner>();
+
+        // Gives the plugin's pages and page scripts, which the host serves from its own action with no
+        // validator and no lifetime, the version tag and no-cache the plugin's own asset route carries, and
+        // a 304 for a browser that holds the current version (#1627). Registered with the host's MVC
+        // options because that is the one seam a plugin has into an action it does not own; the filter
+        // acts on that action and this plugin's own names only, and leaves every other response as the
+        // host built it. Resolved from the container per request, so it carries a logger of its own.
+        serviceCollection.AddSingleton<PluginPageCacheFilter>();
+        serviceCollection.Configure<MvcOptions>(options => options.Filters.AddService<PluginPageCacheFilter>());
 
         // Keeps the login-page "Sign in with …" buttons (#722) in sync with the configured providers by
         // splicing a managed block into the server's branding login disclaimer on every config change.


### PR DESCRIPTION
# What & why

The plugin served its browser assets with no lifetime at all (#1627). Its own route, `SSOViews/*`, has carried a version-derived `ETag` since #253 but never the header that makes a browser ask; the host's `web/ConfigurationPage` action, which serves the five pages, their page scripts and `sso-core.js`, sends no validator and no lifetime for any plugin's page. A browser then decides on its own how long to keep them, and after an upgrade an administrator can go on running the previous release's script for an unbounded time with nothing on the page saying so.

One answer, two routes. `PluginAssetVersion` holds it: the plugin's file version as a strong tag, and `no-cache`, which lets a browser keep an asset but makes it ask before using it, so the answer is a 304 until the plugin changes. `SSOViews/*` stamps both. For the host's action the plugin registers one result filter with the host's MVC options, the one seam a plugin has into an action it does not own: `PluginPageCacheFilter` acts on that action only and only for names this plugin registers, stamps the tag and `no-cache`, and answers a matching `If-None-Match` with 304 so a tab switch does not re-download 300 KB of core script. Everything else passes through exactly as the host built it. The shape was decided on the issue, with the STRIDE notes the review holds against.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

Not on that list, but a filter registered with the host's options runs on every action of the server, so the review ran with the availability lens first.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here grants: a 304 carries no
      body on an action reachable without authentication today, and a failure
      anywhere inside the filter leaves the host's response as built.
- [x] No secrets logged; secrets are redacted on config export. The warning
      carries no request value; the tag is the plugin's file version, exposed
      the same way by `SSOViews/*` since #253.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Performed for this one all
      the same; record below.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** as raised. Detail below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP value
      reaches the line.

### Review record

**Pass 1, the adversarial review of the first cut** (#1658), every lens SAFE on the host's source and MVC's: the filter is skipped where an authorization filter short-circuits and costs one type check elsewhere; a replaced result is executed by the invoker and the client-error filter leaves a 304 alone; the plugin's registration precedes the host's MVC setup and neither the host's option setups nor its `AddMvc` clear the filter list; the host's action and the plugin's own route are both anonymous today, so the 304 grants nothing; the 304 carries the validators, no body and no content type. Two notes and three housekeeping items, all **FIX** here: `If-None-Match` was compared strongly, where RFC 9110 requires the weak comparison and MVC's own executor on the plugin route uses it, so a tag an intermediary weakened would have been served in full on one route and validated on the other - weak now, with the row flipped and the reasoning corrected (equal tags mean equal bytes; a `W/` prefix comes from a recompressed body, not a different asset); the production page-name source was executed by no row - a row in the non-parallel collection now stands a real plugin instance up and drives the resolved filter over a page it registers and one it does not; the 304 is now in place before the stream is released; `PluginAssetVersion` has its mirrored test file; two doc comments naming the old field are reworded. One design note declined with reason: wrapping the filter's construction in a factory that yields a no-op on failure would extend the guarantee to a path that cannot fail today (one public constructor over a logger the host always has); noted, not built.

**Pass 2, the two lenses those notes came from re-run on that tree** (#1659): both SAFE. The comparison is now exactly what MVC's file-result executor does for `If-None-Match` (weak compare, `*`, the same parser for a malformed header), the 304 path carries the validators on both routes, in-process response compression never weakens the tag (the shipped assembly carries no `W/`), so a weakened tag comes only from an external proxy as the comment says; the wiring row is hermetic in the non-parallel collection, executes the public constructor's page source, and a source wired to the view list fails it; the mirror, doors and module rules accept the files. Three notes, all wording, all **FIX** here: the class remark and the warning said the response is left as the host built it, which is false for the one branch where a stream release fails after the 304 has been chosen - both say now that the response stands as it was at that moment; one assertion in the registrator row could not fail once the predicate before it passed - dropped; two pre-existing comments were stale (the 304 negotiation named as middleware, the registrator's summary counting two registrations) - reworded. No behaviour changed and no third pass was run: the build, the rows and the suites are the verification of wording.

This PR replaces #1659 (#1658 before it): the first carried the first cut, the second the fixes of pass 1; neither was merged, both closed by being superseded here.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. One static answer, one filter, one line in the view route.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      Both new types live in `Api/Http`, the web boundary; no new module edge.
- [x] Docs impact considered: the behaviour is what an administrator expects
      of an upgrade and needs no page of its own; the reason for the shape is
      written on #1627 and in `PluginAssetVersion`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both frameworks, 0
      warnings.
- [x] `dotnet test` is green. 3959 on net9.0 and 3960 on net10.0, 0 failed, 4
      skipped (the loopback-bind rows that need an administrator on Windows).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This
      change touches none.

Thirteen rows drive the filter, one in the non-parallel collection drives the resolved instance over a real plugin, two pin the shared answer and one the view route, each proven against a broken build before being trusted: one build with the weak tag refused, the action name ignored, the failure rethrown, the registration dropped and the view route's header dropped fails exactly the rows that name those; a second build whose name comparison can never match fails exactly the rows that need a stamp; a third with the resolved filter reading the view list instead of the page list and the header changed to no-store fails the wiring row and the header rows; every other row stays green on all three.

## Notes

- Live on the walk server (Jellyfin 12.0, this branch built and stamped the way the release build stamps it, as 5.0.0.85 before the review's fixes and as 5.0.0.86 with them), driven with curl: `web/ConfigurationPage?name=SSO-Auth-core.js` answers 200 with `Cache-Control: no-cache` and `ETag: "5.0.0.85"`; the same request with `If-None-Match: "5.0.0.85"` answers 304 carrying both validators; with `If-None-Match: "5.0.0.84"`, the tag a browser holds from the previous build, it answers 200 with the new asset, which is the upgrade walk without a hard reload. The page itself and `SSOViews/i18n.js` answer the same way, and on 5.0.0.86 a weakened tag, `If-None-Match: W/"5.0.0.86"`, answers 304 on both routes, which is the review's first note closed live. TMDb's page, served by the same host action, carries neither header.
- The tag changes with every release because the release build (JPRM) writes the version into `<FileVersion>` before it builds; checked on the released `5.0.0-JF12-beta.82` artifact, whose assembly carries file version 5.0.0.82. A local `dotnet publish` carries the fixed 5.0.0, which is why the walk build was stamped by hand.
- The host could carry the validators itself for every plugin's page; that is a change to Jellyfin, not to this plugin, and is not proposed here.
