### PR TITLE
Condense the Providers page help into a sentence and a fold [#1663]

### DIFF
--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -272,10 +272,13 @@ function condenseHelp(root) {
   // two is unreachable from the rail either way. A Map built from pairs silently kept the LAST, which is
   // the harder of the two to notice on a page, so this at least fails in document order.
   //
-  // THE SHAPE IS NOT REFUSED ANYWHERE, and saying so is the point of this note. No page carries it
-  // today - all twenty blocks on the three condensed pages resolve to distinct elements, counted - and
-  // the Providers page, which the next slice feeds this code, carries 112 sites in 98 keys and is where
-  // it would first arise. The fold and the sentence under the field are unaffected; only the rail is.
+  // THE SHAPE IS REFUSED NOW, AND THIS NOTE SAID IT WAS REFUSED NOWHERE. It said so correctly while the
+  // Providers page was still flat; that page joined the slice in #1663, which is where the note said the
+  // shape would first arise, and the refusal landed with it. tools/ui-condensed-help.js reads the field
+  // each condensed block resolves to - the same walk `fieldOf` below makes - and refuses two blocks
+  // sharing one, naming the key it keeps and the key the rail can no longer reach. No page carries the
+  // shape; what the refusal holds is the next edit that would. The fold and the sentence under the field
+  // are unaffected by it either way; only the rail is.
   const fields = new Map();
   helps.forEach((help) => {
     const field = fieldOf(help);

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -124,7 +124,10 @@
             aria-live="polite"
           ></div>
 
-          <div class="sso-columns sso-columns--rail-first">
+          <div
+            class="sso-columns sso-columns--rail-first"
+            data-sso-condensed-help
+          >
             <div class="sso-column-main">
               <!--
             Configuration check (#1084): ONE action across every configured OpenID and SAML provider,
@@ -215,21 +218,29 @@
                     >
                       No SSO providers yet
                     </p>
-                    <p
-                      class="fieldDescription"
-                      data-i18n-parts="config.oidc_empty_help"
-                    >
-                      Add an OpenID Connect provider to let users sign in
-                      through your identity provider. See the
-                      <a
-                        is="emby-linkbutton"
-                        href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
-                        class="button-link"
-                        data-i18n="config.link_quickstart"
-                        >quick-start guide</a
-                      >
-                      to get the endpoint, client id and secret from your
-                      provider.
+                    <p class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.oidc_empty_help"
+                        >
+                          Add an OpenID Connect provider to let users sign in
+                          through your identity provider. See the
+                          <a
+                            is="emby-linkbutton"
+                            href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
+                            class="button-link"
+                            data-i18n="config.link_quickstart"
+                            >quick-start guide</a
+                          >
+                          to get the endpoint, client id and secret from your
+                          provider.
+                        </div>
+                      </details>
                     </p>
                     <!--
                   First-run guided path (#1085). The steps NAME the controls that already exist inside the
@@ -456,16 +467,24 @@
                       role="status"
                       aria-live="polite"
                     ></div>
-                    <div
-                      class="fieldDescription"
-                      data-i18n="config.template_picker_help"
-                    >
-                      Pre-fills the scopes, role-claim path, username claim, and
-                      an endpoint placeholder for a known identity provider, and
-                      enables only the compatibility options it needs. Review
-                      every field &mdash; especially the endpoint &mdash; and
-                      enter your client secret before saving. Nothing is saved
-                      automatically.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.template_picker_help"
+                        >
+                          Pre-fills the scopes, role-claim path, username claim,
+                          and an endpoint placeholder for a known identity
+                          provider, and enables only the compatibility options
+                          it needs. Review every field &mdash; especially the
+                          endpoint &mdash; and enter your client secret before
+                          saving. Nothing is saved automatically.
+                        </div>
+                      </details>
                     </div>
                   </div>
 
@@ -517,19 +536,28 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_name_help"
-                        >
-                          The name used by Jellyfin to identify the OpenID
-                          provider.
-                          <br />
-                          If an OpenID provider with a matching name does not
-                          exist, a new provider with this name will be created.
-                          <br />
-                          If an OpenID provider with a matching name already
-                          exists, the settings for that provider will be
-                          updated.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_name_help"
+                            >
+                              The name used by Jellyfin to identify the OpenID
+                              provider.
+                              <br />
+                              If an OpenID provider with a matching name does
+                              not exist, a new provider with this name will be
+                              created.
+                              <br />
+                              If an OpenID provider with a matching name already
+                              exists, the settings for that provider will be
+                              updated.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -574,28 +602,39 @@
                           aria-live="polite"
                         ></div>
                         <div
-                          class="fieldDescription"
+                          class="fieldDescription sso-help"
                           id="OidRedirectUri-help"
-                          data-i18n-parts="config.oid_redirect_uri_help"
                         >
-                          The exact redirect URI the login uses. Register it
-                          verbatim at your identity provider. The server builds
-                          it and this field shows what the server answered, so
-                          it is the same string the login sends rather than a
-                          copy of it. Save the provider first: an unsaved one
-                          has nothing for the server to answer for. It is built
-                          from the
-                          <strong data-i18n="config.base_url_override_name"
-                            >Base URL Override</strong
-                          >
-                          (in the Advanced section) when set, otherwise this
-                          server's address; if you sit behind a reverse proxy,
-                          set that override and save, so this matches what the
-                          login actually sends. Users who still start at the
-                          legacy <code>/sso/OID/p/&lt;name&gt;</code> route send
-                          the legacy
-                          <code>/sso/OID/r/&lt;name&gt;</code> spelling instead;
-                          register that one too if any of them do.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_redirect_uri_help"
+                            >
+                              The exact redirect URI the login uses. Register it
+                              verbatim at your identity provider. The server
+                              builds it and this field shows what the server
+                              answered, so it is the same string the login sends
+                              rather than a copy of it. Save the provider first:
+                              an unsaved one has nothing for the server to
+                              answer for. It is built from the
+                              <strong data-i18n="config.base_url_override_name"
+                                >Base URL Override</strong
+                              >
+                              (in the Advanced section) when set, otherwise this
+                              server's address; if you sit behind a reverse
+                              proxy, set that override and save, so this matches
+                              what the login actually sends. Users who still
+                              start at the legacy
+                              <code>/sso/OID/p/&lt;name&gt;</code> route send
+                              the legacy
+                              <code>/sso/OID/r/&lt;name&gt;</code> spelling
+                              instead; register that one too if any of them do.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -623,12 +662,20 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_endpoint_help"
-                        >
-                          The OpenID endpoint. Must have a .well-known path
-                          available.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_endpoint_help"
+                            >
+                              The OpenID endpoint. Must have a .well-known path
+                              available.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -656,17 +703,25 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_client_id_help"
-                        >
-                          The OpenID client ID, for this media server instance.
-                          This is configured on the OIDC provider to uniquely
-                          identify
-                          <strong data-i18n="config.oid_client_id_this"
-                            >this</strong
-                          >
-                          Jellyfin instance.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_client_id_help"
+                            >
+                              The OpenID client ID, for this media server
+                              instance. This is configured on the OIDC provider
+                              to uniquely identify
+                              <strong data-i18n="config.oid_client_id_this"
+                                >this</strong
+                              >
+                              Jellyfin instance.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -691,14 +746,22 @@
                           data-i18n-placeholder="config.placeholder_keep_secret"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_secret_help"
-                        >
-                          The OpenID client secret. Randomly generated & shared.
-                          For security it is never sent back to this page: leave
-                          it blank to keep the stored value, or enter a new
-                          secret to replace it.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_secret_help"
+                            >
+                              The OpenID client secret. Randomly generated &
+                              shared. For security it is never sent back to this
+                              page: leave it blank to keep the stored value, or
+                              enter a new secret to replace it.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -726,26 +789,34 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_scopes_help"
-                        >
-                          Specify additional scopes to include in the OIDC
-                          request.
-                          <br />
-                          One scope per line, each line should contain a scope
-                          name to include in the OIDC request.
-                          <br />
-                          For some OIDC providers (For example,
-                          <a
-                            is="emby-linkbutton"
-                            href="https://github.com/9p4/jellyfin-plugin-sso/issues/23#issuecomment-1112237616"
-                            class="button-link"
-                            >authelia</a
-                          >), additional scopes may be required in order to
-                          validate group membership in role claim.
-                          <br />
-                          Leave blank to only request the default scopes.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_scopes_help"
+                            >
+                              Specify additional scopes to include in the OIDC
+                              request.
+                              <br />
+                              One scope per line, each line should contain a
+                              scope name to include in the OIDC request.
+                              <br />
+                              For some OIDC providers (For example,
+                              <a
+                                is="emby-linkbutton"
+                                href="https://github.com/9p4/jellyfin-plugin-sso/issues/23#issuecomment-1112237616"
+                                class="button-link"
+                                >authelia</a
+                              >), additional scopes may be required in order to
+                              validate group membership in role claim.
+                              <br />
+                              Leave blank to only request the default scopes.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -783,15 +854,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.provider_hide_login_button_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Excludes this provider from the managed "Sign in with
-                          …" block on the login page while keeping it usable
-                          through its direct start URL. Only takes effect while
-                          the global "Manage login buttons on the login page"
-                          option is on; it never hides anything you added to the
-                          branding yourself.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_hide_login_button_help"
+                            >
+                              Excludes this provider from the managed "Sign in
+                              with …" block on the login page while keeping it
+                              usable through its direct start URL. Only takes
+                              effect while the global "Manage login buttons on
+                              the login page" option is on; it never hides
+                              anything you added to the branding yourself.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -813,16 +894,24 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provider_login_button_text_help"
-                        >
-                          Custom label for this provider's managed login-page
-                          button. Leave blank to use the provider name. Only
-                          takes effect while the global "Manage login buttons on
-                          the login page" option is on and the button is not
-                          hidden; any text is safe: it is always rendered inert,
-                          never as markup.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_login_button_text_help"
+                            >
+                              Custom label for this provider's managed
+                              login-page button. Leave blank to use the provider
+                              name. Only takes effect while the global "Manage
+                              login buttons on the login page" option is on and
+                              the button is not hidden; any text is safe: it is
+                              always rendered inert, never as markup.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -844,18 +933,26 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_post_logout_redirect_help"
-                        >
-                          The URL the identity provider returns the browser to
-                          after an RP-initiated OpenID logout, sent as
-                          post_logout_redirect_uri. Honoured only if it is an
-                          absolute http(s) URL at or under this server's base
-                          URL; an off-base or malformed value is rejected on
-                          save. Leave blank for no post-logout redirect. Only
-                          takes effect while the global "Enable Single Logout"
-                          option is on.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_post_logout_redirect_help"
+                            >
+                              The URL the identity provider returns the browser
+                              to after an RP-initiated OpenID logout, sent as
+                              post_logout_redirect_uri. Honoured only if it is
+                              an absolute http(s) URL at or under this server's
+                              base URL; an off-base or malformed value is
+                              rejected on save. Leave blank for no post-logout
+                              redirect. Only takes effect while the global
+                              "Enable Single Logout" option is on.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -887,17 +984,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.enable_authorization_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines if the plugin sets permissions for the
-                          user.
-                          <br />
-                          If false, the user will start with no permissions and
-                          an administrator will add permissions.
-                          <br />
-                          The permissions of existing users will not be
-                          rewritten on subsequent logins.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.enable_authorization_help"
+                            >
+                              Determines if the plugin sets permissions for the
+                              user.
+                              <br />
+                              If false, the user will start with no permissions
+                              and an administrator will add permissions.
+                              <br />
+                              The permissions of existing users will not be
+                              rewritten on subsequent logins.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -920,13 +1027,21 @@
                           class="sso-text"
                           placeholder="preferred_username"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.default_username_claim_help"
-                        >
-                          The default username claim to use from OpenID by
-                          default. If it is not set, it defaults to
-                          <code>preferred_username</code>.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.default_username_claim_help"
+                            >
+                              The default username claim to use from OpenID by
+                              default. If it is not set, it defaults to
+                              <code>preferred_username</code>.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -948,19 +1063,27 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.default_provider_help"
-                        >
-                          The set provider then gets assigned to the user after
-                          they have logged in. If it is not set, nothing is
-                          changed. With this, a user can login with SSO but is
-                          still able to log in via other providers later.<br />A
-                          common option is
-                          <code
-                            >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                          >
-                          for the default provider.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.default_provider_help"
+                            >
+                              The set provider then gets assigned to the user
+                              after they have logged in. If it is not set,
+                              nothing is changed. With this, a user can login
+                              with SSO but is still able to log in via other
+                              providers later.<br />A common option is
+                              <code
+                                >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
+                              >
+                              for the default provider.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -982,13 +1105,21 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.avatar_url_format_help"
-                        >
-                          The url of the avatar with sso variable format:
-                          example :
-                          <code>https://example.com/@{user_id}.png</code>
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.avatar_url_format_help"
+                            >
+                              The url of the avatar with sso variable format:
+                              example :
+                              <code>https://example.com/@{user_id}.png</code>
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1009,12 +1140,22 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.avatar_no_fetch_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          With no avatar url format above, the standard OIDC
-                          <code>picture</code> claim is used automatically.
-                          Check this to opt out of that fetch entirely.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.avatar_no_fetch_help"
+                            >
+                              With no avatar url format above, the standard OIDC
+                              <code>picture</code> claim is used automatically.
+                              Check this to opt out of that fetch entirely.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1042,24 +1183,35 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.role_claim_help"
-                        >
-                          This is the value in the OpenID response to check for
-                          roles. The first element is the claim type, the
-                          subsequent values are to parse the JSON of the claim
-                          value. Use a
-                          <code>"\."</code> to denote a literal ".". This
-                          expects a list of strings from the OIDC server, unless
-                          "Role claim is an object map" below is on.
-                          <br />
-                          For Keycloak, it is <code>realm_access.roles</code> by
-                          default for realm roles. For client roles, it is
-                          <code>resource_access.&gt;clientId&lt;.roles</code>
-                          (e.g. resource_access.jellyfin.roles)
-                          <br />
-                          For Authelia, it is <code>groups</code>
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.role_claim_help"
+                            >
+                              This is the value in the OpenID response to check
+                              for roles. The first element is the claim type,
+                              the subsequent values are to parse the JSON of the
+                              claim value. Use a
+                              <code>"\."</code> to denote a literal ".". This
+                              expects a list of strings from the OIDC server,
+                              unless "Role claim is an object map" below is on.
+                              <br />
+                              For Keycloak, it is
+                              <code>realm_access.roles</code> by default for
+                              realm roles. For client roles, it is
+                              <code
+                                >resource_access.&gt;clientId&lt;.roles</code
+                              >
+                              (e.g. resource_access.jellyfin.roles)
+                              <br />
+                              For Authelia, it is <code>groups</code>
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1080,24 +1232,35 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.role_claim_object_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Read the roles from the property
-                          <em data-i18n="config.role_claim_names_emphasis"
-                            >names</em
-                          >
-                          of a JSON object instead of from a list of strings.
-                          Zitadel needs this: it emits
-                          <code
-                            >{"jellyfin-access": {"&lt;orgId&gt;":
-                            "&lt;domain&gt;"}}</code
-                          >
-                          under <code>urn:zitadel:iam:org:project:roles</code>.
-                          Only the names are read, never the values, never
-                          nested objects. Off by default; leave it off for a
-                          provider that returns a list (Keycloak, Authelia,
-                          authentik).
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.role_claim_object_help"
+                            >
+                              Read the roles from the property
+                              <em data-i18n="config.role_claim_names_emphasis"
+                                >names</em
+                              >
+                              of a JSON object instead of from a list of
+                              strings. Zitadel needs this: it emits
+                              <code
+                                >{"jellyfin-access": {"&lt;orgId&gt;":
+                                "&lt;domain&gt;"}}</code
+                              >
+                              under
+                              <code>urn:zitadel:iam:org:project:roles</code>.
+                              Only the names are read, never the values, never
+                              nested objects. Off by default; leave it off for a
+                              provider that returns a list (Keycloak, Authelia,
+                              authentik).
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -1123,15 +1286,24 @@
                     class="verticalSection verticalSection-extrabottompadding"
                   >
                     <div class="collapseContent">
-                      <div
-                        class="fieldDescription"
-                        data-i18n="config.template_help"
-                      >
-                        What a brand-new account created by this provider starts
-                        with. Every field is opt-in: anything you leave alone
-                        keeps Jellyfin's own default, and these values are
-                        written once, when the account is created, so a change
-                        made later survives every following login.
+                      <div class="fieldDescription sso-help">
+                        <span class="sso-help-lead"></span>
+                        <details class="sso-help-full">
+                          <summary data-i18n="config.help_full_text">
+                            Full text
+                          </summary>
+                          <div
+                            class="sso-help-body"
+                            data-i18n="config.template_help"
+                          >
+                            What a brand-new account created by this provider
+                            starts with. Every field is opt-in: anything you
+                            leave alone keeps Jellyfin's own default, and these
+                            values are written once, when the account is
+                            created, so a change made later survives every
+                            following login.
+                          </div>
+                        </details>
                       </div>
                       <div
                         id="Tmpl-profile-note"
@@ -1169,18 +1341,26 @@
                           name="ProvisioningProfile"
                           class="sso-tmpl-profile emby-select-withcolor emby-select"
                         ></select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provisioning_profile_help"
-                        >
-                          Take the starting policy from a profile defined in
-                          Provisioning Profiles above, instead of from the
-                          fields below. The two are mutually exclusive: a
-                          provider that names a profile and also carries its own
-                          inline fields is refused on save, because one
-                          account-creation policy has one source. Leave it on
-                          (none), or set it back to (none) and save, to use the
-                          fields below again.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provisioning_profile_help"
+                            >
+                              Take the starting policy from a profile defined in
+                              Provisioning Profiles above, instead of from the
+                              fields below. The two are mutually exclusive: a
+                              provider that names a profile and also carries its
+                              own inline fields is refused on save, because one
+                              account-creation policy has one source. Leave it
+                              on (none), or set it back to (none) and save, to
+                              use the fields below again.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1199,13 +1379,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_bitrate_help"
-                        >
-                          The remote streaming ceiling in bits per second. Zero
-                          means no limit, which is a real setting rather than an
-                          empty one. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_bitrate_help"
+                            >
+                              The remote streaming ceiling in bits per second.
+                              Zero means no limit, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1224,14 +1413,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_sessions_help"
-                        >
-                          How many sessions the account may hold at once. Zero
-                          means unlimited, which is a real setting rather than
-                          an empty one. Leave blank to keep Jellyfin's own
-                          default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_sessions_help"
+                            >
+                              How many sessions the account may hold at once.
+                              Zero means unlimited, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1248,14 +1445,23 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_audio_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. It is passed on as given rather than checked
-                          against a list, so any code Jellyfin accepts works.
-                          Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_audio_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. It is passed on as given rather than
+                              checked against a list, so any code Jellyfin
+                              accepts works. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1272,12 +1478,21 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1302,14 +1517,22 @@
                           <option value="None">None</option>
                           <option value="Smart">Smart</option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_mode_help"
-                        >
-                          Which subtitles play by default. The options are the
-                          exact mode names Jellyfin declares, which is the
-                          spelling a save accepts; leaving it unset keeps
-                          Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_mode_help"
+                            >
+                              Which subtitles play by default. The options are
+                              the exact mode names Jellyfin declares, which is
+                              the spelling a save accepts; leaving it unset
+                              keeps Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1335,13 +1558,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_play_default_audio_help"
-                        >
-                          Leaving this unset keeps Jellyfin's own default. No is
-                          a deliberate setting rather than an absent one, which
-                          is why this is a list and not a checkbox.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_play_default_audio_help"
+                            >
+                              Leaving this unset keeps Jellyfin's own default.
+                              No is a deliberate setting rather than an absent
+                              one, which is why this is a list and not a
+                              checkbox.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1367,14 +1599,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_audio_help"
-                        >
-                          Whether an audio track chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_audio_help"
+                            >
+                              Whether an audio track chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1400,14 +1640,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_subtitle_help"
-                        >
-                          Whether a subtitle chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_subtitle_help"
+                            >
+                              Whether a subtitle chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1424,18 +1672,27 @@
                           type="text"
                           class="sso-tmpl-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_home_sections_help"
-                        >
-                          The sections of the web client's home screen, one per
-                          line, top slot first: None, SmallLibraryTiles,
-                          LibraryButtons, ActiveRecordings, Resume, ResumeAudio,
-                          LatestMedia, NextUp, LiveTv or ResumeBook, spelled
-                          exactly like that. Up to ten lines; the slots you do
-                          not fill show nothing, as they would after saving the
-                          client's own home-screen settings. Leave the box empty
-                          to keep Jellyfin's own layout.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_home_sections_help"
+                            >
+                              The sections of the web client's home screen, one
+                              per line, top slot first: None, SmallLibraryTiles,
+                              LibraryButtons, ActiveRecordings, Resume,
+                              ResumeAudio, LatestMedia, NextUp, LiveTv or
+                              ResumeBook, spelled exactly like that. Up to ten
+                              lines; the slots you do not fill show nothing, as
+                              they would after saving the client's own
+                              home-screen settings. Leave the box empty to keep
+                              Jellyfin's own layout.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="sso-subgroup">
@@ -1445,18 +1702,27 @@
                         >
                           Permissions written onto a new account
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_permissions_help"
-                        >
-                          Each row names one Jellyfin permission and the value a
-                          new account starts with. A permission that is not
-                          listed is never touched. The names come from the
-                          server rather than from a list kept on this page, so
-                          they cannot drift from what a save accepts;
-                          administrator, all-folders and Live TV access are not
-                          offered here because each keeps its own setting above,
-                          and no account can be created disabled from here.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_permissions_help"
+                            >
+                              Each row names one Jellyfin permission and the
+                              value a new account starts with. A permission that
+                              is not listed is never touched. The names come
+                              from the server rather than from a list kept on
+                              this page, so they cannot drift from what a save
+                              accepts; administrator, all-folders and Live TV
+                              access are not offered here because each keeps its
+                              own setting above, and no account can be created
+                              disabled from here.
+                            </div>
+                          </details>
                         </div>
                         <div
                           id="Tmpl-Permissions"
@@ -1513,23 +1779,32 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_roles_help"
-                        >
-                          A list of roles, one role per-line to look for in the
-                          OpenID response.
-                          <br />
-                          If a user has any of these roles, then the user is
-                          authenticated. This validates the OpenID response
-                          against the claim set in
-                          <strong data-i18n="config.role_claim_property_name"
-                            >"RoleClaim"</strong
-                          >. (If your provider carries the roles as object keys,
-                          as Zitadel does, also tick "Role claim is an object
-                          map" beside the Role Claim field.)
-                          <br />
-                          Leave blank to disable role checking.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_roles_help"
+                            >
+                              A list of roles, one role per-line to look for in
+                              the OpenID response.
+                              <br />
+                              If a user has any of these roles, then the user is
+                              authenticated. This validates the OpenID response
+                              against the claim set in
+                              <strong
+                                data-i18n="config.role_claim_property_name"
+                                >"RoleClaim"</strong
+                              >. (If your provider carries the roles as object
+                              keys, as Zitadel does, also tick "Role claim is an
+                              object map" beside the Role Claim field.)
+                              <br />
+                              Leave blank to disable role checking.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1551,20 +1826,28 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.admin_roles_help"
-                        >
-                          A list of roles, one role per-line to look for in the
-                          OpenID response.
-                          <br />
-                          Like
-                          <strong data-i18n="config.roles_field_name"
-                            >"Roles"</strong
-                          >, but having any of the roles confers admin
-                          privilege.
-                          <br />
-                          If unset will not grant admin privileges.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.admin_roles_help"
+                            >
+                              A list of roles, one role per-line to look for in
+                              the OpenID response.
+                              <br />
+                              Like
+                              <strong data-i18n="config.roles_field_name"
+                                >"Roles"</strong
+                              >, but having any of the roles confers admin
+                              privilege.
+                              <br />
+                              If unset will not grant admin privileges.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1594,11 +1877,21 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.oidc_enable_all_folders_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            If enabled, all libraries will be accessible to any
-                            user that logs in through this provider.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.oidc_enable_all_folders_help"
+                              >
+                                If enabled, all libraries will be accessible to
+                                any user that logs in through this provider.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1616,18 +1909,27 @@
                             id="EnabledFolders"
                             class="checkboxList paperList checkboxList-paperList sso-folder-list sso-bordered-list"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.enabled_folders_help"
-                          >
-                            Determines which libraries will be accessible to a
-                            user that logs in through this provider.
-                            <br />
-                            If
-                            <strong data-i18n="config.enable_all_folders_name"
-                              >"Enable All Folders"</strong
-                            >
-                            is checked, then this has no effect.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.enabled_folders_help"
+                              >
+                                Determines which libraries will be accessible to
+                                a user that logs in through this provider.
+                                <br />
+                                If
+                                <strong
+                                  data-i18n="config.enable_all_folders_name"
+                                  >"Enable All Folders"</strong
+                                >
+                                is checked, then this has no effect.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1649,11 +1951,21 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.oidc_enable_folder_roles_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Determines if user roles should be used to control
-                            library access.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.oidc_enable_folder_roles_help"
+                              >
+                                Determines if user roles should be used to
+                                control library access.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1686,20 +1998,29 @@
                             id="FolderRoleMapping"
                             class="sso-role-map"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.folder_role_mapping_help"
-                          >
-                            Map roles (given by
-                            <strong data-i18n="config.role_claim_field_name"
-                              >"Role Claim"</strong
-                            >) to lists of libraries. If a user has a given
-                            role, they will have access to the corresponding
-                            libraries. If
-                            <strong data-i18n="config.enable_folder_roles_name"
-                              >"Enable Role-Based Folder Access"</strong
-                            >
-                            is disabled, has no effect.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.folder_role_mapping_help"
+                              >
+                                Map roles (given by
+                                <strong data-i18n="config.role_claim_field_name"
+                                  >"Role Claim"</strong
+                                >) to lists of libraries. If a user has a given
+                                role, they will have access to the corresponding
+                                libraries. If
+                                <strong
+                                  data-i18n="config.enable_folder_roles_name"
+                                  >"Enable Role-Based Folder Access"</strong
+                                >
+                                is disabled, has no effect.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -1732,11 +2053,21 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.oidc_enable_live_tv_roles_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines whether the roles will be used to grant
-                          Live TV privileges.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_enable_live_tv_roles_help"
+                            >
+                              Determines whether the roles will be used to grant
+                              Live TV privileges.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1759,18 +2090,26 @@
                             type="text"
                             class="sso-line-list emby-textarea"
                           ></textarea>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.livetv_roles_help"
-                          >
-                            A list of roles, one role per-line to look for in
-                            the OpenID response.
-                            <br />
-                            Like
-                            <strong data-i18n="config.roles_field_name"
-                              >"Roles"</strong
-                            >, but having any of the roles confers Live TV
-                            privileges.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.livetv_roles_help"
+                              >
+                                A list of roles, one role per-line to look for
+                                in the OpenID response.
+                                <br />
+                                Like
+                                <strong data-i18n="config.roles_field_name"
+                                  >"Roles"</strong
+                                >, but having any of the roles confers Live TV
+                                privileges.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1792,18 +2131,26 @@
                             type="text"
                             class="sso-line-list emby-textarea"
                           ></textarea>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.livetv_management_roles_help"
-                          >
-                            A list of roles, one role per-line to look for in
-                            the OpenID response.
-                            <br />
-                            Like
-                            <strong data-i18n="config.roles_field_name"
-                              >"Roles"</strong
-                            >, but having any of the roles confers Live TV
-                            administration privileges.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.livetv_management_roles_help"
+                              >
+                                A list of roles, one role per-line to look for
+                                in the OpenID response.
+                                <br />
+                                Like
+                                <strong data-i18n="config.roles_field_name"
+                                  >"Roles"</strong
+                                >, but having any of the roles confers Live TV
+                                administration privileges.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -1824,17 +2171,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.livetv_access_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines whether the user can view Live TV by
-                          default.
-                          <br />
-                          This value is still used if
-                          <strong data-i18n="config.livetv_rbac_name"
-                            >Live TV RBAC</strong
-                          >
-                          is enabled!
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.livetv_access_help"
+                            >
+                              Determines whether the user can view Live TV by
+                              default.
+                              <br />
+                              This value is still used if
+                              <strong data-i18n="config.livetv_rbac_name"
+                                >Live TV RBAC</strong
+                              >
+                              is enabled!
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1855,17 +2212,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.livetv_manage_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines whether the user can manage Live TV by
-                          default.
-                          <br />
-                          This value is still used if
-                          <strong data-i18n="config.livetv_rbac_name"
-                            >Live TV RBAC</strong
-                          >
-                          is enabled!
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.livetv_manage_help"
+                            >
+                              Determines whether the user can manage Live TV by
+                              default.
+                              <br />
+                              This value is still used if
+                              <strong data-i18n="config.livetv_rbac_name"
+                                >Live TV RBAC</strong
+                              >
+                              is enabled!
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -1896,10 +2263,20 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.oidc_do_not_load_profile_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          May be required for Cloudflare OpenID
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_do_not_load_profile_help"
+                            >
+                              May be required for Cloudflare OpenID
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1921,12 +2298,20 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_scheme_override_help"
-                        >
-                          If the plugin is redirecting to an insecure URL, set
-                          this to "https"
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_scheme_override_help"
+                            >
+                              If the plugin is redirecting to an insecure URL,
+                              set this to "https"
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1948,12 +2333,20 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_port_override_help"
-                        >
-                          If the plugin is redirecting to an incorrect port, set
-                          this to the appropiate port
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_port_override_help"
+                            >
+                              If the plugin is redirecting to an incorrect port,
+                              set this to the appropiate port
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1982,17 +2375,26 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.base_url_override_help"
-                        >
-                          The canonical external base URL of this server, e.g.
-                          <code>https://jellyfin.example.com</code>. When set,
-                          the redirect URI and SAML base URL are built from it
-                          instead of the request host, so a spoofed or
-                          proxy-forwarded host cannot redirect the login
-                          elsewhere. It overrides the scheme and port overrides
-                          above.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.base_url_override_help"
+                            >
+                              The canonical external base URL of this server,
+                              e.g.
+                              <code>https://jellyfin.example.com</code>. When
+                              set, the redirect URI and SAML base URL are built
+                              from it instead of the request host, so a spoofed
+                              or proxy-forwarded host cannot redirect the login
+                              elsewhere. It overrides the scheme and port
+                              overrides above.
+                            </div>
+                          </details>
                         </div>
                         <div
                           class="sso-callout sso-callout-warning"
@@ -2050,14 +2452,24 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_pkce_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Refuse login unless the provider's discovery
-                            document advertises PKCE (S256) in
-                            code_challenge_methods_supported (RFC 9700 §2.1.1).
-                            When off, an unsupported provider only logs an audit
-                            warning and the login proceeds.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_pkce_help"
+                              >
+                                Refuse login unless the provider's discovery
+                                document advertises PKCE (S256) in
+                                code_challenge_methods_supported (RFC 9700
+                                §2.1.1). When off, an unsupported provider only
+                                logs an audit warning and the login proceeds.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -2082,17 +2494,26 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.acr_values_help"
-                          >
-                            Space-separated acr_values sent on the authorization
-                            request (OIDC Core §3.1.2.1), most-preferred first:
-                            the requested authentication-context references
-                            (e.g. an MFA reference your IdP advertises). Leave
-                            blank to send nothing (unchanged request). Also the
-                            allow-list Require Acr checks the returned acr
-                            against.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.acr_values_help"
+                              >
+                                Space-separated acr_values sent on the
+                                authorization request (OIDC Core §3.1.2.1),
+                                most-preferred first: the requested
+                                authentication-context references (e.g. an MFA
+                                reference your IdP advertises). Leave blank to
+                                send nothing (unchanged request). Also the
+                                allow-list Require Acr checks the returned acr
+                                against.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div class="inputContainer">
@@ -2108,13 +2529,21 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.prompt_help"
-                          >
-                            OIDC prompt parameter, e.g. <code>login</code> to
-                            force re-authentication or <code>consent</code>.
-                            Leave blank to omit it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.prompt_help"
+                              >
+                                OIDC prompt parameter, e.g.
+                                <code>login</code> to force re-authentication or
+                                <code>consent</code>. Leave blank to omit it.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div class="inputContainer">
@@ -2131,14 +2560,22 @@
                             min="0"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.max_age_help"
-                          >
-                            OIDC max_age: the maximum time (seconds) since the
-                            user's last active authentication;
-                            <code>0</code> forces re-authentication. Leave blank
-                            to omit it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.max_age_help"
+                              >
+                                OIDC max_age: the maximum time (seconds) since
+                                the user's last active authentication;
+                                <code>0</code> forces re-authentication. Leave
+                                blank to omit it.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div
@@ -2157,15 +2594,26 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_acr_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Refuse any login whose verified id_token does not
-                            return an acr within Acr Values above: a fail-closed
-                            step-up / forced-MFA gate. Off by default. Requires
-                            Acr Values to be set (the save is rejected
-                            otherwise, so a mis-set cannot lock out a userbase).
-                            The break-glass password admin is unaffected.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_acr_help"
+                              >
+                                Refuse any login whose verified id_token does
+                                not return an acr within Acr Values above: a
+                                fail-closed step-up / forced-MFA gate. Off by
+                                default. Requires Acr Values to be set (the save
+                                is rejected otherwise, so a mis-set cannot lock
+                                out a userbase). The break-glass password admin
+                                is unaffected.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -2194,25 +2642,36 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.allow_adoption_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            ⚠ Sensitive: lets a first SSO login adopt (take
-                            over) a pre-existing, unlinked Jellyfin account
-                            whose username matches the SSO name, instead of
-                            rejecting it. Off by default (fail closed). Enable
-                            only for the one-time legacy-link migration window
-                            described in the account-linking runbook on the
-                            <a
-                              is="emby-linkbutton"
-                              href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
-                              class="button-link"
-                              data-i18n="config.link_wiki"
-                              >wiki</a
-                            >, then turn it back off. A name-matched
-                            administrator account is never adopted regardless of
-                            this setting, and each adoption is recorded as an
-                            audit event.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.allow_adoption_help"
+                              >
+                                ⚠ Sensitive: lets a first SSO login adopt (take
+                                over) a pre-existing, unlinked Jellyfin account
+                                whose username matches the SSO name, instead of
+                                rejecting it. Off by default (fail closed).
+                                Enable only for the one-time legacy-link
+                                migration window described in the
+                                account-linking runbook on the
+                                <a
+                                  is="emby-linkbutton"
+                                  href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
+                                  class="button-link"
+                                  data-i18n="config.link_wiki"
+                                  >wiki</a
+                                >, then turn it back off. A name-matched
+                                administrator account is never adopted
+                                regardless of this setting, and each adoption is
+                                recorded as an audit event.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -2233,25 +2692,36 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.provision_disabled_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            When the identity provider's audience is broader
-                            than your intended Jellyfin audience: an unknown
-                            identity's first successful SSO login creates its
-                            account
-                            <strong
-                              data-i18n="config.provision_disabled_emphasis"
-                              >disabled, with no permissions</strong
-                            >, and the login is refused with an "awaiting
-                            administrator approval" message instead of a
-                            session. Approve the account on the Accounts tab, in
-                            its Waiting for Approval panel, or by enabling it in
-                            the Jellyfin dashboard (Administration → Users). Off
-                            by default (new accounts are created enabled). This
-                            never disables an existing or adopted account, only
-                            a brand-new one, and each deferred provisioning is
-                            recorded as an audit event.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.provision_disabled_help"
+                              >
+                                When the identity provider's audience is broader
+                                than your intended Jellyfin audience: an unknown
+                                identity's first successful SSO login creates
+                                its account
+                                <strong
+                                  data-i18n="config.provision_disabled_emphasis"
+                                  >disabled, with no permissions</strong
+                                >, and the login is refused with an "awaiting
+                                administrator approval" message instead of a
+                                session. Approve the account on the Accounts
+                                tab, in its Waiting for Approval panel, or by
+                                enabling it in the Jellyfin dashboard
+                                (Administration → Users). Off by default (new
+                                accounts are created enabled). This never
+                                disables an existing or adopted account, only a
+                                brand-new one, and each deferred provisioning is
+                                recorded as an audit event.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -2271,25 +2741,37 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.follow_renames_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            When someone is renamed at the identity provider,
-                            rename their Jellyfin account to match on their next
-                            SSO login. Off by default, in which case the
-                            Jellyfin name stays as it was and the two drift
-                            apart. This changes the
-                            <strong data-i18n="config.follow_renames_emphasis"
-                              >display name only</strong
-                            >: the account is found by its stable subject
-                            identifier either way, so turning this on cannot
-                            change which account a login reaches. The new name
-                            is cleaned up the same way a newly created one is.
-                            If another Jellyfin account already holds the name,
-                            the rename is skipped and both accounts keep their
-                            names. A rename that fails for any other reason is
-                            logged and the login still succeeds. Each rename is
-                            recorded as an audit event.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.follow_renames_help"
+                              >
+                                When someone is renamed at the identity
+                                provider, rename their Jellyfin account to match
+                                on their next SSO login. Off by default, in
+                                which case the Jellyfin name stays as it was and
+                                the two drift apart. This changes the
+                                <strong
+                                  data-i18n="config.follow_renames_emphasis"
+                                  >display name only</strong
+                                >: the account is found by its stable subject
+                                identifier either way, so turning this on cannot
+                                change which account a login reaches. The new
+                                name is cleaned up the same way a newly created
+                                one is. If another Jellyfin account already
+                                holds the name, the rename is skipped and both
+                                accounts keep their names. A rename that fails
+                                for any other reason is logged and the login
+                                still succeeds. Each rename is recorded as an
+                                audit event.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -2311,20 +2793,31 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_verified_email_adoption_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            ⚠ Sensitive: only meaningful with Allow Adopting
-                            Existing Accounts above. Additionally requires the
-                            login to carry a provider-verified email
-                            (email_verified == true) before adopting a
-                            same-named account, narrowing who can exploit the
-                            name-based match. Needs the email scope so the
-                            provider actually returns email_verified; without
-                            it, every adoption is refused. Off by default so an
-                            existing deployment relying on adoption is not
-                            silently locked out. An administrator account is
-                            never adopted regardless of this setting.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_verified_email_adoption_help"
+                              >
+                                ⚠ Sensitive: only meaningful with Allow Adopting
+                                Existing Accounts above. Additionally requires
+                                the login to carry a provider-verified email
+                                (email_verified == true) before adopting a
+                                same-named account, narrowing who can exploit
+                                the name-based match. Needs the email scope so
+                                the provider actually returns email_verified;
+                                without it, every adoption is refused. Off by
+                                default so an existing deployment relying on
+                                adoption is not silently locked out. An
+                                administrator account is never adopted
+                                regardless of this setting.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -2346,23 +2839,34 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_verified_email_login_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            ⚠ Sensitive: requires every OpenID login for this
-                            provider to carry a provider-verified email
-                            (email_verified == true), whether it adopts,
-                            creates, or signs in to an already-linked account,
-                            not only the adoption moment above. A login whose
-                            email_verified is not exactly true (absent, false,
-                            or unparseable) is refused. Needs the email scope so
-                            the provider actually returns email_verified;
-                            without it, every login is refused. Off by default
-                            so a deployment that does not set it, or an IdP that
-                            never emits the claim, is unaffected. Independent of
-                            Allow Adopting Existing Accounts and Require
-                            Verified Email For Adoption above (run either, both,
-                            or neither).
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_verified_email_login_help"
+                              >
+                                ⚠ Sensitive: requires every OpenID login for
+                                this provider to carry a provider-verified email
+                                (email_verified == true), whether it adopts,
+                                creates, or signs in to an already-linked
+                                account, not only the adoption moment above. A
+                                login whose email_verified is not exactly true
+                                (absent, false, or unparseable) is refused.
+                                Needs the email scope so the provider actually
+                                returns email_verified; without it, every login
+                                is refused. Off by default so a deployment that
+                                does not set it, or an IdP that never emits the
+                                claim, is unaffected. Independent of Allow
+                                Adopting Existing Accounts and Require Verified
+                                Email For Adoption above (run either, both, or
+                                neither).
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -2374,13 +2878,22 @@
                         >
                           Insecure options
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.insecure_options_help"
-                        >
-                          These options disable OpenID Connect security
-                          defenses. Enable one only if your provider genuinely
-                          requires it; each is recorded as an audit warning.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.insecure_options_help"
+                            >
+                              These options disable OpenID Connect security
+                              defenses. Enable one only if your provider
+                              genuinely requires it; each is recorded as an
+                              audit warning.
+                            </div>
+                          </details>
                         </div>
                         <button
                           is="emby-button"
@@ -2416,15 +2929,25 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n="config.disable_https_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: drops TLS on the discovery, JWKS and
-                              token endpoints, so the id_token signing keys can
-                              be swapped by a man-in-the-middle and a forged
-                              login accepted. Use only on a trusted internal
-                              network. Enabling it is recorded as an audit
-                              warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n="config.disable_https_help"
+                                >
+                                  ⚠ Insecure: drops TLS on the discovery, JWKS
+                                  and token endpoints, so the id_token signing
+                                  keys can be swapped by a man-in-the-middle and
+                                  a forged login accepted. Use only on a trusted
+                                  internal network. Enabling it is recorded as
+                                  an audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
 
@@ -2465,13 +2988,24 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n="config.no_validate_endpoints_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: disables endpoint-origin validation (a
-                              mix-up defense). May be required for Google
-                              OpenID, whose endpoints live on different hosts.
-                              Enabling it is recorded as an audit warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n="config.no_validate_endpoints_help"
+                                >
+                                  ⚠ Insecure: disables endpoint-origin
+                                  validation (a mix-up defense). May be required
+                                  for Google OpenID, whose endpoints live on
+                                  different hosts. Enabling it is recorded as an
+                                  audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
 
@@ -2493,17 +3027,28 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n="config.allow_private_network_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: relaxes the outbound SSRF / DNS-rebind
-                              guard for this provider, allowing connection to an
-                              OIDC provider hosted on a private network. Permits
-                              RFC 1918, CGNAT and IPv6 unique-local addresses.
-                              Loopback, link-local and cloud-metadata ranges
-                              remain blocked. Leave off for any provider
-                              reachable on the public internet. Enabling it is
-                              recorded as an audit warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n="config.allow_private_network_help"
+                                >
+                                  ⚠ Insecure: relaxes the outbound SSRF /
+                                  DNS-rebind guard for this provider, allowing
+                                  connection to an OIDC provider hosted on a
+                                  private network. Permits RFC 1918, CGNAT and
+                                  IPv6 unique-local addresses. Loopback,
+                                  link-local and cloud-metadata ranges remain
+                                  blocked. Leave off for any provider reachable
+                                  on the public internet. Enabling it is
+                                  recorded as an audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
 
@@ -2524,14 +3069,24 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n="config.no_validate_issuer_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: disables matching the discovery
-                              issuer, a mix-up defense. Only for a provider that
-                              legitimately presents a different issuer (some
-                              templated/multi-tenant setups). Enabling it is
-                              recorded as an audit warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n="config.no_validate_issuer_help"
+                                >
+                                  ⚠ Insecure: disables matching the discovery
+                                  issuer, a mix-up defense. Only for a provider
+                                  that legitimately presents a different issuer
+                                  (some templated/multi-tenant setups). Enabling
+                                  it is recorded as an audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
 
@@ -2553,14 +3108,25 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n-parts="config.no_validate_response_issuer_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: disables the RFC 9207 <code>iss</code>
-                              check, an OpenID Connect mix-up defense. Only for
-                              a provider whose authorization response
-                              legitimately carries a different issuer. Enabling
-                              it is recorded as an audit warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n-parts="config.no_validate_response_issuer_help"
+                                >
+                                  ⚠ Insecure: disables the RFC 9207
+                                  <code>iss</code>
+                                  check, an OpenID Connect mix-up defense. Only
+                                  for a provider whose authorization response
+                                  legitimately carries a different issuer.
+                                  Enabling it is recorded as an audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
                         </div>
@@ -2585,19 +3151,28 @@
                         >Test Connection</span
                       >
                     </button>
-                    <div
-                      class="fieldDescription"
-                      data-i18n-parts="config.oid_test_help"
-                    >
-                      Validates the
-                      <strong data-i18n="config.test_saved_emphasis"
-                        >saved</strong
-                      >
-                      provider: the server fetches the OpenID discovery document
-                      over the same hardened, HTTPS-checked path the login uses
-                      and reports the issuer, endpoints and JWKS reachability.
-                      Save the provider first. Requires administrator
-                      privileges; the client secret is never shown.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.oid_test_help"
+                        >
+                          Validates the
+                          <strong data-i18n="config.test_saved_emphasis"
+                            >saved</strong
+                          >
+                          provider: the server fetches the OpenID discovery
+                          document over the same hardened, HTTPS-checked path
+                          the login uses and reports the issuer, endpoints and
+                          JWKS reachability. Save the provider first. Requires
+                          administrator privileges; the client secret is never
+                          shown.
+                        </div>
+                      </details>
                     </div>
                     <div id="TestResult"></div>
                   </div>
@@ -2685,13 +3260,22 @@
                     >
                       No SAML providers yet
                     </p>
-                    <p
-                      class="fieldDescription"
-                      data-i18n="config.saml_empty_help"
-                    >
-                      Add a SAML 2.0 provider to let users sign in through your
-                      identity provider. You can import the endpoint and signing
-                      certificate straight from your IdP's metadata below.
+                    <p class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.saml_empty_help"
+                        >
+                          Add a SAML 2.0 provider to let users sign in through
+                          your identity provider. You can import the endpoint
+                          and signing certificate straight from your IdP's
+                          metadata below.
+                        </div>
+                      </details>
                     </p>
                     <!--
                   First-run guided path (#1085). The steps NAME the controls that already exist inside the
@@ -2890,14 +3474,22 @@
                       role="status"
                       aria-live="polite"
                     ></div>
-                    <div
-                      class="fieldDescription"
-                      data-i18n="config.saml_template_help"
-                    >
-                      Pre-fills an endpoint placeholder for a SAML identity
-                      provider. Use the metadata import below to fill the
-                      endpoint and signing certificate from your IdP, then
-                      review and save. Nothing is saved automatically.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.saml_template_help"
+                        >
+                          Pre-fills an endpoint placeholder for a SAML identity
+                          provider. Use the metadata import below to fill the
+                          endpoint and signing certificate from your IdP, then
+                          review and save. Nothing is saved automatically.
+                        </div>
+                      </details>
                     </div>
                   </div>
 
@@ -2934,13 +3526,21 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_name_help"
-                        >
-                          The name Jellyfin uses to identify this SAML provider.
-                          A new provider is created if the name is new; an
-                          existing one is updated.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_name_help"
+                            >
+                              The name Jellyfin uses to identify this SAML
+                              provider. A new provider is created if the name is
+                              new; an existing one is updated.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3002,15 +3602,24 @@
                           role="status"
                           aria-live="polite"
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_metadata_import_help"
-                        >
-                          Fetches the SSO endpoint and signing certificate(s)
-                          from your identity provider's SAML metadata and fills
-                          them in below for review. It never fills the SAML
-                          Client ID (that is this service provider's own entity
-                          id, which you choose).
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_metadata_import_help"
+                            >
+                              Fetches the SSO endpoint and signing
+                              certificate(s) from your identity provider's SAML
+                              metadata and fills them in below for review. It
+                              never fills the SAML Client ID (that is this
+                              service provider's own entity id, which you
+                              choose).
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3038,12 +3647,20 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_endpoint_help"
-                        >
-                          The identity provider's Single Sign-On URL, where the
-                          browser is redirected to authenticate.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_endpoint_help"
+                            >
+                              The identity provider's Single Sign-On URL, where
+                              the browser is redirected to authenticate.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3067,17 +3684,26 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_slo_endpoint_help"
-                        >
-                          The identity provider's Single-Logout (SLO) URL, a
-                          distinct endpoint from the SSO endpoint above, where
-                          the browser is redirected with a signed SP-initiated
-                          LogoutRequest. Must be an absolute https URL. Leave
-                          blank to disable SP-initiated Single Logout (logout
-                          stays local-only). Only used when the global "Enable
-                          Single Logout" option is on.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_slo_endpoint_help"
+                            >
+                              The identity provider's Single-Logout (SLO) URL, a
+                              distinct endpoint from the SSO endpoint above,
+                              where the browser is redirected with a signed
+                              SP-initiated LogoutRequest. Must be an absolute
+                              https URL. Leave blank to disable SP-initiated
+                              Single Logout (logout stays local-only). Only used
+                              when the global "Enable Single Logout" option is
+                              on.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3105,14 +3731,23 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_client_id_help"
-                        >
-                          This service provider's entity id: the value the
-                          plugin sends as the AuthnRequest issuer and expects as
-                          the audience. You choose it and register it at the
-                          IdP; it is also the SP entityID shown below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_client_id_help"
+                            >
+                              This service provider's entity id: the value the
+                              plugin sends as the AuthnRequest issuer and
+                              expects as the audience. You choose it and
+                              register it at the IdP; it is also the SP entityID
+                              shown below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3138,14 +3773,23 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.saml_certificate_help"
-                        >
-                          The identity provider's PUBLIC signing certificate as
-                          Base64 (DER): the value between the PEM
-                          <code>BEGIN/END CERTIFICATE</code> lines, or the whole
-                          PEM. Used to verify the SAML response signature.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.saml_certificate_help"
+                            >
+                              The identity provider's PUBLIC signing certificate
+                              as Base64 (DER): the value between the PEM
+                              <code>BEGIN/END CERTIFICATE</code> lines, or the
+                              whole PEM. Used to verify the SAML response
+                              signature.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3178,16 +3822,24 @@
                             <span data-i18n="config.copy_button">Copy</span>
                           </button>
                         </div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.saml_acs_url_help"
-                        >
-                          The Assertion Consumer Service URL the IdP POSTs the
-                          SAML response to. Updates as you type the provider
-                          name. Derived from the Base URL Override (Advanced
-                          section) when set, else this server's address. The
-                          legacy spelling
-                          <code>/sso/SAML/p/&lt;name&gt;</code> also works.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.saml_acs_url_help"
+                            >
+                              The Assertion Consumer Service URL the IdP POSTs
+                              the SAML response to. Updates as you type the
+                              provider name. Derived from the Base URL Override
+                              (Advanced section) when set, else this server's
+                              address. The legacy spelling
+                              <code>/sso/SAML/p/&lt;name&gt;</code> also works.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3220,14 +3872,23 @@
                           role="status"
                           aria-live="polite"
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_metadata_url_help"
-                        >
-                          This service provider's metadata document. Many IdPs
-                          can import it by URL instead of hand-configuring the
-                          ACS and entityID. The SP entityID it advertises is the
-                          SAML Client ID above.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_metadata_url_help"
+                            >
+                              This service provider's metadata document. Many
+                              IdPs can import it by URL instead of
+                              hand-configuring the ACS and entityID. The SP
+                              entityID it advertises is the SAML Client ID
+                              above.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3265,15 +3926,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.provider_hide_login_button_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Excludes this provider from the managed "Sign in with
-                          …" block on the login page while keeping it usable
-                          through its direct start URL. Only takes effect while
-                          the global "Manage login buttons on the login page"
-                          option is on; it never hides anything you added to the
-                          branding yourself.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_hide_login_button_help"
+                            >
+                              Excludes this provider from the managed "Sign in
+                              with …" block on the login page while keeping it
+                              usable through its direct start URL. Only takes
+                              effect while the global "Manage login buttons on
+                              the login page" option is on; it never hides
+                              anything you added to the branding yourself.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3295,16 +3966,24 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provider_login_button_text_help"
-                        >
-                          Custom label for this provider's managed login-page
-                          button. Leave blank to use the provider name. Only
-                          takes effect while the global "Manage login buttons on
-                          the login page" option is on and the button is not
-                          hidden; any text is safe: it is always rendered inert,
-                          never as markup.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_login_button_text_help"
+                            >
+                              Custom label for this provider's managed
+                              login-page button. Leave blank to use the provider
+                              name. Only takes effect while the global "Manage
+                              login buttons on the login page" option is on and
+                              the button is not hidden; any text is safe: it is
+                              always rendered inert, never as markup.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -3336,13 +4015,23 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_enable_authorization_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines if the plugin sets permissions for the
-                          user. If off, the user starts with no permissions and
-                          an administrator adds them. Existing users'
-                          permissions are not rewritten on later logins.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_enable_authorization_help"
+                            >
+                              Determines if the plugin sets permissions for the
+                              user. If off, the user starts with no permissions
+                              and an administrator adds them. Existing users'
+                              permissions are not rewritten on later logins.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3364,13 +4053,21 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_default_provider_help"
-                        >
-                          Assigned to the user after they log in. If unset,
-                          nothing changes and the user can still log in via
-                          other providers.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_default_provider_help"
+                            >
+                              Assigned to the user after they log in. If unset,
+                              nothing changes and the user can still log in via
+                              other providers.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3390,14 +4087,24 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_allow_adoption_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          ⚠ Sensitive: lets a first SAML login adopt a
-                          pre-existing, unlinked Jellyfin account whose username
-                          matches the SAML NameID, instead of rejecting it. Off
-                          by default. A name-matched administrator account is
-                          never adopted.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_allow_adoption_help"
+                            >
+                              ⚠ Sensitive: lets a first SAML login adopt a
+                              pre-existing, unlinked Jellyfin account whose
+                              username matches the SAML NameID, instead of
+                              rejecting it. Off by default. A name-matched
+                              administrator account is never adopted.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3418,15 +4125,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_provision_disabled_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          An unknown identity's first login creates its account
-                          disabled, with no permissions, and is refused with an
-                          "awaiting administrator approval" message until an
-                          admin enables it. Off by default. Never disables an
-                          existing or adopted account, and each deferral is
-                          audited.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_provision_disabled_help"
+                            >
+                              An unknown identity's first login creates its
+                              account disabled, with no permissions, and is
+                              refused with an "awaiting administrator approval"
+                              message until an admin enables it. Off by default.
+                              Never disables an existing or adopted account, and
+                              each deferral is audited.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3446,17 +4163,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_follow_renames_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          When someone is renamed at the identity provider,
-                          rename their Jellyfin account to match on their next
-                          SSO login. Off by default. Display name only: the
-                          account is found by its stable NameID either way, so
-                          this cannot change which account a login reaches.
-                          Skipped when another account already holds the name,
-                          and a rename that fails never fails the login. Each
-                          rename is audited.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_follow_renames_help"
+                            >
+                              When someone is renamed at the identity provider,
+                              rename their Jellyfin account to match on their
+                              next SSO login. Off by default. Display name only:
+                              the account is found by its stable NameID either
+                              way, so this cannot change which account a login
+                              reaches. Skipped when another account already
+                              holds the name, and a rename that fails never
+                              fails the login. Each rename is audited.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -3482,15 +4209,24 @@
                     class="verticalSection verticalSection-extrabottompadding"
                   >
                     <div class="collapseContent">
-                      <div
-                        class="fieldDescription"
-                        data-i18n="config.template_help"
-                      >
-                        What a brand-new account created by this provider starts
-                        with. Every field is opt-in: anything you leave alone
-                        keeps Jellyfin's own default, and these values are
-                        written once, when the account is created, so a change
-                        made later survives every following login.
+                      <div class="fieldDescription sso-help">
+                        <span class="sso-help-lead"></span>
+                        <details class="sso-help-full">
+                          <summary data-i18n="config.help_full_text">
+                            Full text
+                          </summary>
+                          <div
+                            class="sso-help-body"
+                            data-i18n="config.template_help"
+                          >
+                            What a brand-new account created by this provider
+                            starts with. Every field is opt-in: anything you
+                            leave alone keeps Jellyfin's own default, and these
+                            values are written once, when the account is
+                            created, so a change made later survives every
+                            following login.
+                          </div>
+                        </details>
                       </div>
                       <div
                         id="saml-Tmpl-profile-note"
@@ -3528,18 +4264,26 @@
                           name="saml-ProvisioningProfile"
                           class="sso-tmpl-profile emby-select-withcolor emby-select"
                         ></select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provisioning_profile_help"
-                        >
-                          Take the starting policy from a profile defined in
-                          Provisioning Profiles above, instead of from the
-                          fields below. The two are mutually exclusive: a
-                          provider that names a profile and also carries its own
-                          inline fields is refused on save, because one
-                          account-creation policy has one source. Leave it on
-                          (none), or set it back to (none) and save, to use the
-                          fields below again.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provisioning_profile_help"
+                            >
+                              Take the starting policy from a profile defined in
+                              Provisioning Profiles above, instead of from the
+                              fields below. The two are mutually exclusive: a
+                              provider that names a profile and also carries its
+                              own inline fields is refused on save, because one
+                              account-creation policy has one source. Leave it
+                              on (none), or set it back to (none) and save, to
+                              use the fields below again.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3558,13 +4302,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_bitrate_help"
-                        >
-                          The remote streaming ceiling in bits per second. Zero
-                          means no limit, which is a real setting rather than an
-                          empty one. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_bitrate_help"
+                            >
+                              The remote streaming ceiling in bits per second.
+                              Zero means no limit, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3583,14 +4336,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_sessions_help"
-                        >
-                          How many sessions the account may hold at once. Zero
-                          means unlimited, which is a real setting rather than
-                          an empty one. Leave blank to keep Jellyfin's own
-                          default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_sessions_help"
+                            >
+                              How many sessions the account may hold at once.
+                              Zero means unlimited, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3607,14 +4368,23 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_audio_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. It is passed on as given rather than checked
-                          against a list, so any code Jellyfin accepts works.
-                          Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_audio_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. It is passed on as given rather than
+                              checked against a list, so any code Jellyfin
+                              accepts works. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3631,12 +4401,21 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3661,14 +4440,22 @@
                           <option value="None">None</option>
                           <option value="Smart">Smart</option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_mode_help"
-                        >
-                          Which subtitles play by default. The options are the
-                          exact mode names Jellyfin declares, which is the
-                          spelling a save accepts; leaving it unset keeps
-                          Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_mode_help"
+                            >
+                              Which subtitles play by default. The options are
+                              the exact mode names Jellyfin declares, which is
+                              the spelling a save accepts; leaving it unset
+                              keeps Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3694,13 +4481,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_play_default_audio_help"
-                        >
-                          Leaving this unset keeps Jellyfin's own default. No is
-                          a deliberate setting rather than an absent one, which
-                          is why this is a list and not a checkbox.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_play_default_audio_help"
+                            >
+                              Leaving this unset keeps Jellyfin's own default.
+                              No is a deliberate setting rather than an absent
+                              one, which is why this is a list and not a
+                              checkbox.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3726,14 +4522,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_audio_help"
-                        >
-                          Whether an audio track chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_audio_help"
+                            >
+                              Whether an audio track chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3759,14 +4563,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_subtitle_help"
-                        >
-                          Whether a subtitle chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_subtitle_help"
+                            >
+                              Whether a subtitle chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3783,18 +4595,27 @@
                           type="text"
                           class="sso-tmpl-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_home_sections_help"
-                        >
-                          The sections of the web client's home screen, one per
-                          line, top slot first: None, SmallLibraryTiles,
-                          LibraryButtons, ActiveRecordings, Resume, ResumeAudio,
-                          LatestMedia, NextUp, LiveTv or ResumeBook, spelled
-                          exactly like that. Up to ten lines; the slots you do
-                          not fill show nothing, as they would after saving the
-                          client's own home-screen settings. Leave the box empty
-                          to keep Jellyfin's own layout.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_home_sections_help"
+                            >
+                              The sections of the web client's home screen, one
+                              per line, top slot first: None, SmallLibraryTiles,
+                              LibraryButtons, ActiveRecordings, Resume,
+                              ResumeAudio, LatestMedia, NextUp, LiveTv or
+                              ResumeBook, spelled exactly like that. Up to ten
+                              lines; the slots you do not fill show nothing, as
+                              they would after saving the client's own
+                              home-screen settings. Leave the box empty to keep
+                              Jellyfin's own layout.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="sso-subgroup">
@@ -3804,18 +4625,27 @@
                         >
                           Permissions written onto a new account
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_permissions_help"
-                        >
-                          Each row names one Jellyfin permission and the value a
-                          new account starts with. A permission that is not
-                          listed is never touched. The names come from the
-                          server rather than from a list kept on this page, so
-                          they cannot drift from what a save accepts;
-                          administrator, all-folders and Live TV access are not
-                          offered here because each keeps its own setting above,
-                          and no account can be created disabled from here.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_permissions_help"
+                            >
+                              Each row names one Jellyfin permission and the
+                              value a new account starts with. A permission that
+                              is not listed is never touched. The names come
+                              from the server rather than from a list kept on
+                              this page, so they cannot drift from what a save
+                              accepts; administrator, all-folders and Live TV
+                              access are not offered here because each keeps its
+                              own setting above, and no account can be created
+                              disabled from here.
+                            </div>
+                          </details>
                         </div>
                         <div
                           id="saml-Tmpl-Permissions"
@@ -3872,14 +4702,22 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_roles_help"
-                        >
-                          One role per line. A login must carry at least one of
-                          these roles (in the assertion's Role attribute) to be
-                          allowed in. Leave blank to allow any authenticated
-                          user.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_roles_help"
+                            >
+                              One role per line. A login must carry at least one
+                              of these roles (in the assertion's Role attribute)
+                              to be allowed in. Leave blank to allow any
+                              authenticated user.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3901,12 +4739,20 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_admin_roles_help"
-                        >
-                          One role per line. A login carrying any of these roles
-                          is granted administrator rights.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_admin_roles_help"
+                            >
+                              One role per line. A login carrying any of these
+                              roles is granted administrator rights.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3936,11 +4782,21 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.saml_enable_all_folders_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            If enabled, all libraries are accessible to any user
-                            that logs in through this provider.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_enable_all_folders_help"
+                              >
+                                If enabled, all libraries are accessible to any
+                                user that logs in through this provider.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -3958,13 +4814,21 @@
                             id="saml-EnabledFolders"
                             class="checkboxList paperList checkboxList-paperList sso-folder-list sso-bordered-list"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_enabled_folders_help"
-                          >
-                            Which libraries are accessible to a user that logs
-                            in through this provider. No effect when "Enable All
-                            Folders" is checked.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_enabled_folders_help"
+                              >
+                                Which libraries are accessible to a user that
+                                logs in through this provider. No effect when
+                                "Enable All Folders" is checked.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -3986,11 +4850,21 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.saml_enable_folder_roles_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Determines if user roles should control library
-                            access.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_enable_folder_roles_help"
+                              >
+                                Determines if user roles should control library
+                                access.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4023,12 +4897,21 @@
                             id="saml-FolderRoleMapping"
                             class="sso-role-map"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_folder_role_mapping_help"
-                          >
-                            Map roles to lists of libraries. A user holding a
-                            given role gets access to its mapped libraries.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_folder_role_mapping_help"
+                              >
+                                Map roles to lists of libraries. A user holding
+                                a given role gets access to its mapped
+                                libraries.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4061,11 +4944,21 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_enable_livetv_roles_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines if user roles should control Live TV
-                          access.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_enable_livetv_roles_help"
+                            >
+                              Determines if user roles should control Live TV
+                              access.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4097,12 +4990,20 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_livetv_roles_help"
-                        >
-                          One role per line. Grants Live TV access / management
-                          to logins carrying a listed role.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_livetv_roles_help"
+                            >
+                              One role per line. Grants Live TV access /
+                              management to logins carrying a listed role.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4169,13 +5070,21 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_scheme_override_help"
-                        >
-                          Force the scheme (http/https) used when building the
-                          ACS and metadata URLs. Prefer the Base URL Override
-                          below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_scheme_override_help"
+                            >
+                              Force the scheme (http/https) used when building
+                              the ACS and metadata URLs. Prefer the Base URL
+                              Override below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4197,12 +5106,20 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_port_override_help"
-                        >
-                          Force the port used when building the ACS and metadata
-                          URLs. Prefer the Base URL Override below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_port_override_help"
+                            >
+                              Force the port used when building the ACS and
+                              metadata URLs. Prefer the Base URL Override below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4282,14 +5199,25 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.saml_validate_recipient_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Additionally require the assertion's
-                            <code>Recipient</code> to equal this SP's ACS URL (a
-                            token-redirection defense). Off by default so an
-                            existing deployment is not locked out; enable once
-                            your IdP sets the recipient correctly.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_validate_recipient_help"
+                              >
+                                Additionally require the assertion's
+                                <code>Recipient</code> to equal this SP's ACS
+                                URL (a token-redirection defense). Off by
+                                default so an existing deployment is not locked
+                                out; enable once your IdP sets the recipient
+                                correctly.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4310,13 +5238,24 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.saml_validate_inresponseto_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Require the response's <code>InResponseTo</code> to
-                            match an AuthnRequest this SP issued (rejects
-                            unsolicited assertions). Off by default; enable for
-                            solicited-only SSO.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_validate_inresponseto_help"
+                              >
+                                Require the response's
+                                <code>InResponseTo</code> to match an
+                                AuthnRequest this SP issued (rejects unsolicited
+                                assertions). Off by default; enable for
+                                solicited-only SSO.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4347,13 +5286,22 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.saml_audience_help"
-                          >
-                            The expected <code>AudienceRestriction</code> in the
-                            assertion. When blank, the SAML Client ID is used.
-                            Ignored when "Do Not Validate Audience" is set.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_audience_help"
+                              >
+                                The expected <code>AudienceRestriction</code> in
+                                the assertion. When blank, the SAML Client ID is
+                                used. Ignored when "Do Not Validate Audience" is
+                                set.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4382,12 +5330,22 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.saml_sign_authn_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Sign outgoing SAML AuthnRequests with the SP signing
-                            key below. Off by default; when on, a valid Signing
-                            Key must be configured.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_sign_authn_help"
+                              >
+                                Sign outgoing SAML AuthnRequests with the SP
+                                signing key below. Off by default; when on, a
+                                valid Signing Key must be configured.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4412,14 +5370,23 @@
                             data-i18n-placeholder="config.placeholder_keep_key"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_signing_key_help"
-                          >
-                            This service provider's PRIVATE signing key, as a
-                            Base64 PKCS#12 (PFX) blob. For security it is never
-                            sent back to this page: leave blank to keep the
-                            stored key, or enter a new one to replace it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_signing_key_help"
+                              >
+                                This service provider's PRIVATE signing key, as
+                                a Base64 PKCS#12 (PFX) blob. For security it is
+                                never sent back to this page: leave blank to
+                                keep the stored key, or enter a new one to
+                                replace it.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4444,15 +5411,23 @@
                             data-i18n-placeholder="config.placeholder_keep_key"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_rollover_signing_key_help"
-                          >
-                            An OPTIONAL second SP signing key for a rollover
-                            overlap: the SP metadata advertises both public
-                            certificates so the IdP trusts either. AuthnRequests
-                            are always signed with the primary key. Write-only,
-                            like the primary key.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_rollover_signing_key_help"
+                              >
+                                An OPTIONAL second SP signing key for a rollover
+                                overlap: the SP metadata advertises both public
+                                certificates so the IdP trusts either.
+                                AuthnRequests are always signed with the primary
+                                key. Write-only, like the primary key.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4489,15 +5464,24 @@
                             role="alert"
                             hidden
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_secondary_certificate_help"
-                          >
-                            An OPTIONAL second IdP PUBLIC signing certificate
-                            accepted during an inbound signing-key rotation: a
-                            response verifying against EITHER this or the
-                            primary certificate is accepted. Base64 (DER) or
-                            PEM, like the primary.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_secondary_certificate_help"
+                              >
+                                An OPTIONAL second IdP PUBLIC signing
+                                certificate accepted during an inbound
+                                signing-key rotation: a response verifying
+                                against EITHER this or the primary certificate
+                                is accepted. Base64 (DER) or PEM, like the
+                                primary.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4509,13 +5493,21 @@
                         >
                           Insecure options
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_insecure_options_help"
-                        >
-                          These options disable SAML security defenses. Enable
-                          one only if your provider genuinely requires it; each
-                          is recorded as an audit warning.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_insecure_options_help"
+                            >
+                              These options disable SAML security defenses.
+                              Enable one only if your provider genuinely
+                              requires it; each is recorded as an audit warning.
+                            </div>
+                          </details>
                         </div>
                         <button
                           is="emby-button"
@@ -4552,15 +5544,25 @@
                               >
                             </label>
                             <div
-                              class="fieldDescription checkboxFieldDescription"
-                              data-i18n-parts="config.saml_no_validate_audience_help"
+                              class="fieldDescription checkboxFieldDescription sso-help"
                             >
-                              ⚠ Insecure: disables the
-                              <code>AudienceRestriction</code> check, so an
-                              assertion minted for a different service provider
-                              could be replayed here. Only if your IdP cannot
-                              set the audience correctly. Enabling it is
-                              recorded as an audit warning.
+                              <span class="sso-help-lead"></span>
+                              <details class="sso-help-full">
+                                <summary data-i18n="config.help_full_text">
+                                  Full text
+                                </summary>
+                                <div
+                                  class="sso-help-body"
+                                  data-i18n-parts="config.saml_no_validate_audience_help"
+                                >
+                                  ⚠ Insecure: disables the
+                                  <code>AudienceRestriction</code> check, so an
+                                  assertion minted for a different service
+                                  provider could be replayed here. Only if your
+                                  IdP cannot set the audience correctly.
+                                  Enabling it is recorded as an audit warning.
+                                </div>
+                              </details>
                             </div>
                           </div>
                         </div>
@@ -4579,18 +5581,27 @@
                         >Test Connection</span
                       >
                     </button>
-                    <div
-                      class="fieldDescription"
-                      data-i18n-parts="config.saml_test_help"
-                    >
-                      Validates the
-                      <strong data-i18n="config.test_saved_emphasis"
-                        >saved</strong
-                      >
-                      provider: parses the stored IdP signing certificate and
-                      reports its non-secret facts (subject, issuer, validity,
-                      thumbprint). Save the provider first. Requires
-                      administrator privileges; no signing key is shown.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.saml_test_help"
+                        >
+                          Validates the
+                          <strong data-i18n="config.test_saved_emphasis"
+                            >saved</strong
+                          >
+                          provider: parses the stored IdP signing certificate
+                          and reports its non-secret facts (subject, issuer,
+                          validity, thumbprint). Save the provider first.
+                          Requires administrator privileges; no signing key is
+                          shown.
+                        </div>
+                      </details>
                     </div>
                     <div id="saml-TestResult"></div>
                   </div>
@@ -4648,6 +5659,24 @@
                 >
                   Open a provider to see whether it is ready to serve a login.
                 </div>
+              </div>
+              <!--
+                THE WHOLE TEXT OF THE FIELD THAT HAS FOCUS (#1663), the same card slice 1 put on the small
+                pages (#1662). Every field below shows one sentence and keeps the rest behind a fold; this is
+                the second way to read the rest, without losing the field while reading about it. Empty and
+                hidden in the markup on purpose: SSO-Auth/Web/i18n.js fills it on focus, so a page whose
+                script never ran shows nothing here rather than a card naming a field nobody chose. The
+                heading is the same catalogue row the folds are named with, so the two cannot drift apart.
+
+                BELOW the readiness card rather than above it, because readiness answers about the provider
+                being edited and does not move while a form is filled in, and this one changes on every focus.
+                Where the two sit relative to each other is the next slice's question (#1664), not this one's.
+              -->
+              <div class="verticalSection sso-help-card" hidden>
+                <h2 class="sectionTitle" data-i18n="config.help_full_text">
+                  Full text
+                </h2>
+                <div class="fieldDescription sso-help-card-text"></div>
               </div>
             </aside>
           </div>

--- a/docs/ui/HELP-CENSUS.md
+++ b/docs/ui/HELP-CENSUS.md
@@ -119,9 +119,27 @@ markup and then LOADS `SSO-Auth/Web/i18n.js` and drives it over both catalogues:
 it refuses a help text still written flat, a fold with no lead line to fill, a
 summary named by anything but the row the folds share, a sentence under the
 field that is not the first sentence of the text behind it, a fold hidden while
-it holds more, and a rail card answering a field that does not have focus. The
-two are complements. This one holds "nothing is deleted"; that one holds "and
-what happened to it is what was promised".
+it holds more, a rail card answering a field that does not have focus, and two
+help blocks resolving to one field - where the card answers for the first of
+them wherever the focus lands and the second cannot be reached from it at all.
+The two are complements. This one holds "nothing is deleted"; that one holds
+"and what happened to it is what was promised".
+
+Slice 2 took the Providers page (#1663), and the `behind a <details>` figure for
+it stops one short of its site count for a reason this table can be read against
+rather than guessed at: `config.saml_base_url_override_help` sits on a
+`sso-callout sso-callout-warning`, which is a warning beside the SAML base-URL
+field rather than that field's description. A warning is not condensed - folding
+one hides the thing it exists to put in front of a reader - and the condensing
+reader's subject is `fieldDescription`, so it neither moves nor refuses it.
+
+The same slice is where the two readers stop covering the same population, which
+is stated here because the census's own figure does not show it. A help text
+whose body is marked `data-i18n-parts` has its `{n}` slots filled from the body's
+own child elements, so the sentence on the screen is assembled on the page; the
+condensing gate builds its runtime fixture from catalogue rows and has no such
+children, so those bodies are judged by its MARKUP reader and not by its applier
+run, and it prints how many per page. This table counts them as it always has.
 
 | Page                 | Help key                                      | Field                                     |
 | -------------------- | --------------------------------------------- | ----------------------------------------- |

--- a/tools/ui-condensed-help.js
+++ b/tools/ui-condensed-help.js
@@ -19,7 +19,8 @@
  * TWO READERS, BECAUSE THE SLICE HAS TWO HALVES AND THEY FAIL DIFFERENTLY. The
  * first reads the shipped markup and refuses a help text that is not authored as
  * a fold, a fold with no lead line to fill, a summary naming something other than
- * the catalogue row the folds share, and a marked page with no rail card. The
+ * the catalogue row the folds share, a marked page with no rail card, and two help
+ * blocks resolving to one field (#1663). The
  * second LOADS the shipped applier and drives it over the shipped catalogues,
  * refusing a lead that is not the first sentence of the text behind it, a fold
  * hiding nothing, a fold hidden while it holds more, and a rail card answering a
@@ -67,6 +68,15 @@
  * pass. The markup reader now refuses that placement by name, which closes the one
  * instance and not the class. A real-page shape the string reader cannot see is
  * still a shape nothing here judges.
+ *
+ * AND ONE HALF OF THE PAGE IS JUDGED BY THE MARKUP READER ALONE (#1663). A help text
+ * whose body is marked `data-i18n-parts` holds a catalogue value with `{n}` slots the
+ * pass fills from the body's own children, so the sentence a reader sees is assembled
+ * on the page and the raw value is not it. The built page has no such children, so
+ * those keys are kept out of the runtime half rather than judged against a lead
+ * holding `{0}`, and the run PRINTS how many of a page's blocks that was. What covers
+ * them is the markup reader, which judges both spellings, and the applier rule they
+ * share with every other block - not an arm of their own.
  *
  * THE CALIBRATION RUNS FIRST AND THE REAL PAGES SECOND. A reader that accepts
  * everything passes its own arithmetic, so the arms below drive both readers over
@@ -349,10 +359,10 @@ function inspectMarkup(page, source) {
       continue;
     }
 
-    const keys = [...body.matchAll(/data-i18n="([a-z0-9_.]+_help)"/g)].map(
-      (m) => m[1],
-    );
-    const own = /data-i18n="([a-z0-9_.]+_help)"/.exec(opening);
+    const keys = [
+      ...body.matchAll(/data-i18n(?:-parts)?="([a-z0-9_.]+_help)"/g),
+    ].map((m) => m[1]);
+    const own = /data-i18n(?:-parts)?="([a-z0-9_.]+_help)"/.exec(opening);
     if (own) {
       refusals.push(
         `${page} still writes ${own[1]} flat: the field shows the whole text under it rather than a sentence and a fold`,
@@ -374,7 +384,7 @@ function inspectMarkup(page, source) {
       continue;
     }
     blocks += 1;
-    at.push(match.index);
+    at.push({ index: match.index, key: keys[0] });
 
     const key = keys[0];
     if (!hasClassToken(opening, "sso-help")) {
@@ -397,7 +407,11 @@ function inspectMarkup(page, source) {
         `the fold of ${key} on ${page} is named by something other than ${SUMMARY_KEY}, so one page's folds can be renamed without the others`,
       );
     }
-    if (!new RegExp(`class="sso-help-body" data-i18n="${key}"`).test(body)) {
+    if (
+      !new RegExp(`class="sso-help-body" data-i18n(?:-parts)?="${key}"`).test(
+        body,
+      )
+    ) {
       refusals.push(
         `${key} on ${page} does not sit on the body of its own fold, so the catalogue writes it somewhere the applier does not read it from`,
       );
@@ -445,15 +459,97 @@ function inspectMarkup(page, source) {
       refusals.push(`the rail card on ${page} is not headed by ${SUMMARY_KEY}`);
     }
 
-    const outside = at.filter((i) => i < scope.from || i > scope.to).length;
+    const outside = at.filter(
+      (block) => block.index < scope.from || block.index > scope.to,
+    ).length;
     if (outside > 0) {
       refusals.push(
         `${outside} condensed help text(s) on ${page} sit outside the ${CONDENSE_ROOT} container, so no sentence is ever written under those fields`,
       );
     }
+
+    // TWO HELP BLOCKS IN ONE FIELD (#1663). The applier keeps the FIRST in document
+    // order and the second is then unreachable from the rail card - focus anywhere in
+    // that field shows the first block's text, whichever control the reader is in. The
+    // fold and the sentence under the field are unaffected, so nothing on the page
+    // looks wrong; the card just answers with the wrong text, which is the failure a
+    // reader is least able to name.
+    //
+    // WHY IT IS REFUSED ON THIS PAGE AND NOT ON THE THREE BEFORE IT. No page carried
+    // the shape when slice 1 landed, counted over its twenty blocks, and the applier
+    // says so at the choice it makes rather than leaving it to be discovered. The
+    // Providers page is where it can first arise: 112 sites in 98 keys over two
+    // protocol forms, fourteen keys standing twice. It does not carry the shape today
+    // either - this refusal is green on the tree it lands with, and its bite is the
+    // negative arm below rather than a page it currently catches.
+    forEachSharedField(markup, at, (first, second) =>
+      refusals.push(
+        `${first} and ${second} on ${page} are two help blocks in one field: the rail card answers for ${first} wherever the focus lands in it, and ${second} is unreachable from it`,
+      ),
+    );
   }
 
   return { refusals, blocks };
+}
+
+/*
+ * Calls back once per pair of condensed blocks that the applier would resolve to ONE
+ * field, naming the key it keeps and the key it drops.
+ *
+ * THE FIELD IS DECIDED THE WAY THE APPLIER DECIDES IT, which is the only reading that
+ * makes the refusal about the page rather than about this file: `fieldOf` in
+ * SSO-Auth/Web/i18n.js walks up from the block to the nearest `inputContainer` or
+ * `checkboxContainer`, so the innermost such element containing a block is its field.
+ * A block inside neither is its own parent's, which no two blocks can share unless
+ * they are siblings - a shape this reader does not see and the note above says so.
+ */
+function forEachSharedField(markup, blocks, say) {
+  const containers = [];
+  const opening = /<([a-z][a-z0-9]*)([^>]*)>/g;
+  let match;
+  while ((match = opening.exec(markup)) !== null) {
+    if (/\/\s*$/.test(match[2])) {
+      continue;
+    }
+    const names = (/class="([^"]*)"/.exec(match[2]) || ["", ""])[1].split(
+      /\s+/,
+    );
+    if (
+      !names.includes("inputContainer") &&
+      !names.includes("checkboxContainer")
+    ) {
+      continue;
+    }
+    const from = match.index + match[0].length;
+    const body = elementBody(markup, from, match[1]);
+    if (body !== null) {
+      containers.push({ from, to: from + body.length });
+    }
+  }
+
+  // INNERMOST WINS, because a container nested in another is the field the applier
+  // stops at first on its way up. Picking the outermost would collapse every field of
+  // a section into one and refuse a page nothing is wrong with.
+  const held = new Map();
+  blocks.forEach((block) => {
+    let field = null;
+    containers.forEach((span) => {
+      if (block.index < span.from || block.index > span.to) {
+        return;
+      }
+      if (field === null || span.from > field.from) {
+        field = span;
+      }
+    });
+    if (field === null) {
+      return;
+    }
+    if (held.has(field.from)) {
+      say(held.get(field.from), block.key);
+      return;
+    }
+    held.set(field.from, block.key);
+  });
 }
 
 // The span of the container a page marks for condensing, or null when it marks
@@ -882,7 +978,7 @@ function fixtureMarkup(key, parts) {
   if (p.flat) {
     return [
       `<div ${CONDENSE_ROOT}>`,
-      `<div class="fieldDescription" data-i18n="${key}">whatever</div>`,
+      `<div class="fieldDescription" data-i18n${p.assembled ? "-parts" : ""}="${key}">whatever</div>`,
       `</div>`,
     ].join("\n");
   }
@@ -897,7 +993,9 @@ function fixtureMarkup(key, parts) {
       ? `<summary data-i18n="${SUMMARY_KEY}">Full text</summary>`
       : `<summary data-i18n="config.something_else">More</summary>`,
     p.body
-      ? `<div class="sso-help-body" data-i18n="${key}">whatever</div>`
+      ? p.assembled
+        ? `<div class="sso-help-body" data-i18n-parts="${key}">whatever <strong data-i18n="config.fixture_emphasis">this</strong></div>`
+        : `<div class="sso-help-body" data-i18n="${key}">whatever</div>`
       : `<div class="sso-help-body"><span data-i18n="${key}">whatever</span></div>`,
     p.details ? `</details>` : "</div>",
     `</div>`,
@@ -912,6 +1010,32 @@ function fixtureMarkup(key, parts) {
   return [`<div ${CONDENSE_ROOT}>`, block, p.card ? card : "", `</div>`].join(
     "\n",
   );
+}
+
+/*
+ * Two condensed blocks, in two field containers or in one (#1663).
+ *
+ * THE NEAR-MISS IS THE POINT AND IT IS ONE CLOSING TAG. `shared: false` is the shape
+ * every page already has - a block per field - and `shared: true` is that page with
+ * one `</div>` moved, which is exactly the edit somebody makes while rearranging a
+ * form. The refusal has to separate those two and nothing else.
+ */
+function fixturePair(key, other, shared) {
+  const block = (name) =>
+    [
+      `<div class="fieldDescription sso-help">`,
+      `<span class="sso-help-lead"></span>`,
+      `<details class="sso-help-full">`,
+      `<summary data-i18n="${SUMMARY_KEY}">Full text</summary>`,
+      `<div class="sso-help-body" data-i18n="${name}">whatever</div>`,
+      `</details>`,
+      `</div>`,
+    ].join("\n");
+  const card = `<div class="verticalSection sso-help-card" hidden><h2 class="sectionTitle" data-i18n="${SUMMARY_KEY}">Full text</h2><div class="sso-help-card-text"></div></div>`;
+  const fields = shared
+    ? `<div class="inputContainer">${block(key)}${block(other)}</div>`
+    : `<div class="inputContainer">${block(key)}</div><div class="inputContainer">${block(other)}</div>`;
+  return [`<div ${CONDENSE_ROOT}>`, fields, card, `</div>`].join("\n");
 }
 
 async function calibrate(i18n) {
@@ -939,8 +1063,28 @@ async function calibrate(i18n) {
       fixtureMarkup("config.fixture_0_help", { comment: true }),
     ).refusals,
   );
+  record(
+    "a fold whose text is assembled from parts",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { assembled: true }),
+    ).refusals,
+  );
+  record(
+    "two help blocks in two fields",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixturePair("config.fixture_0_help", "config.fixture_1_help", false),
+    ).refusals,
+  );
   const markupNegatives = [
     ["a help text still written flat", { flat: true }],
+    [
+      "a parts-marked help text still written flat",
+      { flat: true, assembled: true },
+    ],
     ["a block the applier will not find", { marked: false }],
     ["a fold with no lead line to fill", { lead: false }],
     ["a whole text behind no fold", { details: false }],
@@ -956,6 +1100,14 @@ async function calibrate(i18n) {
       inspectMarkup("fixture", fixtureMarkup("config.fixture_0_help", parts))
         .refusals,
     ),
+  );
+  record(
+    "two help blocks in one field",
+    true,
+    inspectMarkup(
+      "fixture",
+      fixturePair("config.fixture_0_help", "config.fixture_1_help", true),
+    ).refusals,
   );
 
   // --- the hand-written answers, which is the only arm not derived from the rule ---
@@ -1243,11 +1395,27 @@ async function run() {
     // moment Prettier wraps the body tag, and a run that counted nothing printed
     // a green line for all three pages. That is the shape this tool exists to
     // refuse, arriving in the tool itself.
-    const keys = [
+    const bodies = [
       ...markup
         .replace(/\s+/g, " ")
-        .matchAll(/class="sso-help-body" data-i18n="([a-z0-9_.]+_help)"/g),
-    ].map((m) => m[1]);
+        .matchAll(
+          /class="sso-help-body" data-i18n(?<parts>-parts)?="(?<key>[a-z0-9_.]+_help)"/g,
+        ),
+    ].map((m) => ({ key: m.groups.key, parts: m.groups.parts !== undefined }));
+    const keys = bodies.map((body) => body.key);
+
+    // WHAT THE APPLIER IS DRIVEN OVER IS THE PLAIN-BODIED HALF, AND THE OTHER HALF IS
+    // PRINTED RATHER THAN COUNTED SILENTLY (#1663). A `data-i18n-parts` body holds a
+    // catalogue value with `{n}` slots that the pass fills from the body's own child
+    // elements, so the text a reader sees is assembled on the page and the raw value
+    // is not it. The page this file BUILDS carries no such children - buildPage writes
+    // one text node per body - so feeding a parts key into it would judge the lead
+    // against a sentence holding `{0}`, which is a refusal about this fixture rather
+    // than about the page. The markup half above judges every block on both spellings;
+    // this half judges the ones whose text is the catalogue row itself.
+    const driven = bodies.filter((body) => !body.parts).map((b) => b.key);
+    const assembled = keys.length - driven.length;
+
     if (keys.length === 0) {
       console.error(
         `REFUSED  ${page} carries ${CONDENSE_ROOT} and no condensed help text, so the applier is driven over nothing on it`,
@@ -1282,12 +1450,12 @@ async function run() {
       }
 
       const texts = Object.fromEntries(
-        keys.map((key) => [
+        driven.map((key) => [
           key,
           values[key] !== undefined ? values[key] : en[key],
         ]),
       );
-      const built = buildPage(keys, texts, summary, {});
+      const built = buildPage(driven, texts, summary, {});
       await render(i18n, built, { ...texts, [SUMMARY_KEY]: summary });
       const runtime = inspect(built, texts, summary);
       [
@@ -1299,7 +1467,10 @@ async function run() {
       });
       if (name === "en") {
         console.log(
-          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence`,
+          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence` +
+            (assembled === 0
+              ? ""
+              : `, ${assembled} assembled from parts and judged by the markup reader only`),
         );
       }
     }


### PR DESCRIPTION
# Superseded by #1673, and the reason is a defect this branch ships

This branch condensed every `*_help` field description on the Providers page,
and the adversarial review that ran against its head found a shape this branch
gets wrong. It is replaced rather than amended, which is what #1663 asks for
after a review and the only shape available here, since a force-push is not.

**What is wrong with this head.** Two folds are authored inside a
`<p class="fieldDescription">` - both first-run empty states. `<details>` is on
the HTML spec's implied-end-tag list for `<p>`, so a browser closes the `<p>`
before the fold and lifts the fold out of the block. The applier then finds a
`.sso-help` with no `.sso-help-body`, returns at its guard, and the lead line
stays empty for good - which the stylesheet hides, so those two fields show a
bare "Full text" triangle and nothing above it. A focus inside either field
raises an uncaught `TypeError` in the rail handler and leaves the card showing
the previous field's text.

Both readers in the gate were green over it, because both walk the tags as
AUTHORED and a browser walks them as PARSED.

**What #1673 does about it.** The two blocks are `<div>`, and a fold authored
inside a `<p>` is refused by name - put this branch's markup back and the gate
names exactly those two keys. It also carries the second review's finding, that
the shared-field refusal read only one of the two branches `fieldOf` walks, and
a heading-level repair. The full record is in that pull request's body.

Nothing here is lost: #1673 is this change plus those repairs, as one commit.
Closed rather than left open so the issue has one candidate from me.
