### PR TITLE
Condense the help on the Providers page [#1663]

### DIFF
--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -124,7 +124,10 @@
             aria-live="polite"
           ></div>
 
-          <div class="sso-columns sso-columns--rail-first">
+          <div
+            class="sso-columns sso-columns--rail-first"
+            data-sso-condensed-help
+          >
             <div class="sso-column-main">
               <!--
             Configuration check (#1084): ONE action across every configured OpenID and SAML provider,
@@ -215,21 +218,29 @@
                     >
                       No SSO providers yet
                     </p>
-                    <p
-                      class="fieldDescription"
-                      data-i18n-parts="config.oidc_empty_help"
-                    >
-                      Add an OpenID Connect provider to let users sign in
-                      through your identity provider. See the
-                      <a
-                        is="emby-linkbutton"
-                        href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
-                        class="button-link"
-                        data-i18n="config.link_quickstart"
-                        >quick-start guide</a
-                      >
-                      to get the endpoint, client id and secret from your
-                      provider.
+                    <p class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.oidc_empty_help"
+                        >
+                          Add an OpenID Connect provider to let users sign in
+                          through your identity provider. See the
+                          <a
+                            is="emby-linkbutton"
+                            href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki"
+                            class="button-link"
+                            data-i18n="config.link_quickstart"
+                            >quick-start guide</a
+                          >
+                          to get the endpoint, client id and secret from your
+                          provider.
+                        </div>
+                      </details>
                     </p>
                     <!--
                   First-run guided path (#1085). The steps NAME the controls that already exist inside the
@@ -456,16 +467,24 @@
                       role="status"
                       aria-live="polite"
                     ></div>
-                    <div
-                      class="fieldDescription"
-                      data-i18n="config.template_picker_help"
-                    >
-                      Pre-fills the scopes, role-claim path, username claim, and
-                      an endpoint placeholder for a known identity provider, and
-                      enables only the compatibility options it needs. Review
-                      every field &mdash; especially the endpoint &mdash; and
-                      enter your client secret before saving. Nothing is saved
-                      automatically.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.template_picker_help"
+                        >
+                          Pre-fills the scopes, role-claim path, username claim,
+                          and an endpoint placeholder for a known identity
+                          provider, and enables only the compatibility options
+                          it needs. Review every field &mdash; especially the
+                          endpoint &mdash; and enter your client secret before
+                          saving. Nothing is saved automatically.
+                        </div>
+                      </details>
                     </div>
                   </div>
 
@@ -517,19 +536,28 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_name_help"
-                        >
-                          The name used by Jellyfin to identify the OpenID
-                          provider.
-                          <br />
-                          If an OpenID provider with a matching name does not
-                          exist, a new provider with this name will be created.
-                          <br />
-                          If an OpenID provider with a matching name already
-                          exists, the settings for that provider will be
-                          updated.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_name_help"
+                            >
+                              The name used by Jellyfin to identify the OpenID
+                              provider.
+                              <br />
+                              If an OpenID provider with a matching name does
+                              not exist, a new provider with this name will be
+                              created.
+                              <br />
+                              If an OpenID provider with a matching name already
+                              exists, the settings for that provider will be
+                              updated.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -573,29 +601,38 @@
                           role="status"
                           aria-live="polite"
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          id="OidRedirectUri-help"
-                          data-i18n-parts="config.oid_redirect_uri_help"
-                        >
-                          The exact redirect URI the login uses. Register it
-                          verbatim at your identity provider. The server builds
-                          it and this field shows what the server answered, so
-                          it is the same string the login sends rather than a
-                          copy of it. Save the provider first: an unsaved one
-                          has nothing for the server to answer for. It is built
-                          from the
-                          <strong data-i18n="config.base_url_override_name"
-                            >Base URL Override</strong
-                          >
-                          (in the Advanced section) when set, otherwise this
-                          server's address; if you sit behind a reverse proxy,
-                          set that override and save, so this matches what the
-                          login actually sends. Users who still start at the
-                          legacy <code>/sso/OID/p/&lt;name&gt;</code> route send
-                          the legacy
-                          <code>/sso/OID/r/&lt;name&gt;</code> spelling instead;
-                          register that one too if any of them do.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              id="OidRedirectUri-help"
+                              data-i18n-parts="config.oid_redirect_uri_help"
+                            >
+                              The exact redirect URI the login uses. Register it
+                              verbatim at your identity provider. The server
+                              builds it and this field shows what the server
+                              answered, so it is the same string the login sends
+                              rather than a copy of it. Save the provider first:
+                              an unsaved one has nothing for the server to
+                              answer for. It is built from the
+                              <strong data-i18n="config.base_url_override_name"
+                                >Base URL Override</strong
+                              >
+                              (in the Advanced section) when set, otherwise this
+                              server's address; if you sit behind a reverse
+                              proxy, set that override and save, so this matches
+                              what the login actually sends. Users who still
+                              start at the legacy
+                              <code>/sso/OID/p/&lt;name&gt;</code> route send
+                              the legacy
+                              <code>/sso/OID/r/&lt;name&gt;</code> spelling
+                              instead; register that one too if any of them do.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -623,12 +660,20 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_endpoint_help"
-                        >
-                          The OpenID endpoint. Must have a .well-known path
-                          available.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_endpoint_help"
+                            >
+                              The OpenID endpoint. Must have a .well-known path
+                              available.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -656,17 +701,25 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_client_id_help"
-                        >
-                          The OpenID client ID, for this media server instance.
-                          This is configured on the OIDC provider to uniquely
-                          identify
-                          <strong data-i18n="config.oid_client_id_this"
-                            >this</strong
-                          >
-                          Jellyfin instance.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_client_id_help"
+                            >
+                              The OpenID client ID, for this media server
+                              instance. This is configured on the OIDC provider
+                              to uniquely identify
+                              <strong data-i18n="config.oid_client_id_this"
+                                >this</strong
+                              >
+                              Jellyfin instance.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -691,14 +744,22 @@
                           data-i18n-placeholder="config.placeholder_keep_secret"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_secret_help"
-                        >
-                          The OpenID client secret. Randomly generated & shared.
-                          For security it is never sent back to this page: leave
-                          it blank to keep the stored value, or enter a new
-                          secret to replace it.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_secret_help"
+                            >
+                              The OpenID client secret. Randomly generated &
+                              shared. For security it is never sent back to this
+                              page: leave it blank to keep the stored value, or
+                              enter a new secret to replace it.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -726,26 +787,34 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_scopes_help"
-                        >
-                          Specify additional scopes to include in the OIDC
-                          request.
-                          <br />
-                          One scope per line, each line should contain a scope
-                          name to include in the OIDC request.
-                          <br />
-                          For some OIDC providers (For example,
-                          <a
-                            is="emby-linkbutton"
-                            href="https://github.com/9p4/jellyfin-plugin-sso/issues/23#issuecomment-1112237616"
-                            class="button-link"
-                            >authelia</a
-                          >), additional scopes may be required in order to
-                          validate group membership in role claim.
-                          <br />
-                          Leave blank to only request the default scopes.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_scopes_help"
+                            >
+                              Specify additional scopes to include in the OIDC
+                              request.
+                              <br />
+                              One scope per line, each line should contain a
+                              scope name to include in the OIDC request.
+                              <br />
+                              For some OIDC providers (For example,
+                              <a
+                                is="emby-linkbutton"
+                                href="https://github.com/9p4/jellyfin-plugin-sso/issues/23#issuecomment-1112237616"
+                                class="button-link"
+                                >authelia</a
+                              >), additional scopes may be required in order to
+                              validate group membership in role claim.
+                              <br />
+                              Leave blank to only request the default scopes.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -783,15 +852,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.provider_hide_login_button_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Excludes this provider from the managed "Sign in with
-                          …" block on the login page while keeping it usable
-                          through its direct start URL. Only takes effect while
-                          the global "Manage login buttons on the login page"
-                          option is on; it never hides anything you added to the
-                          branding yourself.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_hide_login_button_help"
+                            >
+                              Excludes this provider from the managed "Sign in
+                              with …" block on the login page while keeping it
+                              usable through its direct start URL. Only takes
+                              effect while the global "Manage login buttons on
+                              the login page" option is on; it never hides
+                              anything you added to the branding yourself.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -813,16 +892,24 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provider_login_button_text_help"
-                        >
-                          Custom label for this provider's managed login-page
-                          button. Leave blank to use the provider name. Only
-                          takes effect while the global "Manage login buttons on
-                          the login page" option is on and the button is not
-                          hidden; any text is safe: it is always rendered inert,
-                          never as markup.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_login_button_text_help"
+                            >
+                              Custom label for this provider's managed
+                              login-page button. Leave blank to use the provider
+                              name. Only takes effect while the global "Manage
+                              login buttons on the login page" option is on and
+                              the button is not hidden; any text is safe: it is
+                              always rendered inert, never as markup.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -844,18 +931,26 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.oidc_post_logout_redirect_help"
-                        >
-                          The URL the identity provider returns the browser to
-                          after an RP-initiated OpenID logout, sent as
-                          post_logout_redirect_uri. Honoured only if it is an
-                          absolute http(s) URL at or under this server's base
-                          URL; an off-base or malformed value is rejected on
-                          save. Leave blank for no post-logout redirect. Only
-                          takes effect while the global "Enable Single Logout"
-                          option is on.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.oidc_post_logout_redirect_help"
+                            >
+                              The URL the identity provider returns the browser
+                              to after an RP-initiated OpenID logout, sent as
+                              post_logout_redirect_uri. Honoured only if it is
+                              an absolute http(s) URL at or under this server's
+                              base URL; an off-base or malformed value is
+                              rejected on save. Leave blank for no post-logout
+                              redirect. Only takes effect while the global
+                              "Enable Single Logout" option is on.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -887,17 +982,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.enable_authorization_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines if the plugin sets permissions for the
-                          user.
-                          <br />
-                          If false, the user will start with no permissions and
-                          an administrator will add permissions.
-                          <br />
-                          The permissions of existing users will not be
-                          rewritten on subsequent logins.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.enable_authorization_help"
+                            >
+                              Determines if the plugin sets permissions for the
+                              user.
+                              <br />
+                              If false, the user will start with no permissions
+                              and an administrator will add permissions.
+                              <br />
+                              The permissions of existing users will not be
+                              rewritten on subsequent logins.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -920,13 +1025,21 @@
                           class="sso-text"
                           placeholder="preferred_username"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.default_username_claim_help"
-                        >
-                          The default username claim to use from OpenID by
-                          default. If it is not set, it defaults to
-                          <code>preferred_username</code>.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.default_username_claim_help"
+                            >
+                              The default username claim to use from OpenID by
+                              default. If it is not set, it defaults to
+                              <code>preferred_username</code>.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -948,19 +1061,27 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.default_provider_help"
-                        >
-                          The set provider then gets assigned to the user after
-                          they have logged in. If it is not set, nothing is
-                          changed. With this, a user can login with SSO but is
-                          still able to log in via other providers later.<br />A
-                          common option is
-                          <code
-                            >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
-                          >
-                          for the default provider.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.default_provider_help"
+                            >
+                              The set provider then gets assigned to the user
+                              after they have logged in. If it is not set,
+                              nothing is changed. With this, a user can login
+                              with SSO but is still able to log in via other
+                              providers later.<br />A common option is
+                              <code
+                                >Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider</code
+                              >
+                              for the default provider.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -985,6 +1106,7 @@
                         <div
                           class="fieldDescription"
                           data-i18n-parts="config.avatar_url_format_help"
+                          data-sso-help-flat
                         >
                           The url of the avatar with sso variable format:
                           example :
@@ -1009,12 +1131,22 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.avatar_no_fetch_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          With no avatar url format above, the standard OIDC
-                          <code>picture</code> claim is used automatically.
-                          Check this to opt out of that fetch entirely.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.avatar_no_fetch_help"
+                            >
+                              With no avatar url format above, the standard OIDC
+                              <code>picture</code> claim is used automatically.
+                              Check this to opt out of that fetch entirely.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1042,24 +1174,35 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.role_claim_help"
-                        >
-                          This is the value in the OpenID response to check for
-                          roles. The first element is the claim type, the
-                          subsequent values are to parse the JSON of the claim
-                          value. Use a
-                          <code>"\."</code> to denote a literal ".". This
-                          expects a list of strings from the OIDC server, unless
-                          "Role claim is an object map" below is on.
-                          <br />
-                          For Keycloak, it is <code>realm_access.roles</code> by
-                          default for realm roles. For client roles, it is
-                          <code>resource_access.&gt;clientId&lt;.roles</code>
-                          (e.g. resource_access.jellyfin.roles)
-                          <br />
-                          For Authelia, it is <code>groups</code>
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.role_claim_help"
+                            >
+                              This is the value in the OpenID response to check
+                              for roles. The first element is the claim type,
+                              the subsequent values are to parse the JSON of the
+                              claim value. Use a
+                              <code>"\."</code> to denote a literal ".". This
+                              expects a list of strings from the OIDC server,
+                              unless "Role claim is an object map" below is on.
+                              <br />
+                              For Keycloak, it is
+                              <code>realm_access.roles</code> by default for
+                              realm roles. For client roles, it is
+                              <code
+                                >resource_access.&gt;clientId&lt;.roles</code
+                              >
+                              (e.g. resource_access.jellyfin.roles)
+                              <br />
+                              For Authelia, it is <code>groups</code>
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1080,24 +1223,35 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.role_claim_object_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Read the roles from the property
-                          <em data-i18n="config.role_claim_names_emphasis"
-                            >names</em
-                          >
-                          of a JSON object instead of from a list of strings.
-                          Zitadel needs this: it emits
-                          <code
-                            >{"jellyfin-access": {"&lt;orgId&gt;":
-                            "&lt;domain&gt;"}}</code
-                          >
-                          under <code>urn:zitadel:iam:org:project:roles</code>.
-                          Only the names are read, never the values, never
-                          nested objects. Off by default; leave it off for a
-                          provider that returns a list (Keycloak, Authelia,
-                          authentik).
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.role_claim_object_help"
+                            >
+                              Read the roles from the property
+                              <em data-i18n="config.role_claim_names_emphasis"
+                                >names</em
+                              >
+                              of a JSON object instead of from a list of
+                              strings. Zitadel needs this: it emits
+                              <code
+                                >{"jellyfin-access": {"&lt;orgId&gt;":
+                                "&lt;domain&gt;"}}</code
+                              >
+                              under
+                              <code>urn:zitadel:iam:org:project:roles</code>.
+                              Only the names are read, never the values, never
+                              nested objects. Off by default; leave it off for a
+                              provider that returns a list (Keycloak, Authelia,
+                              authentik).
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -1123,15 +1277,24 @@
                     class="verticalSection verticalSection-extrabottompadding"
                   >
                     <div class="collapseContent">
-                      <div
-                        class="fieldDescription"
-                        data-i18n="config.template_help"
-                      >
-                        What a brand-new account created by this provider starts
-                        with. Every field is opt-in: anything you leave alone
-                        keeps Jellyfin's own default, and these values are
-                        written once, when the account is created, so a change
-                        made later survives every following login.
+                      <div class="fieldDescription sso-help">
+                        <span class="sso-help-lead"></span>
+                        <details class="sso-help-full">
+                          <summary data-i18n="config.help_full_text">
+                            Full text
+                          </summary>
+                          <div
+                            class="sso-help-body"
+                            data-i18n="config.template_help"
+                          >
+                            What a brand-new account created by this provider
+                            starts with. Every field is opt-in: anything you
+                            leave alone keeps Jellyfin's own default, and these
+                            values are written once, when the account is
+                            created, so a change made later survives every
+                            following login.
+                          </div>
+                        </details>
                       </div>
                       <div
                         id="Tmpl-profile-note"
@@ -1169,18 +1332,26 @@
                           name="ProvisioningProfile"
                           class="sso-tmpl-profile emby-select-withcolor emby-select"
                         ></select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provisioning_profile_help"
-                        >
-                          Take the starting policy from a profile defined in
-                          Provisioning Profiles above, instead of from the
-                          fields below. The two are mutually exclusive: a
-                          provider that names a profile and also carries its own
-                          inline fields is refused on save, because one
-                          account-creation policy has one source. Leave it on
-                          (none), or set it back to (none) and save, to use the
-                          fields below again.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provisioning_profile_help"
+                            >
+                              Take the starting policy from a profile defined in
+                              Provisioning Profiles above, instead of from the
+                              fields below. The two are mutually exclusive: a
+                              provider that names a profile and also carries its
+                              own inline fields is refused on save, because one
+                              account-creation policy has one source. Leave it
+                              on (none), or set it back to (none) and save, to
+                              use the fields below again.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1199,13 +1370,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_bitrate_help"
-                        >
-                          The remote streaming ceiling in bits per second. Zero
-                          means no limit, which is a real setting rather than an
-                          empty one. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_bitrate_help"
+                            >
+                              The remote streaming ceiling in bits per second.
+                              Zero means no limit, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1224,14 +1404,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_sessions_help"
-                        >
-                          How many sessions the account may hold at once. Zero
-                          means unlimited, which is a real setting rather than
-                          an empty one. Leave blank to keep Jellyfin's own
-                          default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_sessions_help"
+                            >
+                              How many sessions the account may hold at once.
+                              Zero means unlimited, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1248,14 +1436,23 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_audio_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. It is passed on as given rather than checked
-                          against a list, so any code Jellyfin accepts works.
-                          Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_audio_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. It is passed on as given rather than
+                              checked against a list, so any code Jellyfin
+                              accepts works. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1272,12 +1469,21 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1302,14 +1508,22 @@
                           <option value="None">None</option>
                           <option value="Smart">Smart</option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_mode_help"
-                        >
-                          Which subtitles play by default. The options are the
-                          exact mode names Jellyfin declares, which is the
-                          spelling a save accepts; leaving it unset keeps
-                          Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_mode_help"
+                            >
+                              Which subtitles play by default. The options are
+                              the exact mode names Jellyfin declares, which is
+                              the spelling a save accepts; leaving it unset
+                              keeps Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1335,13 +1549,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_play_default_audio_help"
-                        >
-                          Leaving this unset keeps Jellyfin's own default. No is
-                          a deliberate setting rather than an absent one, which
-                          is why this is a list and not a checkbox.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_play_default_audio_help"
+                            >
+                              Leaving this unset keeps Jellyfin's own default.
+                              No is a deliberate setting rather than an absent
+                              one, which is why this is a list and not a
+                              checkbox.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1367,14 +1590,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_audio_help"
-                        >
-                          Whether an audio track chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_audio_help"
+                            >
+                              Whether an audio track chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1400,14 +1631,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_subtitle_help"
-                        >
-                          Whether a subtitle chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_subtitle_help"
+                            >
+                              Whether a subtitle chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -1424,18 +1663,27 @@
                           type="text"
                           class="sso-tmpl-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_home_sections_help"
-                        >
-                          The sections of the web client's home screen, one per
-                          line, top slot first: None, SmallLibraryTiles,
-                          LibraryButtons, ActiveRecordings, Resume, ResumeAudio,
-                          LatestMedia, NextUp, LiveTv or ResumeBook, spelled
-                          exactly like that. Up to ten lines; the slots you do
-                          not fill show nothing, as they would after saving the
-                          client's own home-screen settings. Leave the box empty
-                          to keep Jellyfin's own layout.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_home_sections_help"
+                            >
+                              The sections of the web client's home screen, one
+                              per line, top slot first: None, SmallLibraryTiles,
+                              LibraryButtons, ActiveRecordings, Resume,
+                              ResumeAudio, LatestMedia, NextUp, LiveTv or
+                              ResumeBook, spelled exactly like that. Up to ten
+                              lines; the slots you do not fill show nothing, as
+                              they would after saving the client's own
+                              home-screen settings. Leave the box empty to keep
+                              Jellyfin's own layout.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="sso-subgroup">
@@ -1445,18 +1693,27 @@
                         >
                           Permissions written onto a new account
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_permissions_help"
-                        >
-                          Each row names one Jellyfin permission and the value a
-                          new account starts with. A permission that is not
-                          listed is never touched. The names come from the
-                          server rather than from a list kept on this page, so
-                          they cannot drift from what a save accepts;
-                          administrator, all-folders and Live TV access are not
-                          offered here because each keeps its own setting above,
-                          and no account can be created disabled from here.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_permissions_help"
+                            >
+                              Each row names one Jellyfin permission and the
+                              value a new account starts with. A permission that
+                              is not listed is never touched. The names come
+                              from the server rather than from a list kept on
+                              this page, so they cannot drift from what a save
+                              accepts; administrator, all-folders and Live TV
+                              access are not offered here because each keeps its
+                              own setting above, and no account can be created
+                              disabled from here.
+                            </div>
+                          </details>
                         </div>
                         <div
                           id="Tmpl-Permissions"
@@ -1513,23 +1770,32 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.oid_roles_help"
-                        >
-                          A list of roles, one role per-line to look for in the
-                          OpenID response.
-                          <br />
-                          If a user has any of these roles, then the user is
-                          authenticated. This validates the OpenID response
-                          against the claim set in
-                          <strong data-i18n="config.role_claim_property_name"
-                            >"RoleClaim"</strong
-                          >. (If your provider carries the roles as object keys,
-                          as Zitadel does, also tick "Role claim is an object
-                          map" beside the Role Claim field.)
-                          <br />
-                          Leave blank to disable role checking.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.oid_roles_help"
+                            >
+                              A list of roles, one role per-line to look for in
+                              the OpenID response.
+                              <br />
+                              If a user has any of these roles, then the user is
+                              authenticated. This validates the OpenID response
+                              against the claim set in
+                              <strong
+                                data-i18n="config.role_claim_property_name"
+                                >"RoleClaim"</strong
+                              >. (If your provider carries the roles as object
+                              keys, as Zitadel does, also tick "Role claim is an
+                              object map" beside the Role Claim field.)
+                              <br />
+                              Leave blank to disable role checking.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1551,20 +1817,28 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.admin_roles_help"
-                        >
-                          A list of roles, one role per-line to look for in the
-                          OpenID response.
-                          <br />
-                          Like
-                          <strong data-i18n="config.roles_field_name"
-                            >"Roles"</strong
-                          >, but having any of the roles confers admin
-                          privilege.
-                          <br />
-                          If unset will not grant admin privileges.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.admin_roles_help"
+                            >
+                              A list of roles, one role per-line to look for in
+                              the OpenID response.
+                              <br />
+                              Like
+                              <strong data-i18n="config.roles_field_name"
+                                >"Roles"</strong
+                              >, but having any of the roles confers admin
+                              privilege.
+                              <br />
+                              If unset will not grant admin privileges.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1596,6 +1870,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.oidc_enable_all_folders_help"
+                            data-sso-help-flat
                           >
                             If enabled, all libraries will be accessible to any
                             user that logs in through this provider.
@@ -1616,18 +1891,27 @@
                             id="EnabledFolders"
                             class="checkboxList paperList checkboxList-paperList sso-folder-list sso-bordered-list"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.enabled_folders_help"
-                          >
-                            Determines which libraries will be accessible to a
-                            user that logs in through this provider.
-                            <br />
-                            If
-                            <strong data-i18n="config.enable_all_folders_name"
-                              >"Enable All Folders"</strong
-                            >
-                            is checked, then this has no effect.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.enabled_folders_help"
+                              >
+                                Determines which libraries will be accessible to
+                                a user that logs in through this provider.
+                                <br />
+                                If
+                                <strong
+                                  data-i18n="config.enable_all_folders_name"
+                                  >"Enable All Folders"</strong
+                                >
+                                is checked, then this has no effect.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1651,6 +1935,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.oidc_enable_folder_roles_help"
+                            data-sso-help-flat
                           >
                             Determines if user roles should be used to control
                             library access.
@@ -1686,20 +1971,29 @@
                             id="FolderRoleMapping"
                             class="sso-role-map"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.folder_role_mapping_help"
-                          >
-                            Map roles (given by
-                            <strong data-i18n="config.role_claim_field_name"
-                              >"Role Claim"</strong
-                            >) to lists of libraries. If a user has a given
-                            role, they will have access to the corresponding
-                            libraries. If
-                            <strong data-i18n="config.enable_folder_roles_name"
-                              >"Enable Role-Based Folder Access"</strong
-                            >
-                            is disabled, has no effect.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.folder_role_mapping_help"
+                              >
+                                Map roles (given by
+                                <strong data-i18n="config.role_claim_field_name"
+                                  >"Role Claim"</strong
+                                >) to lists of libraries. If a user has a given
+                                role, they will have access to the corresponding
+                                libraries. If
+                                <strong
+                                  data-i18n="config.enable_folder_roles_name"
+                                  >"Enable Role-Based Folder Access"</strong
+                                >
+                                is disabled, has no effect.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -1734,6 +2028,7 @@
                         <div
                           class="fieldDescription checkboxFieldDescription"
                           data-i18n="config.oidc_enable_live_tv_roles_help"
+                          data-sso-help-flat
                         >
                           Determines whether the roles will be used to grant
                           Live TV privileges.
@@ -1759,18 +2054,26 @@
                             type="text"
                             class="sso-line-list emby-textarea"
                           ></textarea>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.livetv_roles_help"
-                          >
-                            A list of roles, one role per-line to look for in
-                            the OpenID response.
-                            <br />
-                            Like
-                            <strong data-i18n="config.roles_field_name"
-                              >"Roles"</strong
-                            >, but having any of the roles confers Live TV
-                            privileges.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.livetv_roles_help"
+                              >
+                                A list of roles, one role per-line to look for
+                                in the OpenID response.
+                                <br />
+                                Like
+                                <strong data-i18n="config.roles_field_name"
+                                  >"Roles"</strong
+                                >, but having any of the roles confers Live TV
+                                privileges.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -1792,18 +2095,26 @@
                             type="text"
                             class="sso-line-list emby-textarea"
                           ></textarea>
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.livetv_management_roles_help"
-                          >
-                            A list of roles, one role per-line to look for in
-                            the OpenID response.
-                            <br />
-                            Like
-                            <strong data-i18n="config.roles_field_name"
-                              >"Roles"</strong
-                            >, but having any of the roles confers Live TV
-                            administration privileges.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.livetv_management_roles_help"
+                              >
+                                A list of roles, one role per-line to look for
+                                in the OpenID response.
+                                <br />
+                                Like
+                                <strong data-i18n="config.roles_field_name"
+                                  >"Roles"</strong
+                                >, but having any of the roles confers Live TV
+                                administration privileges.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -1824,17 +2135,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.livetv_access_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines whether the user can view Live TV by
-                          default.
-                          <br />
-                          This value is still used if
-                          <strong data-i18n="config.livetv_rbac_name"
-                            >Live TV RBAC</strong
-                          >
-                          is enabled!
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.livetv_access_help"
+                            >
+                              Determines whether the user can view Live TV by
+                              default.
+                              <br />
+                              This value is still used if
+                              <strong data-i18n="config.livetv_rbac_name"
+                                >Live TV RBAC</strong
+                              >
+                              is enabled!
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -1855,17 +2176,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n-parts="config.livetv_manage_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines whether the user can manage Live TV by
-                          default.
-                          <br />
-                          This value is still used if
-                          <strong data-i18n="config.livetv_rbac_name"
-                            >Live TV RBAC</strong
-                          >
-                          is enabled!
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.livetv_manage_help"
+                            >
+                              Determines whether the user can manage Live TV by
+                              default.
+                              <br />
+                              This value is still used if
+                              <strong data-i18n="config.livetv_rbac_name"
+                                >Live TV RBAC</strong
+                              >
+                              is enabled!
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -1898,6 +2229,7 @@
                         <div
                           class="fieldDescription checkboxFieldDescription"
                           data-i18n="config.oidc_do_not_load_profile_help"
+                          data-sso-help-flat
                         >
                           May be required for Cloudflare OpenID
                         </div>
@@ -1924,6 +2256,7 @@
                         <div
                           class="fieldDescription"
                           data-i18n="config.oidc_scheme_override_help"
+                          data-sso-help-flat
                         >
                           If the plugin is redirecting to an insecure URL, set
                           this to "https"
@@ -1951,6 +2284,7 @@
                         <div
                           class="fieldDescription"
                           data-i18n="config.oidc_port_override_help"
+                          data-sso-help-flat
                         >
                           If the plugin is redirecting to an incorrect port, set
                           this to the appropiate port
@@ -1982,17 +2316,26 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.base_url_override_help"
-                        >
-                          The canonical external base URL of this server, e.g.
-                          <code>https://jellyfin.example.com</code>. When set,
-                          the redirect URI and SAML base URL are built from it
-                          instead of the request host, so a spoofed or
-                          proxy-forwarded host cannot redirect the login
-                          elsewhere. It overrides the scheme and port overrides
-                          above.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.base_url_override_help"
+                            >
+                              The canonical external base URL of this server,
+                              e.g.
+                              <code>https://jellyfin.example.com</code>. When
+                              set, the redirect URI and SAML base URL are built
+                              from it instead of the request host, so a spoofed
+                              or proxy-forwarded host cannot redirect the login
+                              elsewhere. It overrides the scheme and port
+                              overrides above.
+                            </div>
+                          </details>
                         </div>
                         <div
                           class="sso-callout sso-callout-warning"
@@ -2050,14 +2393,24 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_pkce_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Refuse login unless the provider's discovery
-                            document advertises PKCE (S256) in
-                            code_challenge_methods_supported (RFC 9700 §2.1.1).
-                            When off, an unsupported provider only logs an audit
-                            warning and the login proceeds.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_pkce_help"
+                              >
+                                Refuse login unless the provider's discovery
+                                document advertises PKCE (S256) in
+                                code_challenge_methods_supported (RFC 9700
+                                §2.1.1). When off, an unsupported provider only
+                                logs an audit warning and the login proceeds.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -2082,17 +2435,26 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.acr_values_help"
-                          >
-                            Space-separated acr_values sent on the authorization
-                            request (OIDC Core §3.1.2.1), most-preferred first:
-                            the requested authentication-context references
-                            (e.g. an MFA reference your IdP advertises). Leave
-                            blank to send nothing (unchanged request). Also the
-                            allow-list Require Acr checks the returned acr
-                            against.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.acr_values_help"
+                              >
+                                Space-separated acr_values sent on the
+                                authorization request (OIDC Core §3.1.2.1),
+                                most-preferred first: the requested
+                                authentication-context references (e.g. an MFA
+                                reference your IdP advertises). Leave blank to
+                                send nothing (unchanged request). Also the
+                                allow-list Require Acr checks the returned acr
+                                against.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div class="inputContainer">
@@ -2108,13 +2470,21 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.prompt_help"
-                          >
-                            OIDC prompt parameter, e.g. <code>login</code> to
-                            force re-authentication or <code>consent</code>.
-                            Leave blank to omit it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.prompt_help"
+                              >
+                                OIDC prompt parameter, e.g.
+                                <code>login</code> to force re-authentication or
+                                <code>consent</code>. Leave blank to omit it.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div class="inputContainer">
@@ -2131,14 +2501,22 @@
                             min="0"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.max_age_help"
-                          >
-                            OIDC max_age: the maximum time (seconds) since the
-                            user's last active authentication;
-                            <code>0</code> forces re-authentication. Leave blank
-                            to omit it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.max_age_help"
+                              >
+                                OIDC max_age: the maximum time (seconds) since
+                                the user's last active authentication;
+                                <code>0</code> forces re-authentication. Leave
+                                blank to omit it.
+                              </div>
+                            </details>
                           </div>
                         </div>
                         <div
@@ -2157,15 +2535,26 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.require_acr_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Refuse any login whose verified id_token does not
-                            return an acr within Acr Values above: a fail-closed
-                            step-up / forced-MFA gate. Off by default. Requires
-                            Acr Values to be set (the save is rejected
-                            otherwise, so a mis-set cannot lock out a userbase).
-                            The break-glass password admin is unaffected.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.require_acr_help"
+                              >
+                                Refuse any login whose verified id_token does
+                                not return an acr within Acr Values above: a
+                                fail-closed step-up / forced-MFA gate. Off by
+                                default. Requires Acr Values to be set (the save
+                                is rejected otherwise, so a mis-set cannot lock
+                                out a userbase). The break-glass password admin
+                                is unaffected.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -2196,6 +2585,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n-parts="config.allow_adoption_help"
+                            data-sso-help-flat
                           >
                             ⚠ Sensitive: lets a first SSO login adopt (take
                             over) a pre-existing, unlinked Jellyfin account
@@ -2235,6 +2625,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n-parts="config.provision_disabled_help"
+                            data-sso-help-flat
                           >
                             When the identity provider's audience is broader
                             than your intended Jellyfin audience: an unknown
@@ -2273,6 +2664,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n-parts="config.follow_renames_help"
+                            data-sso-help-flat
                           >
                             When someone is renamed at the identity provider,
                             rename their Jellyfin account to match on their next
@@ -2313,6 +2705,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.require_verified_email_adoption_help"
+                            data-sso-help-flat
                           >
                             ⚠ Sensitive: only meaningful with Allow Adopting
                             Existing Accounts above. Additionally requires the
@@ -2348,6 +2741,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.require_verified_email_login_help"
+                            data-sso-help-flat
                           >
                             ⚠ Sensitive: requires every OpenID login for this
                             provider to carry a provider-verified email
@@ -2374,13 +2768,22 @@
                         >
                           Insecure options
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.insecure_options_help"
-                        >
-                          These options disable OpenID Connect security
-                          defenses. Enable one only if your provider genuinely
-                          requires it; each is recorded as an audit warning.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.insecure_options_help"
+                            >
+                              These options disable OpenID Connect security
+                              defenses. Enable one only if your provider
+                              genuinely requires it; each is recorded as an
+                              audit warning.
+                            </div>
+                          </details>
                         </div>
                         <button
                           is="emby-button"
@@ -2418,6 +2821,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n="config.disable_https_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: drops TLS on the discovery, JWKS and
                               token endpoints, so the id_token signing keys can
@@ -2467,6 +2871,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n="config.no_validate_endpoints_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: disables endpoint-origin validation (a
                               mix-up defense). May be required for Google
@@ -2495,6 +2900,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n="config.allow_private_network_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: relaxes the outbound SSRF / DNS-rebind
                               guard for this provider, allowing connection to an
@@ -2526,6 +2932,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n="config.no_validate_issuer_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: disables matching the discovery
                               issuer, a mix-up defense. Only for a provider that
@@ -2555,6 +2962,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n-parts="config.no_validate_response_issuer_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: disables the RFC 9207 <code>iss</code>
                               check, an OpenID Connect mix-up defense. Only for
@@ -2585,19 +2993,28 @@
                         >Test Connection</span
                       >
                     </button>
-                    <div
-                      class="fieldDescription"
-                      data-i18n-parts="config.oid_test_help"
-                    >
-                      Validates the
-                      <strong data-i18n="config.test_saved_emphasis"
-                        >saved</strong
-                      >
-                      provider: the server fetches the OpenID discovery document
-                      over the same hardened, HTTPS-checked path the login uses
-                      and reports the issuer, endpoints and JWKS reachability.
-                      Save the provider first. Requires administrator
-                      privileges; the client secret is never shown.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.oid_test_help"
+                        >
+                          Validates the
+                          <strong data-i18n="config.test_saved_emphasis"
+                            >saved</strong
+                          >
+                          provider: the server fetches the OpenID discovery
+                          document over the same hardened, HTTPS-checked path
+                          the login uses and reports the issuer, endpoints and
+                          JWKS reachability. Save the provider first. Requires
+                          administrator privileges; the client secret is never
+                          shown.
+                        </div>
+                      </details>
                     </div>
                     <div id="TestResult"></div>
                   </div>
@@ -2685,13 +3102,22 @@
                     >
                       No SAML providers yet
                     </p>
-                    <p
-                      class="fieldDescription"
-                      data-i18n="config.saml_empty_help"
-                    >
-                      Add a SAML 2.0 provider to let users sign in through your
-                      identity provider. You can import the endpoint and signing
-                      certificate straight from your IdP's metadata below.
+                    <p class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.saml_empty_help"
+                        >
+                          Add a SAML 2.0 provider to let users sign in through
+                          your identity provider. You can import the endpoint
+                          and signing certificate straight from your IdP's
+                          metadata below.
+                        </div>
+                      </details>
                     </p>
                     <!--
                   First-run guided path (#1085). The steps NAME the controls that already exist inside the
@@ -2890,14 +3316,22 @@
                       role="status"
                       aria-live="polite"
                     ></div>
-                    <div
-                      class="fieldDescription"
-                      data-i18n="config.saml_template_help"
-                    >
-                      Pre-fills an endpoint placeholder for a SAML identity
-                      provider. Use the metadata import below to fill the
-                      endpoint and signing certificate from your IdP, then
-                      review and save. Nothing is saved automatically.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n="config.saml_template_help"
+                        >
+                          Pre-fills an endpoint placeholder for a SAML identity
+                          provider. Use the metadata import below to fill the
+                          endpoint and signing certificate from your IdP, then
+                          review and save. Nothing is saved automatically.
+                        </div>
+                      </details>
                     </div>
                   </div>
 
@@ -2934,13 +3368,21 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_name_help"
-                        >
-                          The name Jellyfin uses to identify this SAML provider.
-                          A new provider is created if the name is new; an
-                          existing one is updated.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_name_help"
+                            >
+                              The name Jellyfin uses to identify this SAML
+                              provider. A new provider is created if the name is
+                              new; an existing one is updated.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3002,15 +3444,24 @@
                           role="status"
                           aria-live="polite"
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_metadata_import_help"
-                        >
-                          Fetches the SSO endpoint and signing certificate(s)
-                          from your identity provider's SAML metadata and fills
-                          them in below for review. It never fills the SAML
-                          Client ID (that is this service provider's own entity
-                          id, which you choose).
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_metadata_import_help"
+                            >
+                              Fetches the SSO endpoint and signing
+                              certificate(s) from your identity provider's SAML
+                              metadata and fills them in below for review. It
+                              never fills the SAML Client ID (that is this
+                              service provider's own entity id, which you
+                              choose).
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3041,6 +3492,7 @@
                         <div
                           class="fieldDescription"
                           data-i18n="config.saml_endpoint_help"
+                          data-sso-help-flat
                         >
                           The identity provider's Single Sign-On URL, where the
                           browser is redirected to authenticate.
@@ -3067,17 +3519,26 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_slo_endpoint_help"
-                        >
-                          The identity provider's Single-Logout (SLO) URL, a
-                          distinct endpoint from the SSO endpoint above, where
-                          the browser is redirected with a signed SP-initiated
-                          LogoutRequest. Must be an absolute https URL. Leave
-                          blank to disable SP-initiated Single Logout (logout
-                          stays local-only). Only used when the global "Enable
-                          Single Logout" option is on.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_slo_endpoint_help"
+                            >
+                              The identity provider's Single-Logout (SLO) URL, a
+                              distinct endpoint from the SSO endpoint above,
+                              where the browser is redirected with a signed
+                              SP-initiated LogoutRequest. Must be an absolute
+                              https URL. Leave blank to disable SP-initiated
+                              Single Logout (logout stays local-only). Only used
+                              when the global "Enable Single Logout" option is
+                              on.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3105,14 +3566,23 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_client_id_help"
-                        >
-                          This service provider's entity id: the value the
-                          plugin sends as the AuthnRequest issuer and expects as
-                          the audience. You choose it and register it at the
-                          IdP; it is also the SP entityID shown below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_client_id_help"
+                            >
+                              This service provider's entity id: the value the
+                              plugin sends as the AuthnRequest issuer and
+                              expects as the audience. You choose it and
+                              register it at the IdP; it is also the SP entityID
+                              shown below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3138,14 +3608,23 @@
                           role="alert"
                           hidden
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.saml_certificate_help"
-                        >
-                          The identity provider's PUBLIC signing certificate as
-                          Base64 (DER): the value between the PEM
-                          <code>BEGIN/END CERTIFICATE</code> lines, or the whole
-                          PEM. Used to verify the SAML response signature.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.saml_certificate_help"
+                            >
+                              The identity provider's PUBLIC signing certificate
+                              as Base64 (DER): the value between the PEM
+                              <code>BEGIN/END CERTIFICATE</code> lines, or the
+                              whole PEM. Used to verify the SAML response
+                              signature.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3178,16 +3657,24 @@
                             <span data-i18n="config.copy_button">Copy</span>
                           </button>
                         </div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n-parts="config.saml_acs_url_help"
-                        >
-                          The Assertion Consumer Service URL the IdP POSTs the
-                          SAML response to. Updates as you type the provider
-                          name. Derived from the Base URL Override (Advanced
-                          section) when set, else this server's address. The
-                          legacy spelling
-                          <code>/sso/SAML/p/&lt;name&gt;</code> also works.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n-parts="config.saml_acs_url_help"
+                            >
+                              The Assertion Consumer Service URL the IdP POSTs
+                              the SAML response to. Updates as you type the
+                              provider name. Derived from the Base URL Override
+                              (Advanced section) when set, else this server's
+                              address. The legacy spelling
+                              <code>/sso/SAML/p/&lt;name&gt;</code> also works.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3220,14 +3707,23 @@
                           role="status"
                           aria-live="polite"
                         ></div>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_metadata_url_help"
-                        >
-                          This service provider's metadata document. Many IdPs
-                          can import it by URL instead of hand-configuring the
-                          ACS and entityID. The SP entityID it advertises is the
-                          SAML Client ID above.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_metadata_url_help"
+                            >
+                              This service provider's metadata document. Many
+                              IdPs can import it by URL instead of
+                              hand-configuring the ACS and entityID. The SP
+                              entityID it advertises is the SAML Client ID
+                              above.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3265,15 +3761,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.provider_hide_login_button_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Excludes this provider from the managed "Sign in with
-                          …" block on the login page while keeping it usable
-                          through its direct start URL. Only takes effect while
-                          the global "Manage login buttons on the login page"
-                          option is on; it never hides anything you added to the
-                          branding yourself.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_hide_login_button_help"
+                            >
+                              Excludes this provider from the managed "Sign in
+                              with …" block on the login page while keeping it
+                              usable through its direct start URL. Only takes
+                              effect while the global "Manage login buttons on
+                              the login page" option is on; it never hides
+                              anything you added to the branding yourself.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3295,16 +3801,24 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provider_login_button_text_help"
-                        >
-                          Custom label for this provider's managed login-page
-                          button. Leave blank to use the provider name. Only
-                          takes effect while the global "Manage login buttons on
-                          the login page" option is on and the button is not
-                          hidden; any text is safe: it is always rendered inert,
-                          never as markup.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provider_login_button_text_help"
+                            >
+                              Custom label for this provider's managed
+                              login-page button. Leave blank to use the provider
+                              name. Only takes effect while the global "Manage
+                              login buttons on the login page" option is on and
+                              the button is not hidden; any text is safe: it is
+                              always rendered inert, never as markup.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -3336,13 +3850,23 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_enable_authorization_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          Determines if the plugin sets permissions for the
-                          user. If off, the user starts with no permissions and
-                          an administrator adds them. Existing users'
-                          permissions are not rewritten on later logins.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_enable_authorization_help"
+                            >
+                              Determines if the plugin sets permissions for the
+                              user. If off, the user starts with no permissions
+                              and an administrator adds them. Existing users'
+                              permissions are not rewritten on later logins.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3364,13 +3888,21 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_default_provider_help"
-                        >
-                          Assigned to the user after they log in. If unset,
-                          nothing changes and the user can still log in via
-                          other providers.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_default_provider_help"
+                            >
+                              Assigned to the user after they log in. If unset,
+                              nothing changes and the user can still log in via
+                              other providers.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3390,14 +3922,24 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_allow_adoption_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          ⚠ Sensitive: lets a first SAML login adopt a
-                          pre-existing, unlinked Jellyfin account whose username
-                          matches the SAML NameID, instead of rejecting it. Off
-                          by default. A name-matched administrator account is
-                          never adopted.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_allow_adoption_help"
+                            >
+                              ⚠ Sensitive: lets a first SAML login adopt a
+                              pre-existing, unlinked Jellyfin account whose
+                              username matches the SAML NameID, instead of
+                              rejecting it. Off by default. A name-matched
+                              administrator account is never adopted.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3418,15 +3960,25 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_provision_disabled_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          An unknown identity's first login creates its account
-                          disabled, with no permissions, and is refused with an
-                          "awaiting administrator approval" message until an
-                          admin enables it. Off by default. Never disables an
-                          existing or adopted account, and each deferral is
-                          audited.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_provision_disabled_help"
+                            >
+                              An unknown identity's first login creates its
+                              account disabled, with no permissions, and is
+                              refused with an "awaiting administrator approval"
+                              message until an admin enables it. Off by default.
+                              Never disables an existing or adopted account, and
+                              each deferral is audited.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3446,17 +3998,27 @@
                           >
                         </label>
                         <div
-                          class="fieldDescription checkboxFieldDescription"
-                          data-i18n="config.saml_follow_renames_help"
+                          class="fieldDescription checkboxFieldDescription sso-help"
                         >
-                          When someone is renamed at the identity provider,
-                          rename their Jellyfin account to match on their next
-                          SSO login. Off by default. Display name only: the
-                          account is found by its stable NameID either way, so
-                          this cannot change which account a login reaches.
-                          Skipped when another account already holds the name,
-                          and a rename that fails never fails the login. Each
-                          rename is audited.
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_follow_renames_help"
+                            >
+                              When someone is renamed at the identity provider,
+                              rename their Jellyfin account to match on their
+                              next SSO login. Off by default. Display name only:
+                              the account is found by its stable NameID either
+                              way, so this cannot change which account a login
+                              reaches. Skipped when another account already
+                              holds the name, and a rename that fails never
+                              fails the login. Each rename is audited.
+                            </div>
+                          </details>
                         </div>
                       </div>
                     </div>
@@ -3482,15 +4044,24 @@
                     class="verticalSection verticalSection-extrabottompadding"
                   >
                     <div class="collapseContent">
-                      <div
-                        class="fieldDescription"
-                        data-i18n="config.template_help"
-                      >
-                        What a brand-new account created by this provider starts
-                        with. Every field is opt-in: anything you leave alone
-                        keeps Jellyfin's own default, and these values are
-                        written once, when the account is created, so a change
-                        made later survives every following login.
+                      <div class="fieldDescription sso-help">
+                        <span class="sso-help-lead"></span>
+                        <details class="sso-help-full">
+                          <summary data-i18n="config.help_full_text">
+                            Full text
+                          </summary>
+                          <div
+                            class="sso-help-body"
+                            data-i18n="config.template_help"
+                          >
+                            What a brand-new account created by this provider
+                            starts with. Every field is opt-in: anything you
+                            leave alone keeps Jellyfin's own default, and these
+                            values are written once, when the account is
+                            created, so a change made later survives every
+                            following login.
+                          </div>
+                        </details>
                       </div>
                       <div
                         id="saml-Tmpl-profile-note"
@@ -3528,18 +4099,26 @@
                           name="saml-ProvisioningProfile"
                           class="sso-tmpl-profile emby-select-withcolor emby-select"
                         ></select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.provisioning_profile_help"
-                        >
-                          Take the starting policy from a profile defined in
-                          Provisioning Profiles above, instead of from the
-                          fields below. The two are mutually exclusive: a
-                          provider that names a profile and also carries its own
-                          inline fields is refused on save, because one
-                          account-creation policy has one source. Leave it on
-                          (none), or set it back to (none) and save, to use the
-                          fields below again.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.provisioning_profile_help"
+                            >
+                              Take the starting policy from a profile defined in
+                              Provisioning Profiles above, instead of from the
+                              fields below. The two are mutually exclusive: a
+                              provider that names a profile and also carries its
+                              own inline fields is refused on save, because one
+                              account-creation policy has one source. Leave it
+                              on (none), or set it back to (none) and save, to
+                              use the fields below again.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3558,13 +4137,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_bitrate_help"
-                        >
-                          The remote streaming ceiling in bits per second. Zero
-                          means no limit, which is a real setting rather than an
-                          empty one. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_bitrate_help"
+                            >
+                              The remote streaming ceiling in bits per second.
+                              Zero means no limit, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3583,14 +4171,22 @@
                           step="1"
                           class="sso-tmpl-number emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_sessions_help"
-                        >
-                          How many sessions the account may hold at once. Zero
-                          means unlimited, which is a real setting rather than
-                          an empty one. Leave blank to keep Jellyfin's own
-                          default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_sessions_help"
+                            >
+                              How many sessions the account may hold at once.
+                              Zero means unlimited, which is a real setting
+                              rather than an empty one. Leave blank to keep
+                              Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3607,14 +4203,23 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_audio_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. It is passed on as given rather than checked
-                          against a list, so any code Jellyfin accepts works.
-                          Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_audio_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. It is passed on as given rather than
+                              checked against a list, so any code Jellyfin
+                              accepts works. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3631,12 +4236,21 @@
                           type="text"
                           class="sso-tmpl-text emby-input"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_language_help"
-                        >
-                          The language code Jellyfin itself stores, for example
-                          eng. Leave blank to keep Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_language_help"
+                            >
+                              The language code Jellyfin itself stores, for
+                              example eng. Leave blank to keep Jellyfin's own
+                              default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3661,14 +4275,22 @@
                           <option value="None">None</option>
                           <option value="Smart">Smart</option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_subtitle_mode_help"
-                        >
-                          Which subtitles play by default. The options are the
-                          exact mode names Jellyfin declares, which is the
-                          spelling a save accepts; leaving it unset keeps
-                          Jellyfin's own default.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_subtitle_mode_help"
+                            >
+                              Which subtitles play by default. The options are
+                              the exact mode names Jellyfin declares, which is
+                              the spelling a save accepts; leaving it unset
+                              keeps Jellyfin's own default.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3694,13 +4316,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_play_default_audio_help"
-                        >
-                          Leaving this unset keeps Jellyfin's own default. No is
-                          a deliberate setting rather than an absent one, which
-                          is why this is a list and not a checkbox.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_play_default_audio_help"
+                            >
+                              Leaving this unset keeps Jellyfin's own default.
+                              No is a deliberate setting rather than an absent
+                              one, which is why this is a list and not a
+                              checkbox.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3726,14 +4357,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_audio_help"
-                        >
-                          Whether an audio track chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_audio_help"
+                            >
+                              Whether an audio track chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3759,14 +4398,22 @@
                             No
                           </option>
                         </select>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_remember_subtitle_help"
-                        >
-                          Whether a subtitle chosen during playback is
-                          remembered for next time. Leaving this unset keeps
-                          Jellyfin's own default; No is a deliberate setting
-                          rather than an absent one.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_remember_subtitle_help"
+                            >
+                              Whether a subtitle chosen during playback is
+                              remembered for next time. Leaving this unset keeps
+                              Jellyfin's own default; No is a deliberate setting
+                              rather than an absent one.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="inputContainer">
@@ -3783,18 +4430,27 @@
                           type="text"
                           class="sso-tmpl-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_home_sections_help"
-                        >
-                          The sections of the web client's home screen, one per
-                          line, top slot first: None, SmallLibraryTiles,
-                          LibraryButtons, ActiveRecordings, Resume, ResumeAudio,
-                          LatestMedia, NextUp, LiveTv or ResumeBook, spelled
-                          exactly like that. Up to ten lines; the slots you do
-                          not fill show nothing, as they would after saving the
-                          client's own home-screen settings. Leave the box empty
-                          to keep Jellyfin's own layout.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_home_sections_help"
+                            >
+                              The sections of the web client's home screen, one
+                              per line, top slot first: None, SmallLibraryTiles,
+                              LibraryButtons, ActiveRecordings, Resume,
+                              ResumeAudio, LatestMedia, NextUp, LiveTv or
+                              ResumeBook, spelled exactly like that. Up to ten
+                              lines; the slots you do not fill show nothing, as
+                              they would after saving the client's own
+                              home-screen settings. Leave the box empty to keep
+                              Jellyfin's own layout.
+                            </div>
+                          </details>
                         </div>
                       </div>
                       <div class="sso-subgroup">
@@ -3804,18 +4460,27 @@
                         >
                           Permissions written onto a new account
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.template_permissions_help"
-                        >
-                          Each row names one Jellyfin permission and the value a
-                          new account starts with. A permission that is not
-                          listed is never touched. The names come from the
-                          server rather than from a list kept on this page, so
-                          they cannot drift from what a save accepts;
-                          administrator, all-folders and Live TV access are not
-                          offered here because each keeps its own setting above,
-                          and no account can be created disabled from here.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.template_permissions_help"
+                            >
+                              Each row names one Jellyfin permission and the
+                              value a new account starts with. A permission that
+                              is not listed is never touched. The names come
+                              from the server rather than from a list kept on
+                              this page, so they cannot drift from what a save
+                              accepts; administrator, all-folders and Live TV
+                              access are not offered here because each keeps its
+                              own setting above, and no account can be created
+                              disabled from here.
+                            </div>
+                          </details>
                         </div>
                         <div
                           id="saml-Tmpl-Permissions"
@@ -3872,14 +4537,22 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_roles_help"
-                        >
-                          One role per line. A login must carry at least one of
-                          these roles (in the assertion's Role attribute) to be
-                          allowed in. Leave blank to allow any authenticated
-                          user.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_roles_help"
+                            >
+                              One role per line. A login must carry at least one
+                              of these roles (in the assertion's Role attribute)
+                              to be allowed in. Leave blank to allow any
+                              authenticated user.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3901,12 +4574,20 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_admin_roles_help"
-                        >
-                          One role per line. A login carrying any of these roles
-                          is granted administrator rights.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_admin_roles_help"
+                            >
+                              One role per line. A login carrying any of these
+                              roles is granted administrator rights.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -3938,6 +4619,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.saml_enable_all_folders_help"
+                            data-sso-help-flat
                           >
                             If enabled, all libraries are accessible to any user
                             that logs in through this provider.
@@ -3958,13 +4640,21 @@
                             id="saml-EnabledFolders"
                             class="checkboxList paperList checkboxList-paperList sso-folder-list sso-bordered-list"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_enabled_folders_help"
-                          >
-                            Which libraries are accessible to a user that logs
-                            in through this provider. No effect when "Enable All
-                            Folders" is checked.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_enabled_folders_help"
+                              >
+                                Which libraries are accessible to a user that
+                                logs in through this provider. No effect when
+                                "Enable All Folders" is checked.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -3988,6 +4678,7 @@
                           <div
                             class="fieldDescription checkboxFieldDescription"
                             data-i18n="config.saml_enable_folder_roles_help"
+                            data-sso-help-flat
                           >
                             Determines if user roles should control library
                             access.
@@ -4023,12 +4714,21 @@
                             id="saml-FolderRoleMapping"
                             class="sso-role-map"
                           ></div>
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_folder_role_mapping_help"
-                          >
-                            Map roles to lists of libraries. A user holding a
-                            given role gets access to its mapped libraries.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_folder_role_mapping_help"
+                              >
+                                Map roles to lists of libraries. A user holding
+                                a given role gets access to its mapped
+                                libraries.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4063,6 +4763,7 @@
                         <div
                           class="fieldDescription checkboxFieldDescription"
                           data-i18n="config.saml_enable_livetv_roles_help"
+                          data-sso-help-flat
                         >
                           Determines if user roles should control Live TV
                           access.
@@ -4097,12 +4798,20 @@
                           type="text"
                           class="sso-line-list emby-textarea"
                         ></textarea>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_livetv_roles_help"
-                        >
-                          One role per line. Grants Live TV access / management
-                          to logins carrying a listed role.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_livetv_roles_help"
+                            >
+                              One role per line. Grants Live TV access /
+                              management to logins carrying a listed role.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4169,13 +4878,21 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_scheme_override_help"
-                        >
-                          Force the scheme (http/https) used when building the
-                          ACS and metadata URLs. Prefer the Base URL Override
-                          below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_scheme_override_help"
+                            >
+                              Force the scheme (http/https) used when building
+                              the ACS and metadata URLs. Prefer the Base URL
+                              Override below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4197,12 +4914,20 @@
                           type="text"
                           class="sso-text"
                         />
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_port_override_help"
-                        >
-                          Force the port used when building the ACS and metadata
-                          URLs. Prefer the Base URL Override below.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_port_override_help"
+                            >
+                              Force the port used when building the ACS and
+                              metadata URLs. Prefer the Base URL Override below.
+                            </div>
+                          </details>
                         </div>
                       </div>
 
@@ -4235,6 +4960,7 @@
                           class="sso-callout sso-callout-warning"
                           role="note"
                           data-i18n-parts="config.saml_base_url_override_help"
+                          data-sso-help-flat
                         >
                           ⚠ Recommended. The canonical external base URL of this
                           server, e.g.
@@ -4282,14 +5008,25 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.saml_validate_recipient_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Additionally require the assertion's
-                            <code>Recipient</code> to equal this SP's ACS URL (a
-                            token-redirection defense). Off by default so an
-                            existing deployment is not locked out; enable once
-                            your IdP sets the recipient correctly.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_validate_recipient_help"
+                              >
+                                Additionally require the assertion's
+                                <code>Recipient</code> to equal this SP's ACS
+                                URL (a token-redirection defense). Off by
+                                default so an existing deployment is not locked
+                                out; enable once your IdP sets the recipient
+                                correctly.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4310,13 +5047,24 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n-parts="config.saml_validate_inresponseto_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Require the response's <code>InResponseTo</code> to
-                            match an AuthnRequest this SP issued (rejects
-                            unsolicited assertions). Off by default; enable for
-                            solicited-only SSO.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_validate_inresponseto_help"
+                              >
+                                Require the response's
+                                <code>InResponseTo</code> to match an
+                                AuthnRequest this SP issued (rejects unsolicited
+                                assertions). Off by default; enable for
+                                solicited-only SSO.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4347,13 +5095,22 @@
                             type="text"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n-parts="config.saml_audience_help"
-                          >
-                            The expected <code>AudienceRestriction</code> in the
-                            assertion. When blank, the SAML Client ID is used.
-                            Ignored when "Do Not Validate Audience" is set.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n-parts="config.saml_audience_help"
+                              >
+                                The expected <code>AudienceRestriction</code> in
+                                the assertion. When blank, the SAML Client ID is
+                                used. Ignored when "Do Not Validate Audience" is
+                                set.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4382,12 +5139,22 @@
                             >
                           </label>
                           <div
-                            class="fieldDescription checkboxFieldDescription"
-                            data-i18n="config.saml_sign_authn_help"
+                            class="fieldDescription checkboxFieldDescription sso-help"
                           >
-                            Sign outgoing SAML AuthnRequests with the SP signing
-                            key below. Off by default; when on, a valid Signing
-                            Key must be configured.
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_sign_authn_help"
+                              >
+                                Sign outgoing SAML AuthnRequests with the SP
+                                signing key below. Off by default; when on, a
+                                valid Signing Key must be configured.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4412,14 +5179,23 @@
                             data-i18n-placeholder="config.placeholder_keep_key"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_signing_key_help"
-                          >
-                            This service provider's PRIVATE signing key, as a
-                            Base64 PKCS#12 (PFX) blob. For security it is never
-                            sent back to this page: leave blank to keep the
-                            stored key, or enter a new one to replace it.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_signing_key_help"
+                              >
+                                This service provider's PRIVATE signing key, as
+                                a Base64 PKCS#12 (PFX) blob. For security it is
+                                never sent back to this page: leave blank to
+                                keep the stored key, or enter a new one to
+                                replace it.
+                              </div>
+                            </details>
                           </div>
                         </div>
 
@@ -4444,15 +5220,23 @@
                             data-i18n-placeholder="config.placeholder_keep_key"
                             class="sso-text"
                           />
-                          <div
-                            class="fieldDescription"
-                            data-i18n="config.saml_rollover_signing_key_help"
-                          >
-                            An OPTIONAL second SP signing key for a rollover
-                            overlap: the SP metadata advertises both public
-                            certificates so the IdP trusts either. AuthnRequests
-                            are always signed with the primary key. Write-only,
-                            like the primary key.
+                          <div class="fieldDescription sso-help">
+                            <span class="sso-help-lead"></span>
+                            <details class="sso-help-full">
+                              <summary data-i18n="config.help_full_text">
+                                Full text
+                              </summary>
+                              <div
+                                class="sso-help-body"
+                                data-i18n="config.saml_rollover_signing_key_help"
+                              >
+                                An OPTIONAL second SP signing key for a rollover
+                                overlap: the SP metadata advertises both public
+                                certificates so the IdP trusts either.
+                                AuthnRequests are always signed with the primary
+                                key. Write-only, like the primary key.
+                              </div>
+                            </details>
                           </div>
                         </div>
                       </div>
@@ -4492,6 +5276,7 @@
                           <div
                             class="fieldDescription"
                             data-i18n="config.saml_secondary_certificate_help"
+                            data-sso-help-flat
                           >
                             An OPTIONAL second IdP PUBLIC signing certificate
                             accepted during an inbound signing-key rotation: a
@@ -4509,13 +5294,21 @@
                         >
                           Insecure options
                         </p>
-                        <div
-                          class="fieldDescription"
-                          data-i18n="config.saml_insecure_options_help"
-                        >
-                          These options disable SAML security defenses. Enable
-                          one only if your provider genuinely requires it; each
-                          is recorded as an audit warning.
+                        <div class="fieldDescription sso-help">
+                          <span class="sso-help-lead"></span>
+                          <details class="sso-help-full">
+                            <summary data-i18n="config.help_full_text">
+                              Full text
+                            </summary>
+                            <div
+                              class="sso-help-body"
+                              data-i18n="config.saml_insecure_options_help"
+                            >
+                              These options disable SAML security defenses.
+                              Enable one only if your provider genuinely
+                              requires it; each is recorded as an audit warning.
+                            </div>
+                          </details>
                         </div>
                         <button
                           is="emby-button"
@@ -4554,6 +5347,7 @@
                             <div
                               class="fieldDescription checkboxFieldDescription"
                               data-i18n-parts="config.saml_no_validate_audience_help"
+                              data-sso-help-flat
                             >
                               ⚠ Insecure: disables the
                               <code>AudienceRestriction</code> check, so an
@@ -4579,18 +5373,27 @@
                         >Test Connection</span
                       >
                     </button>
-                    <div
-                      class="fieldDescription"
-                      data-i18n-parts="config.saml_test_help"
-                    >
-                      Validates the
-                      <strong data-i18n="config.test_saved_emphasis"
-                        >saved</strong
-                      >
-                      provider: parses the stored IdP signing certificate and
-                      reports its non-secret facts (subject, issuer, validity,
-                      thumbprint). Save the provider first. Requires
-                      administrator privileges; no signing key is shown.
+                    <div class="fieldDescription sso-help">
+                      <span class="sso-help-lead"></span>
+                      <details class="sso-help-full">
+                        <summary data-i18n="config.help_full_text">
+                          Full text
+                        </summary>
+                        <div
+                          class="sso-help-body"
+                          data-i18n-parts="config.saml_test_help"
+                        >
+                          Validates the
+                          <strong data-i18n="config.test_saved_emphasis"
+                            >saved</strong
+                          >
+                          provider: parses the stored IdP signing certificate
+                          and reports its non-secret facts (subject, issuer,
+                          validity, thumbprint). Save the provider first.
+                          Requires administrator privileges; no signing key is
+                          shown.
+                        </div>
+                      </details>
                     </div>
                     <div id="saml-TestResult"></div>
                   </div>
@@ -4648,6 +5451,29 @@
                 >
                   Open a provider to see whether it is ready to serve a login.
                 </div>
+              </div>
+              <!--
+                THE WHOLE TEXT OF THE FIELD THAT HAS FOCUS (#1663, the rule of #1662). Every field on
+                either protocol form shows one sentence and keeps the rest behind a fold; this is the
+                second way to read the rest, without losing the field while reading about it. Empty and
+                hidden in the markup on purpose: SSO-Auth/Web/i18n.js fills it on focus, so a page whose
+                script never ran shows nothing here rather than a card naming a field nobody chose. It
+                sits BELOW the readiness card because readiness is the question an admin opens this page
+                with, and this one answers whatever they happen to be typing in.
+
+                WHERE IT LANDS ON A NARROW SCREEN IS NOT WHAT IT LOOKS LIKE HERE, and this page is the
+                only one it is true of. `sso-columns--rail-first` is on this container and on no other,
+                so under the 60em breakpoint the whole rail - readiness card and this one - stacks ABOVE
+                the form rather than below it. That order was measured for the readiness card and is
+                right for it; for this card it means the text of the field being typed in sits above
+                every field. Nothing here measures that, and it is the walk's to settle rather than a
+                property to assert in a comment.
+              -->
+              <div class="verticalSection sso-help-card" hidden>
+                <h2 class="sectionTitle" data-i18n="config.help_full_text">
+                  Full text
+                </h2>
+                <div class="fieldDescription sso-help-card-text"></div>
               </div>
             </aside>
           </div>

--- a/docs/ui/HELP-CENSUS.md
+++ b/docs/ui/HELP-CENSUS.md
@@ -123,6 +123,17 @@ it holds more, and a rail card answering a field that does not have focus. The
 two are complements. This one holds "nothing is deleted"; that one holds "and
 what happened to it is what was promised".
 
+Slice 2 (#1663) put the same folds on the Providers page and left twenty-four of
+its help texts flat on purpose, each DECLARING it with a `data-sso-help-flat`
+attribute at the site: the twelve inside the two security regions that slice 5
+(#1666) turns into folds of their own, where a second fold over a warning is the
+wrong change to make early; the one `sso-callout` note, which is a statement
+about the server rather than a description of the field beside it; and the eleven
+whose text holds a single sentence, which have nothing to put behind a fold. A
+flat help text that declares nothing is refused, and so is a page whose declared
+and condensed halves do not add up to the markers the page carries - that second
+sum is what catches a help text written on a class neither reader knows.
+
 | Page                 | Help key                                      | Field                                     |
 | -------------------- | --------------------------------------------- | ----------------------------------------- |
 | `accountsPage.html`  | `config.linked_accounts_help`                 | `(sso-linked-accounts)`                   |

--- a/tools/ui-condensed-help.js
+++ b/tools/ui-condensed-help.js
@@ -92,6 +92,48 @@ const SUMMARY_KEY = "config.help_full_text";
 // somewhere to write the first sentence and a page whose script never ran shows no blank prose.
 const EMPTY_LEAD = '<span class="sso-help-lead"></span>';
 
+// A help key a marker names, under EITHER marker. `data-i18n-parts` is a sentence
+// that holds markup (#1529), and 36 of the Providers page's help texts are written
+// that way; a reader that knew only the plain marker read every one of them as a
+// condensed block naming no key at all.
+const HELP_KEY = 'data-i18n(?:-parts)?="([a-z0-9_.]+_help)"';
+
+// The same pattern pinned to one key. Both forms allow OTHER ATTRIBUTES between the
+// body's class and its marker, because one body carries an id: the input it describes
+// points at it through aria-describedby, and that reference has to resolve to the
+// element holding the text rather than to the wrapper whose first readable child is
+// the word the summary is named with.
+const HELP_KEY_FOR = (key) => `data-i18n(?:-parts)?="${key}"`;
+
+// A field description DECLARING that it stays flat, which is the only way one may.
+// The Providers page leaves thirteen that way - the twelve inside the two security
+// regions that slice 5 (#1666) turns into folds of their own, where a second fold
+// over a warning would be the wrong change to make early, and the one callout,
+// which is a note rather than a field. The declaration is an attribute at the site
+// rather than a class list inside this tool: a reader of the page sees why it is
+// flat where the page is flat, and a help text nobody declared is still refused.
+const FLAT_MARK = "data-sso-help-flat";
+
+// The elements that never close, so a stack of open tags does not keep one and a
+// later closing tag does not unwind the wrong element. The `<input>` inside every
+// field container is exactly where that bites.
+const VOID_ELEMENTS = new Set([
+  "br",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "wbr",
+  "source",
+  "area",
+  "base",
+  "col",
+  "embed",
+  "param",
+  "track",
+]);
+
 // ---------------------------------------------------------------------------
 // The stub DOM
 // ---------------------------------------------------------------------------
@@ -269,8 +311,15 @@ globalThis.ApiClient = { getUrl: (route) => `https://stub.invalid/${route}` };
 // where there had been twenty. The census next door drops its `<details>` figure
 // from 20 to 19 for the same edit and refuses nothing, because the text is still
 // present once in its own field. Neither reader owned it.
+// A CALLOUT IS IN THE POPULATION TOO, and it is in it so that its declaration is
+// READ rather than merely written. One `*_help` key on the Providers page sits on a
+// `sso-callout sso-callout-warning` with `role="note"` - a warning about a reverse
+// proxy, which is a statement about the server rather than a description of the
+// field beside it, and folding a warning is the wrong move. It stays flat and says
+// so; a reader that did not know the class would have accepted the attribute while
+// reading nothing, which is the shape of a declaration nobody checks.
 const HELP_BLOCK =
-  /<(?<tag>[a-z][a-z0-9]*)\b(?<attrs>[^>]*\bclass="[^"]*\bfieldDescription\b[^"]*"[^>]*)>/g;
+  /<(?<tag>[a-z][a-z0-9]*)\b(?<attrs>[^>]*\bclass="[^"]*\b(?:fieldDescription|sso-callout)\b[^"]*"[^>]*)>/g;
 
 /*
  * Whether an opening tag carries a class, as a CLASS rather than as a substring.
@@ -335,6 +384,7 @@ function inspectMarkup(page, source) {
   const refusals = [];
   const at = [];
   let blocks = 0;
+  let flat = 0;
   HELP_BLOCK.lastIndex = 0;
   let match;
   while ((match = HELP_BLOCK.exec(markup)) !== null) {
@@ -349,14 +399,22 @@ function inspectMarkup(page, source) {
       continue;
     }
 
-    const keys = [...body.matchAll(/data-i18n="([a-z0-9_.]+_help)"/g)].map(
-      (m) => m[1],
-    );
-    const own = /data-i18n="([a-z0-9_.]+_help)"/.exec(opening);
+    const keys = [...body.matchAll(new RegExp(HELP_KEY, "g"))].map((m) => m[1]);
+    const own = new RegExp(HELP_KEY).exec(opening);
     if (own) {
-      refusals.push(
-        `${page} still writes ${own[1]} flat: the field shows the whole text under it rather than a sentence and a fold`,
-      );
+      // A DECLARED flat field passes and an undeclared one does not, which is the
+      // whole difference between a boundary between two issues and a hole. The
+      // attribute is at the site, so the page says where it is flat and this tool
+      // does not carry a list of exceptions somebody has to keep in step.
+      if (!opening.includes(FLAT_MARK)) {
+        refusals.push(
+          `${page} still writes ${own[1]} flat and does not declare it: the field shows the whole text under it rather than a sentence and a fold`,
+        );
+        continue;
+      }
+      // Counted only once the declaration is there, so a refused page does not
+      // report its offender among the sites that declared themselves.
+      flat += 1;
       continue;
     }
     // A BLOCK THE READER COULD NOT READ IS REFUSED, never skipped. This was a plain
@@ -372,6 +430,14 @@ function inspectMarkup(page, source) {
         );
       }
       continue;
+    }
+    // AFTER the key read, because before it this fired on any keyless field
+    // description somebody had left a stray attribute on - an element that is
+    // neither condensed nor a help site, refused for being both.
+    if (opening.includes(FLAT_MARK)) {
+      refusals.push(
+        `a condensed block on ${page} declares itself flat, so one of the two statements about it is wrong`,
+      );
     }
     blocks += 1;
     at.push(match.index);
@@ -397,7 +463,9 @@ function inspectMarkup(page, source) {
         `the fold of ${key} on ${page} is named by something other than ${SUMMARY_KEY}, so one page's folds can be renamed without the others`,
       );
     }
-    if (!new RegExp(`class="sso-help-body" data-i18n="${key}"`).test(body)) {
+    if (
+      !new RegExp(`class="sso-help-body"[^>]*${HELP_KEY_FOR(key)}`).test(body)
+    ) {
       refusals.push(
         `${key} on ${page} does not sit on the body of its own fold, so the catalogue writes it somewhere the applier does not read it from`,
       );
@@ -417,7 +485,7 @@ function inspectMarkup(page, source) {
       refusals.push(
         `${page} condenses ${blocks} help text(s) and carries no readable ${CONDENSE_ROOT} container, so the applier is handed nothing to walk`,
       );
-      return { refusals, blocks };
+      return { refusals, blocks, flat };
     }
 
     const card = markup.indexOf('class="verticalSection sso-help-card"');
@@ -452,6 +520,145 @@ function inspectMarkup(page, source) {
       );
     }
   }
+
+  return { refusals, blocks, flat };
+}
+
+/*
+ * Every tag on a page, with quoted attribute values and comments respected.
+ *
+ * A SECOND READER OF THE SAME BYTES, and what it adds is the STACK: which elements a
+ * block sits inside, which a match-and-count walk cannot say. Quoted attribute values
+ * are respected as well, and THAT HALF IS INSURANCE RATHER THAN A REPAIR - measured
+ * across all six HTML assets in this tree, no attribute value holds a `<` or a `>`.
+ * The comment half is real: a comment on the Providers page carries a closing tag,
+ * and a depth counter reading it as a real one truncates the element it is in. Said
+ * this way round because the first version of this paragraph claimed both as failures
+ * this page had produced, and only one of them had.
+ */
+function tags(str) {
+  const out = [];
+  let i = 0;
+  while (i < str.length) {
+    const lt = str.indexOf("<", i);
+    if (lt < 0) break;
+    if (str.startsWith("<!--", lt)) {
+      const e = str.indexOf("-->", lt);
+      i = e < 0 ? str.length : e + 3;
+      continue;
+    }
+    let j = lt + 1;
+    let closing = false;
+    if (str[j] === "/") {
+      closing = true;
+      j++;
+    }
+    let name = "";
+    while (j < str.length && /[a-zA-Z0-9-]/.test(str[j])) {
+      name += str[j];
+      j++;
+    }
+    if (name === "") {
+      i = lt + 1;
+      continue;
+    }
+    let quote = null;
+    let self = false;
+    while (j < str.length) {
+      const c = str[j];
+      if (quote) {
+        if (c === quote) quote = null;
+        j++;
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        quote = c;
+        j++;
+        continue;
+      }
+      if (c === ">") {
+        self = str[j - 1] === "/";
+        j++;
+        break;
+      }
+      j++;
+    }
+    out.push({
+      name: name.toLowerCase(),
+      closing,
+      self,
+      attrs: str.slice(lt + 1 + name.length + (closing ? 1 : 0), j - 1),
+      start: lt,
+      end: j,
+    });
+    i = j;
+  }
+  return out;
+}
+
+/*
+ * Refuses two condensed help blocks resolving to ONE field.
+ *
+ * WHAT IT COSTS IS THE RAIL AND NOT THE FOLD. The applier keys the focused field to
+ * one help block by walking up to the nearest `inputContainer` or `checkboxContainer`
+ * - the census's own rule for which field a text belongs to - so two blocks under one
+ * container leave the second unreachable from the card, in silence. Both still show
+ * their own sentence and their own fold.
+ *
+ * IT WAS UNREFUSED WHEN SLICE 1 LANDED and #1662 says so of itself. No page had the
+ * shape then, counted over its twenty blocks; the Providers page brings ninety-nine
+ * and is where it would first arise, which is why the refusal lands with it.
+ */
+function inspectFields(page, source) {
+  const refusals = [];
+  const toks = tags(source);
+  const open = [];
+  const owners = new Map();
+  let blocks = 0;
+
+  toks.forEach((t) => {
+    if (t.self) return;
+    if (t.closing) {
+      while (open.length && open[open.length - 1].name !== t.name) open.pop();
+      open.pop();
+      return;
+    }
+
+    // hasClassToken, not a word-boundary match: `sso-help-lead`, `-full`, `-body`
+    // and `-card-text` all satisfy a boundary after "help", and the first spelling
+    // of this counted fourteen blocks on a page holding three.
+    const isBlock = hasClassToken(t.attrs, "sso-help");
+    if (!VOID_ELEMENTS.has(t.name)) {
+      open.push(t);
+    }
+    if (!isBlock) return;
+
+    blocks += 1;
+    // The block itself is on the stack, so the field is looked for beneath it.
+    const above = open.slice(0, -1);
+    // THE SAME CLASS TEST THE APPLIER MAKES, which is a token test and not a
+    // boundary match. `checkboxContainer-withDescription` satisfies a boundary after
+    // "checkboxContainer" and does NOT satisfy classList.contains, so the first
+    // spelling of this computed a different field from the one the rail actually
+    // keys on - and then passed a page where the second block of a shared field was
+    // unreachable, which is the whole loss this reader exists for.
+    const field =
+      [...above]
+        .reverse()
+        .find(
+          (el) =>
+            hasClassToken(el.attrs, "inputContainer") ||
+            hasClassToken(el.attrs, "checkboxContainer"),
+        ) || above[above.length - 1];
+    const at = field ? field.start : -1;
+    if (owners.has(at)) {
+      refusals.push(
+        `two condensed help texts on ${page} share one field, so the second is unreachable from the rail card: the blocks at offsets ${owners.get(at)} and ${t.start}`,
+      );
+      return;
+    }
+    owners.set(at, t.start);
+  });
 
   return { refusals, blocks };
 }
@@ -882,14 +1089,14 @@ function fixtureMarkup(key, parts) {
   if (p.flat) {
     return [
       `<div ${CONDENSE_ROOT}>`,
-      `<div class="fieldDescription" data-i18n="${key}">whatever</div>`,
+      `<div class="fieldDescription" data-i18n="${key}"${p.declared ? " " + FLAT_MARK : ""}>whatever</div>`,
       `</div>`,
     ].join("\n");
   }
 
   const card = `<div class="verticalSection sso-help-card" hidden><h2 class="sectionTitle" data-i18n="${SUMMARY_KEY}">Full text</h2><div class="sso-help-card-text"></div></div>`;
   const block = [
-    `<div class="fieldDescription${p.marked ? " sso-help" : ""}">`,
+    `<div class="fieldDescription${p.marked ? " sso-help" : ""}"${p.declared ? " " + FLAT_MARK : ""}>`,
     p.comment ? `<!-- a note that mentions a closing </div> tag -->` : "",
     p.lead ? `<span class="sso-help-lead"></span>` : "",
     p.details ? `<details class="sso-help-full">` : "<div>",
@@ -897,7 +1104,7 @@ function fixtureMarkup(key, parts) {
       ? `<summary data-i18n="${SUMMARY_KEY}">Full text</summary>`
       : `<summary data-i18n="config.something_else">More</summary>`,
     p.body
-      ? `<div class="sso-help-body" data-i18n="${key}">whatever</div>`
+      ? `<div class="sso-help-body" data-i18n${p.partsBody ? "-parts" : ""}="${key}">whatever</div>`
       : `<div class="sso-help-body"><span data-i18n="${key}">whatever</span></div>`,
     p.details ? `</details>` : "</div>",
     `</div>`,
@@ -912,6 +1119,36 @@ function fixtureMarkup(key, parts) {
   return [`<div ${CONDENSE_ROOT}>`, block, p.card ? card : "", `</div>`].join(
     "\n",
   );
+}
+
+/*
+ * A field container holding `n` condensed help blocks, for the field reader's arms.
+ * `voidTag` puts an `<input>` beside them, which is what a real field holds and what
+ * unwinds a stack of open tags that does not know which elements never close.
+ */
+function fieldMarkup(n, opts) {
+  const blocks = [];
+  for (let i = 0; i < n; i++) {
+    blocks.push(
+      [
+        `<div class="fieldDescription sso-help">`,
+        `<span class="sso-help-lead"></span>`,
+        `<details class="sso-help-full">`,
+        `<summary data-i18n="${SUMMARY_KEY}">Full text</summary>`,
+        `<div class="sso-help-body" data-i18n="config.fixture_${i}_help">whatever</div>`,
+        `</details>`,
+        `</div>`,
+      ].join("\n"),
+    );
+  }
+  return [
+    `<div ${CONDENSE_ROOT}>`,
+    `<div class="inputContainer">`,
+    opts && opts.voidTag ? `<input id="x" type="text" />` : "",
+    ...blocks,
+    `</div>`,
+    `</div>`,
+  ].join("\n");
 }
 
 async function calibrate(i18n) {
@@ -939,8 +1176,43 @@ async function calibrate(i18n) {
       fixtureMarkup("config.fixture_0_help", { comment: true }),
     ).refusals,
   );
+  record(
+    "a help text written flat and declaring it",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { flat: true, declared: true }),
+    ).refusals,
+  );
+  record(
+    "a parts-marked body is a key like any other",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { partsBody: true }),
+    ).refusals,
+  );
+
+  // The field reader, which is a different reader over the same bytes.
+  record(
+    "one condensed block per field container",
+    false,
+    inspectFields("fixture", fieldMarkup(1)).refusals,
+  );
+  record(
+    "two condensed blocks in one field container",
+    true,
+    inspectFields("fixture", fieldMarkup(2)).refusals,
+  );
+  record(
+    "an input in the container does not unwind the stack",
+    false,
+    inspectFields("fixture", fieldMarkup(1, { voidTag: true })).refusals,
+  );
+
   const markupNegatives = [
     ["a help text still written flat", { flat: true }],
+    ["a condensed block declaring itself flat", { declared: true }],
     ["a block the applier will not find", { marked: false }],
     ["a fold with no lead line to fill", { lead: false }],
     ["a whole text behind no fold", { details: false }],
@@ -1230,13 +1502,21 @@ async function run() {
 
   let refused = 0;
   let total = 0;
+  let declaredFlat = 0;
   for (const page of pages) {
     const markup = read(path.join(WEB, page));
     const authored = inspectMarkup(page, markup);
-    authored.refusals.forEach((message) => {
+    const fields = inspectFields(page, markup);
+    [...authored.refusals, ...fields.refusals].forEach((message) => {
       console.error(`REFUSED  ${message}`);
       refused += 1;
     });
+    if (authored.blocks !== fields.blocks) {
+      console.error(
+        `REFUSED  ${page}: the string reader finds ${authored.blocks} condensed block(s) and the tag reader finds ${fields.blocks}, so one of them is not seeing the page`,
+      );
+      refused += 1;
+    }
 
     // Collapsed for the same reason the markup reader collapses, and the floor
     // below is not decoration: reading the file as written yields ZERO keys the
@@ -1246,7 +1526,7 @@ async function run() {
     const keys = [
       ...markup
         .replace(/\s+/g, " ")
-        .matchAll(/class="sso-help-body" data-i18n="([a-z0-9_.]+_help)"/g),
+        .matchAll(new RegExp('class="sso-help-body"[^>]*' + HELP_KEY, "g")),
     ].map((m) => m[1]);
     if (keys.length === 0) {
       console.error(
@@ -1260,6 +1540,24 @@ async function run() {
     // block either of them loses - a truncated walk, a body tag spelled differently,
     // a field quietly un-condensed - moves one number and not the other. Without this
     // the run printed a green line over nineteen blocks where there had been twenty.
+    // THE WHOLE POPULATION IS TIED TO THE PAGE'S OWN MARKER COUNT, which is the
+    // arithmetic the flat half was missing. Both readers above enter a block through
+    // its CLASS, so a help text written on a class neither knows is invisible to
+    // both: the review of 2026-09-12 renamed one declared-flat field to
+    // `sso-field-note`, took its declaration away, and every gate here stayed green
+    // because the only trace was a count nothing asserted. This counts every marker
+    // on the page, class-agnostic, and requires the two halves to add up to it.
+    const markers = [
+      ...markup
+        .replace(/<!--[sS]*?-->/g, " ")
+        .matchAll(new RegExp(HELP_KEY, "g")),
+    ].length;
+    if (authored.blocks + authored.flat !== markers) {
+      console.error(
+        `REFUSED  ${page}: ${markers} help marker(s) on the page and ${authored.blocks} condensed plus ${authored.flat} declared flat, so a help text sits on an element neither reader enters`,
+      );
+      refused += 1;
+    }
     if (authored.blocks !== keys.length) {
       console.error(
         `REFUSED  ${page}: the element reader finds ${authored.blocks} condensed block(s) and the marker reader finds ${keys.length}, so one of them is not seeing the page`,
@@ -1267,6 +1565,7 @@ async function run() {
       refused += 1;
     }
     total += keys.length;
+    declaredFlat += authored.flat;
 
     for (const [name, values] of [
       ["en", en],
@@ -1299,14 +1598,14 @@ async function run() {
       });
       if (name === "en") {
         console.log(
-          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence`,
+          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence, ${authored.flat} left flat by declaration`,
         );
       }
     }
   }
 
   console.log(
-    `the marked pages:   ${total} condensed help text(s) over ${pages.length} page(s), read in en and de`,
+    `the marked pages:   ${total} condensed help text(s) and ${declaredFlat} left flat by declaration, over ${pages.length} page(s), read in en and de`,
   );
   if (refused > 0) {
     console.error(`${refused} refusal(s) in the condensed help (#1662)`);


### PR DESCRIPTION
# Superseded by #1673, which landed the same slice

This pull request is closed rather than merged, and #1673 is the survivor. Both are slice 2 of #1663 and they were built at the same time against the same base; #1673 reached the mainline first (`7e249477`), and this branch now conflicts with it in all three files it touches.

Nothing here is re-landed on top of it. What this pass found that the merged state does not carry is written into #1663 and filed as its own issues instead, because a conflicting duplicate of a merged change is not the way to deliver a finding:

- The `aria-describedby` of the redirect-URI field now resolves to the fold wrapper, so the field's accessible description begins with the summary's own word rather than the help text.
- `config.avatar_url_format_help` holds one sentence, so its `<code>` sample is written into the lead as plain text and its marked-up copy sits inside a hidden fold.
- A flat help text that declares nothing, and a page whose condensed and flat halves do not add up to the markers it carries, are refused by nothing.
- Two condensed help blocks resolving to one field container are refused by nothing, which is what #1662 said of itself and named this page as the place it would first arise.

The branch is not rewritten and not deleted by this closure; it is abandoned.
