### PR TITLE
Close the help-marker count over the page, class-agnostic [#1677]

### DIFF
--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -5148,9 +5148,20 @@
                           role="alert"
                           hidden
                         ></div>
+                        <!--
+                      DECLARED FLAT (#1677), and the declaration is the point rather than the class. This
+                      carries a *_help key and is NOT condensed: it is a warning beside the field, and
+                      folding a warning hides the thing it exists to put in front of a reader. Both readers
+                      in tools/ui-condensed-help.js enter a help text through its class, so without this
+                      attribute the site would sit in neither population and a field taken out of the
+                      condensing by renaming its class would look exactly the same. The gate closes the
+                      count over the markers instead, and every marker it cannot see as a fold has to say
+                      here why it is not one.
+                    -->
                         <div
                           class="sso-callout sso-callout-warning"
                           role="note"
+                          data-sso-flat-help="a warning beside the field, not its description: folding it would hide what it exists to put in front of a reader"
                           data-i18n-parts="config.saml_base_url_override_help"
                         >
                           ⚠ Recommended. The canonical external base URL of this

--- a/docs/ui/HELP-CENSUS.md
+++ b/docs/ui/HELP-CENSUS.md
@@ -141,6 +141,16 @@ field rather than that field's description. A warning is not condensed - folding
 one hides the thing it exists to put in front of a reader - and the condensing
 reader's subject is `fieldDescription`, so it neither moves nor refuses it.
 
+THAT SENTENCE USED TO BE THE WHOLE ANSWER AND IT WAS NOT ENOUGH (#1677). Both
+readers in the condensing gate enter a help text through its CLASS, so a site on
+a class neither of them knows was in neither population, and nothing closed the
+difference: a field taken out of the condensing by renaming its class looked
+exactly like the warning above. The gate counts the `*_help` MARKERS now,
+class-agnostic, and requires every one to be either a condensed block or a site
+carrying `data-sso-flat-help` with its reason at the site. The run prints how
+many a page declares, so "one short" is a number a reader can see rather than
+one they have to reconstruct from this page.
+
 The same slice is where the two readers stop covering the same population, which
 is stated here because the census's own figure does not show it. A help text
 whose body is marked `data-i18n-parts` has its `{n}` slots filled from the body's

--- a/tools/ui-condensed-help.js
+++ b/tools/ui-condensed-help.js
@@ -22,7 +22,10 @@
  * the catalogue row the folds share, a marked page with no rail card, a fold authored
  * inside a `<p>` - which `<details>` closes, so a browser takes the fold out of the
  * block - and two help blocks resolving to one field, by either branch of the walk the
- * applier makes (#1663). The
+ * applier makes (#1663). It also closes the COUNT over the page: every `*_help` marker
+ * is either a condensed block or a site that DECLARES itself flat with a reason, so a
+ * help text on a class neither reader enters is refused rather than dropped from both
+ * populations in silence (#1677). The
  * second LOADS the shipped applier and drives it over the shipped catalogues,
  * refusing a lead that is not the first sentence of the text behind it, a fold
  * hiding nothing, a fold hidden while it holds more, and a rail card answering a
@@ -335,6 +338,7 @@ function elementBody(markup, from, tag) {
  * never arrived is left with.
  */
 function inspectMarkup(page, source) {
+  let flat = 0;
   // Whitespace-collapsed first, because Prettier decides where the lines in these
   // files break: it puts every attribute of a long tag on its own line and the
   // closing angle bracket on a line after them. A reader matching
@@ -467,7 +471,7 @@ function inspectMarkup(page, source) {
       refusals.push(
         `${page} condenses ${blocks} help text(s) and carries no readable ${CONDENSE_ROOT} container, so the applier is handed nothing to walk`,
       );
-      return { refusals, blocks };
+      return { refusals, blocks, declared: flat };
     }
 
     const card = markup.indexOf('class="verticalSection sso-help-card"');
@@ -530,9 +534,36 @@ function inspectMarkup(page, source) {
         `${first} and ${second} on ${page} are two help blocks in one field: the rail card answers for ${first} wherever the focus lands in it, and ${second} is unreachable from it`,
       ),
     );
+
+    // THE COUNT IS CLOSED, CLASS-AGNOSTIC (#1677). Everything above enters a help text
+    // through its CLASS - `fieldDescription` for a block, `sso-help` for a condensed one
+    // - so a `*_help` marker written on a class neither reader knows is in NEITHER
+    // population, and the census next door does not care how a site is authored. A field
+    // taken out of the condensing by renaming its class would leave no trace anywhere but
+    // in a number nothing asserts.
+    //
+    // So the markers are counted from the attribute alone and the page has to add up:
+    // every one is either a condensed block or a site that DECLARES itself flat, with the
+    // reason at the site. The tree carries exactly one declaration today and it is a
+    // warning rather than a field description - folding a warning hides the thing it
+    // exists to put in front of a reader - which is why the answer is a declaration and
+    // not an exemption by class name: the next one has to say why too.
+    const markers = [
+      ...markup.matchAll(/data-i18n(?:-parts)?="[a-z0-9_.]+_help"/g),
+    ].length;
+    flat = [...markup.matchAll(/<[a-z][a-z0-9]*\b[^>]*>/g)].filter(
+      (tag) =>
+        /data-sso-flat-help="[^"]+"/.test(tag[0]) &&
+        /data-i18n(?:-parts)?="[a-z0-9_.]+_help"/.test(tag[0]),
+    ).length;
+    if (markers !== blocks + flat) {
+      refusals.push(
+        `${page} carries ${markers} help marker(s) and accounts for ${blocks + flat} of them - ${blocks} condensed and ${flat} declared flat - so a help text sits on an element neither reader enters`,
+      );
+    }
   }
 
-  return { refusals, blocks };
+  return { refusals, blocks, declared: flat };
 }
 
 // Elements a browser closes without a closing tag; they never contain a help block
@@ -1116,9 +1147,24 @@ function fixtureMarkup(key, parts) {
   if (p.scoped === false) {
     return [`<div ${CONDENSE_ROOT}>`, block, `</div>`, card].join("\n");
   }
-  return [`<div ${CONDENSE_ROOT}>`, block, p.card ? card : "", `</div>`].join(
-    "\n",
-  );
+
+  // A second `*_help` marker on a class neither reader enters (#1677). `stray` leaves it
+  // undeclared, which the closure refuses; `flat` declares it with a reason, which it
+  // accepts. The two differ by one attribute, which is the whole near-miss: renaming a
+  // field's class to take it out of the condensing produces the first, and a warning that
+  // was never a field description produces the second.
+  const extra =
+    p.stray || p.declared
+      ? `<div class="sso-callout"${p.declared ? ' data-sso-flat-help="a warning, not a field description"' : ""} data-i18n-parts="config.fixture_9_help">a warning</div>`
+      : "";
+
+  return [
+    `<div ${CONDENSE_ROOT}>`,
+    block,
+    extra,
+    p.card ? card : "",
+    `</div>`,
+  ].join("\n");
 }
 
 /*
@@ -1179,6 +1225,14 @@ async function calibrate(i18n) {
     ).refusals,
   );
   record(
+    "a help marker declared flat, with its reason",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { declared: true }),
+    ).refusals,
+  );
+  record(
     "a fold whose text is assembled from parts",
     false,
     inspectMarkup(
@@ -1201,6 +1255,7 @@ async function calibrate(i18n) {
       { flat: true, assembled: true },
     ],
     ["a fold authored inside a <p>", { tag: "p" }],
+    ["a help marker on a class neither reader enters", { stray: true }],
     ["a rail card with no heading", { heading: false }],
     ["a block the applier will not find", { marked: false }],
     ["a fold with no lead line to fill", { lead: false }],
@@ -1595,7 +1650,10 @@ async function run() {
           `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence` +
             (assembled === 0
               ? ""
-              : `, ${assembled} assembled from parts and judged by the markup reader only`),
+              : `, ${assembled} assembled from parts and judged by the markup reader only`) +
+            (authored.declared === 0
+              ? ""
+              : `, ${authored.declared} declared flat with a reason`),
         );
       }
     }


### PR DESCRIPTION
# What & why

Both readers in `tools/ui-condensed-help.js` enter a help text through its
CLASS - `fieldDescription` for a block, `sso-help` for a condensed one - so a
`*_help` marker written on a class neither of them knows sat in **neither**
population, and `tools/ui-help-census.js` next door does not care how a site is
authored. A field taken out of the condensing by renaming its class left no
trace anywhere except in a number nothing asserted.

The markers are counted from the attribute alone now, class-agnostic, and the
page has to add up: every one is either a condensed block or a site that
**declares itself flat** through `data-sso-flat-help`, with the reason at the
site. The run prints how many a page declares:

```
$ node tools/ui-condensed-help.js
calibration:       57 arms, 31 that must pass and 26 that must be refused, all as expected
providersPage.html  111 condensed help text(s), 66 with a fold that holds more, 10 whose text is one sentence, 35 assembled from parts and judged by the markup reader only, 1 declared flat with a reason
the marked pages:   131 condensed help text(s) over 4 page(s), read in en and de
every condensed help text is authored as a fold and shows its own first sentence under the field, in both catalogues
```

so "one short of the site count" is a figure a reader can see rather than
reconstruct from the census page.

**Closes #1677**, whose two Done-when conditions are both met - the first was
already met at `origin/5.0` `7e249477` and is recorded on the issue with the
commands that read it; this change is the second.

## The one declaration in the tree

`config.saml_base_url_override_help` sits on a `sso-callout sso-callout-warning`
beside the SAML base-URL field. Folding a warning hides the thing it exists to
put in front of a reader, so it stays flat - and it now says so where a reader
of the markup meets it, rather than being tolerated by a class name the gate
happens not to enter.

**A declaration rather than an exemption by class name, because the next one has
to say why too.** Exempting `sso-callout` would have covered this site and every
future one silently, which is the same accounting hole one class wider.

## Proof it bites

```
$ node tools/__m6.js        # the closure removed
CALIBRATION  a help marker on a class neither reader enters: no refusal
the calibration disagreed, so nothing was counted (#1662)
```

The mutant was a temporary copy, run and deleted; the tree carries none. Before
the declaration was added to the page, the closure named the real site on the
real page rather than only a fixture:

```
REFUSED  providersPage.html carries 112 help marker(s) and accounts for 111 of them - 111 condensed and 0 declared flat - so a help text sits on an element neither reader enters
```

The negative and its near-miss differ by **one attribute**: an undeclared marker
on an unknown class is refused, the same marker carrying a reason is not. That
is the edit somebody makes when they rename a field's class, and the edit
somebody makes when they add a warning.

## Means

No new means. The closure is four lines in the gate this tree already runs in
the `.NET` workflow, and the declaration is an attribute in the page it is
about. A register file beside the tree was the alternative and was not taken:
the reason belongs where the next person editing that element will read it, and
a second file is a second place for the two to drift.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not a login-path, crypto, config-persistence or release-pipeline change: a CI
gate and one attribute on an admin page.

- [ ] Fail-closed preserved - not applicable, no validation path is touched.
- [x] No secrets logged; secrets are redacted on config export - unchanged.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline - none of those is touched.
      **No adversarial review was run on this change and that is deliberate**:
      the repository asks for one where CI cannot exercise the change, and here
      CI runs the gate itself, on every page, with a calibration that stops the
      run before the pages are opened. The refusal is proven by deletion above.
- [x] Review record: none, for the reason in the line above. Stated rather than
      left blank.
- [ ] Log inputs from the IdP are sanitized inline at the log call - not
      applicable.

## Quality checklist

- [x] No duplicated logic; the closure is one arithmetic statement beside the
      readers it closes over.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment says what failure it prevents.
- [x] Architecture-conformance tests pass (full suite green on both frameworks).
- [x] Docs impact considered: `docs/ui/HELP-CENSUS.md` is updated in this change
      - it carried the old answer ("the condensing reader's subject is
      `fieldDescription`, so it neither moves nor refuses it") as if that were
      enough, and now says why it was not and what replaced it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green on both frameworks, 0
      warnings.
- [x] `dotnet test` green: 3959 on net9.0 and 3960 on net10.0, 0 failed, 4
      skipped (the loopback-binding tests that need a Windows firewall consent
      dialog, #1227 - skipped on the mainline too).
- [x] Prettier clean.

`ui-condensed-help`, `ui-help-census`, `ui-untranslated-markup`,
`ui-sentence-parts` and `ui-mock-fields` are green here; the remaining UI gates
are untouched by this change.

## Notes

The branch #1677's own Notes name as carrying a pair of readers was closed as a
duplicate and is not merged; nothing from it is taken here. What this change
takes from that issue is the requirement, which it states precisely: a count
that closes over the markers rather than over the classes.
