### PR TITLE
Answer readiness once, in the rail, and only for the open editor [#1664]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
@@ -136,6 +136,40 @@ public partial class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void TheReadinessRail_IsAddressedByIdsTheProvidersPageCarries()
+    {
+        // The readiness panel used to be a section inside each provider form and is now one list in the
+        // rail (#1664), so ONE id carries what two used to. sso-core.js reaches it through a named
+        // constant rather than a literal selector, which is deliberate - both protocol specs point at the
+        // same list and a second spelling would be a second place for them to disagree - and it is exactly
+        // the shape tools/ui-mock-fields.js refuses to read: that reader skips a concatenated selector on
+        // purpose, so nothing else in this tree names the id at all.
+        //
+        // WHAT THAT COSTS IF NOBODY PINS IT. railReadiness returns at its own guard when the list is
+        // missing, and the forms no longer carry panels to fall back on, so renaming the element takes
+        // readiness off the page in silence - no error, no empty panel, just a card that never answers.
+        // The rule above exists for the same failure on the aggregate check and says why in full.
+        var js = ConfigJs();
+        var providers = WebAssets.Page("providersPage.html");
+
+        Assert.Contains("const RAIL_READINESS_LIST = \"sso-rail-readiness-list\";", js, StringComparison.Ordinal);
+        Assert.Contains("\"#\" + RAIL_READINESS_LIST", js, StringComparison.Ordinal);
+
+        foreach (var id in new[] { "sso-rail-readiness", "sso-rail-readiness-list" })
+        {
+            Assert.Contains("id=\"" + id + "\"", providers, StringComparison.Ordinal);
+        }
+
+        // The invitation and the list are the two halves of one card and one of them is always the visible
+        // one, so a page shipping the list visible would show a headed panel with no rows before anything
+        // is open - which reads as a provider that answered nothing.
+        Assert.Contains("id=\"sso-rail-readiness-list\"", providers, StringComparison.Ordinal);
+        Assert.Matches(
+            "id=\"sso-rail-readiness-list\"[^>]*hidden",
+            System.Text.RegularExpressions.Regex.Replace(providers, @"\s+", " "));
+    }
+
+    [Fact]
     public void TheServeDefaultsBanner_ReadsTheMemberTheReportDeclares()
     {
         // #1543. This one member is why the banner appears at all, and BOTH of its consumers fail quiet: the

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -354,6 +354,7 @@
   "config.saml_template_help": "Füllt einen Platzhalter für den Endpunkt eines SAML-Identitätsanbieters vor. Füllen Sie Endpunkt und Signaturzertifikat über die Metadaten-Einfuhr unten aus den Daten Ihres Identitätsanbieters, prüfen Sie dann und speichern Sie. Es wird nichts automatisch gespeichert.",
   "config.test_connection": "Verbindung testen",
   "config.save_provider": "Speichern",
+  "config.readiness_moved": "Ob dieser Anbieter bereit ist, eine Anmeldung zu bedienen, steht unter »Bereitschaft«.",
   "config.readiness_empty": "Öffnen Sie einen Anbieter, um zu sehen, ob er eine Anmeldung bedienen kann.",
   "config.oid_name_label": "Name des OpenID-Anbieters: {0}",
   "config.oid_name_help": "Der Name, unter dem Jellyfin den OpenID-Anbieter führt. {0} Gibt es keinen OpenID-Anbieter dieses Namens, wird einer unter diesem Namen angelegt. {1} Gibt es ihn schon, werden dessen Einstellungen aktualisiert.",

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -354,6 +354,7 @@
   "config.saml_template_help": "Pre-fills an endpoint placeholder for a SAML identity provider. Use the metadata import below to fill the endpoint and signing certificate from your IdP, then review and save. Nothing is saved automatically.",
   "config.test_connection": "Test Connection",
   "config.save_provider": "Save",
+  "config.readiness_moved": "Whether this provider is ready to serve a login is answered in the Readiness panel.",
   "config.readiness_empty": "Open a provider to see whether it is ready to serve a login.",
   "config.oid_name_label": "Name of OpenID Provider: {0}",
   "config.oid_name_help": "The name used by Jellyfin to identify the OpenID provider. {0} If an OpenID provider with a matching name does not exist, a new provider with this name will be created. {1} If an OpenID provider with a matching name already exists, the settings for that provider will be updated.",

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -389,30 +389,19 @@
                   </p>
 
                   <!--
-                Readiness panel (#1083). One aggregate answer to "is this provider ready for a login
-                attempt, and if not what is left?", assembled from signals the page already has: the
-                required fields on this form, the inline validation messages beside them, the last Test
-                Connection outcome, the computed redirect URI, and the flagged security toggles.
-                ADVISORY ONLY - it never blocks Save, it never writes a toggle's `.checked`, and it issues
-                no request of its own. Every row carries its state as words (#221), never as colour alone,
-                and the field names in a row are read from the form's own labels rather than restated
-                here, so a relabelled field cannot drift against this panel. Rows are built with
-                createElement/textContent, so nothing reaches the DOM as markup.
+                WHERE THE READINESS PANEL WENT (#1664). It was a section here (#1083) and it is now the
+                rail's card, answered once for whichever editor is open. This line is the pointer the
+                issue asks for: a reader of the form meets it where the panel used to be and is told
+                where the answer is, rather than finding the panel gone. It is a sentence and not a
+                second panel - nothing here restates a row, so there is nothing to drift.
               -->
-                  <section class="sso-readiness" id="OidReadiness">
-                    <h4
-                      class="checkboxListLabel"
-                      data-i18n="config.readiness_title"
-                    >
-                      Readiness
-                    </h4>
-                    <ul
-                      class="sso-readiness-list"
-                      id="OidReadinessList"
-                      role="status"
-                      aria-live="polite"
-                    ></ul>
-                  </section>
+                  <p
+                    class="fieldDescription sso-readiness-pointer"
+                    data-i18n="config.readiness_moved"
+                  >
+                    Whether this provider is ready to serve a login is answered
+                    in the Readiness panel.
+                  </p>
 
                   <!--
                 The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
@@ -3400,30 +3389,17 @@
                   </p>
 
                   <!--
-                Readiness panel (#1083). One aggregate answer to "is this provider ready for a login
-                attempt, and if not what is left?", assembled from signals the page already has: the
-                required fields on this form, the inline validation messages beside them, the last Test
-                Connection outcome, the computed reply URL (ACS), and the flagged security toggles.
-                ADVISORY ONLY - it never blocks Save, it never writes a toggle's `.checked`, and it issues
-                no request of its own. Every row carries its state as words (#221), never as colour alone,
-                and the field names in a row are read from the form's own labels rather than restated
-                here, so a relabelled field cannot drift against this panel. Rows are built with
-                createElement/textContent, so nothing reaches the DOM as markup.
+                WHERE THE READINESS PANEL WENT (#1664), the SAML half of the move the OpenID form above
+                carries the same note for. The rail answers for whichever editor is open, so one card
+                serves both forms and neither holds a panel of its own.
               -->
-                  <section class="sso-readiness" id="saml-Readiness">
-                    <h4
-                      class="checkboxListLabel"
-                      data-i18n="config.readiness_title"
-                    >
-                      Readiness
-                    </h4>
-                    <ul
-                      class="sso-readiness-list"
-                      id="saml-ReadinessList"
-                      role="status"
-                      aria-live="polite"
-                    ></ul>
-                  </section>
+                  <p
+                    class="fieldDescription sso-readiness-pointer"
+                    data-i18n="config.readiness_moved"
+                  >
+                    Whether this provider is ready to serve a login is answered
+                    in the Readiness panel.
+                  </p>
 
                   <!--
                 The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
@@ -5670,6 +5646,27 @@
                 >
                   Open a provider to see whether it is ready to serve a login.
                 </div>
+                <!--
+                  THE READINESS PANEL, ONCE, FOR WHICHEVER EDITOR IS OPEN (#1664). It was a section inside
+                  each provider form (#1083) and the two could never both be answering, because only one
+                  workspace is open at a time (#1527). One list here is the same answer with one place to
+                  read it, and each form keeps a pointer where its panel was.
+
+                  EMPTY IN THE MARKUP AND THE LINE ABOVE VISIBLE, so a page whose script never ran shows
+                  the invitation rather than a headed panel with nothing in it. sso-core.js swaps the two
+                  whenever an editor opens or closes, and it is the only thing that writes here.
+
+                  role="status" and aria-live="polite" ride along from the panel this replaces: the list
+                  is rebuilt on every field change, and a reader who has moved past the form is told what
+                  changed without being interrupted. Every row still carries its state as words (#221).
+                -->
+                <ul
+                  class="sso-readiness-list"
+                  id="sso-rail-readiness-list"
+                  role="status"
+                  aria-live="polite"
+                  hidden
+                ></ul>
               </div>
               <!--
                 THE WHOLE TEXT OF THE FIELD THAT HAS FOCUS (#1663), the same card slice 1 put on the small

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -246,6 +246,11 @@ const OIDC_PRESET_MANAGED_TOGGLES = [
 ];
 const SAML_PRESET_MANAGED_TOGGLES = ["DoNotValidateAudience"];
 
+// The one list the readiness panel writes into (#1664). It is named once because both protocol specs
+// point at it now: a second spelling is a second place for the two forms to disagree about where the
+// answer goes, and the whole point of the move is that there is only one.
+const RAIL_READINESS_LIST = "sso-rail-readiness-list";
+
 const ssoConfigurationPage = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
   // Toggles that disable an OpenID Connect security defense. An active one is a downgrade the admin must
@@ -806,9 +811,11 @@ const ssoConfigurationPage = {
   showEditor: (page) => {
     ssoConfigurationPage.hideSamlEditor(page);
     page.querySelector("#sso-editor").hidden = false;
+    ssoConfigurationPage.railReadiness(page);
   },
   hideEditor: (page) => {
     page.querySelector("#sso-editor").hidden = true;
+    ssoConfigurationPage.railReadiness(page);
   },
   setEditorTitle: (page, title) => {
     page.querySelector("#sso-editor-title").textContent = title;
@@ -3249,7 +3256,46 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.readinessTestState[key] = ok;
     ssoConfigurationPage.refreshReadiness(page, key);
   },
-  // ---- Readiness panel (#1083) ----
+  // ---- Readiness panel (#1083), answered once in the rail (#1664) ----
+  // WHICH PROTOCOL THE PAGE IS CURRENTLY ABOUT, or null when it is about neither. COMPUTED RATHER THAN
+  // REMEMBERED: the two editors are mutually exclusive (#1527) and every route that opens one hides the
+  // other, so this is a function of two `hidden` attributes and never of a variable somebody has to keep
+  // in step.
+  //
+  // ONE READING, USED BY THE RAIL AND BY THE PANEL ITSELF, because two readings disagreeing is the
+  // failure this arrangement can have: one list shared by both forms shows whatever was written into it
+  // last, whichever form is on screen.
+  openEditorKey: (page) => {
+    const oid = page.querySelector("#sso-editor");
+    const saml = page.querySelector("#saml-editor");
+    if (!oid || !saml) {
+      return null;
+    }
+    return !oid.hidden ? "oid" : !saml.hidden ? "saml" : null;
+  },
+  // The rail, brought into line with whatever is on screen. Both openers and both closers call it, and a
+  // doubled call is a rebuild of the same list - which the panel was already safe for, being idempotent
+  // and request-free.
+  //
+  // BOTH HIDDEN IS THE INVITATION, not an empty panel: a headed list with no rows reads as a provider
+  // that answered nothing, which is the opposite of the truth when no provider is open.
+  railReadiness: (page) => {
+    const list = page.querySelector("#" + RAIL_READINESS_LIST);
+    const empty = page.querySelector("#sso-rail-readiness");
+    if (!list || !empty) {
+      return;
+    }
+    const open = ssoConfigurationPage.openEditorKey(page);
+    if (open === null) {
+      list.replaceChildren();
+      list.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+    empty.hidden = true;
+    list.hidden = false;
+    ssoConfigurationPage.refreshReadiness(page, open);
+  },
   // The last Test Connection outcome per protocol, so the reachability row can report it WITHOUT
   // re-issuing the request. null means "not yet tested in this page session", which is what a provider
   // that has never been tested must read as - not as a failure. resetEditor / resetSamlEditor clear it,
@@ -3259,7 +3305,7 @@ const ssoConfigurationPage = {
   // panel adds no field, no request and no state of its own beyond the test outcome above.
   readinessSpecs: {
     oid: {
-      listId: "OidReadinessList",
+      listId: RAIL_READINESS_LIST,
       testKey: "oid",
       requiredIds: ["OidProviderName", "OidEndpoint", "OidClientId"],
       errorIds: [
@@ -3273,7 +3319,7 @@ const ssoConfigurationPage = {
       urlId: "OidRedirectUri",
     },
     saml: {
-      listId: "saml-ReadinessList",
+      listId: RAIL_READINESS_LIST,
       testKey: "saml",
       requiredIds: [
         "saml-provider-name",
@@ -3373,6 +3419,23 @@ const ssoConfigurationPage = {
   // Rebuild a panel from the form's current state. Cheap and idempotent, so it is safe to call from a
   // field event; it issues no request and reads nothing the page does not already hold.
   refreshReadiness: (page, key) => {
+    // ONLY THE OPEN EDITOR MAY WRITE, and this is not belt-and-braces on top of
+    // railReadiness - it is the half railReadiness cannot cover (#1664). Three callers
+    // reach here ASYNCHRONOUSLY with a protocol decided when the request went out: the
+    // redirect-URI debounce, the two loadProvider replies, and recordTestOutcome. While
+    // each protocol wrote into its own list inside its own editor those late writes were
+    // harmless - they landed in a hidden panel and were rebuilt on the next open. One
+    // shared list removed that isolation, so an OpenID reply arriving after the
+    // administrator clicked a SAML provider painted the OpenID answer under the SAML
+    // form, including "Ready - Endpoint test", and it stood until the next keystroke.
+    // Found by a review that drove it rather than by a reading of this file.
+    //
+    // A LATE WRITE IS DROPPED RATHER THAN QUEUED, because it is stale by then: the panel
+    // is rebuilt from the form on the next open and on every field event, so nothing is
+    // owed to the reply that lost the race.
+    if (ssoConfigurationPage.openEditorKey(page) !== key) {
+      return;
+    }
     const spec = ssoConfigurationPage.readinessSpecs[key];
     const list = page.querySelector("#" + spec.listId);
     if (!list) {
@@ -4743,9 +4806,11 @@ const ssoConfigurationPage = {
   showSamlEditor: (page) => {
     ssoConfigurationPage.hideEditor(page);
     page.querySelector("#saml-editor").hidden = false;
+    ssoConfigurationPage.railReadiness(page);
   },
   hideSamlEditor: (page) => {
     page.querySelector("#saml-editor").hidden = true;
+    ssoConfigurationPage.railReadiness(page);
   },
   setSamlEditorTitle: (page, title) => {
     page.querySelector("#saml-editor-title").textContent = title;

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -637,11 +637,16 @@
    form rather than beside it.
 
    NO `position: sticky` HERE, and it was written before it was thought about. The stated purpose was to
-   survive a scroll, and `.sso-columns` sets `align-items: start` while the rail holds nothing but this
-   card - so the sticky element's containing block is its own height and there is nowhere to travel. It
-   would have been a declaration that does nothing, asserting a behaviour in a comment beside it. What
-   the rail should do when the form is taller than the screen is a question for the walk, not for a
-   property nobody measured. */
+   survive a scroll, and `.sso-columns` sets `align-items: start`, so a sticky element whose containing
+   block is the rail's own content has nowhere to travel. It would have been a declaration that does
+   nothing, asserting a behaviour in a comment beside it.
+
+   THE REASON SAID "THE RAIL HOLDS NOTHING BUT THIS CARD" AND THAT STOPPED BEING TRUE (#1664). The
+   Providers rail holds the readiness card as well now, so the rail's content is no longer one card's
+   height, and whether that changes the answer is not settled here - it is measured on a walk or not at
+   all. The declaration is still absent and the sentence that justified it is repaired rather than left
+   standing as a fact about a page that has moved on. What the rail should do when the form is taller
+   than the screen remains the walk's question. */
 .sso-help-card {
   max-height: 60vh;
   overflow-y: auto;


### PR DESCRIPTION
# Superseded by #1682, after the re-run of the review that failed the first head

This branch is the readiness move with the cross-protocol repair on it, and the
re-run of the lens that had failed it refuted the blocking finding on exactly
this content. It is replaced rather than amended because #1664 asks for that and
because a force-push is not available here; nothing in it is lost.

**What #1682 adds on top of this head**, both from that re-run and neither a
defect a reader would see today:

- `readinessSpecs.*.listId` had become a per-protocol field holding the same
  value in both specs, and it was the one route left to a headed empty panel:
  `railReadiness` unhides the list and hands over, so a lookup that misses below
  it leaves the card headed and empty. The lens produced exactly that by putting
  the old literals back. The field is gone from both specs and the list is read
  from one name.
- The priming `refreshReadiness` at init was dead - the rail answers only for an
  open editor and neither is open at init - while its comment said it rebuilt the
  panel. Removed rather than left as a line that reads like it does something.

The full record, the eight re-driven sequences, the 600-step fuzz and the proof
that the gate is load-bearing are in #1682's body.

Closed rather than left open so the issue has one candidate from me.
