### PR TITLE
Answer readiness once, in the rail, and only for the open editor [#1664]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.ProviderCheckSurface.cs
@@ -136,6 +136,40 @@ public partial class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void TheReadinessRail_IsAddressedByIdsTheProvidersPageCarries()
+    {
+        // The readiness panel used to be a section inside each provider form and is now one list in the
+        // rail (#1664), so ONE id carries what two used to. sso-core.js reaches it through a named
+        // constant rather than a literal selector, which is deliberate - both protocol specs point at the
+        // same list and a second spelling would be a second place for them to disagree - and it is exactly
+        // the shape tools/ui-mock-fields.js refuses to read: that reader skips a concatenated selector on
+        // purpose, so nothing else in this tree names the id at all.
+        //
+        // WHAT THAT COSTS IF NOBODY PINS IT. railReadiness returns at its own guard when the list is
+        // missing, and the forms no longer carry panels to fall back on, so renaming the element takes
+        // readiness off the page in silence - no error, no empty panel, just a card that never answers.
+        // The rule above exists for the same failure on the aggregate check and says why in full.
+        var js = ConfigJs();
+        var providers = WebAssets.Page("providersPage.html");
+
+        Assert.Contains("const RAIL_READINESS_LIST = \"sso-rail-readiness-list\";", js, StringComparison.Ordinal);
+        Assert.Contains("\"#\" + RAIL_READINESS_LIST", js, StringComparison.Ordinal);
+
+        foreach (var id in new[] { "sso-rail-readiness", "sso-rail-readiness-list" })
+        {
+            Assert.Contains("id=\"" + id + "\"", providers, StringComparison.Ordinal);
+        }
+
+        // The invitation and the list are the two halves of one card and one of them is always the visible
+        // one, so a page shipping the list visible would show a headed panel with no rows before anything
+        // is open - which reads as a provider that answered nothing.
+        Assert.Contains("id=\"sso-rail-readiness-list\"", providers, StringComparison.Ordinal);
+        Assert.Matches(
+            "id=\"sso-rail-readiness-list\"[^>]*hidden",
+            System.Text.RegularExpressions.Regex.Replace(providers, @"\s+", " "));
+    }
+
+    [Fact]
     public void TheServeDefaultsBanner_ReadsTheMemberTheReportDeclares()
     {
         // #1543. This one member is why the banner appears at all, and BOTH of its consumers fail quiet: the

--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -354,6 +354,7 @@
   "config.saml_template_help": "Füllt einen Platzhalter für den Endpunkt eines SAML-Identitätsanbieters vor. Füllen Sie Endpunkt und Signaturzertifikat über die Metadaten-Einfuhr unten aus den Daten Ihres Identitätsanbieters, prüfen Sie dann und speichern Sie. Es wird nichts automatisch gespeichert.",
   "config.test_connection": "Verbindung testen",
   "config.save_provider": "Speichern",
+  "config.readiness_moved": "Ob dieser Anbieter bereit ist, eine Anmeldung zu bedienen, steht unter »Bereitschaft«.",
   "config.readiness_empty": "Öffnen Sie einen Anbieter, um zu sehen, ob er eine Anmeldung bedienen kann.",
   "config.oid_name_label": "Name des OpenID-Anbieters: {0}",
   "config.oid_name_help": "Der Name, unter dem Jellyfin den OpenID-Anbieter führt. {0} Gibt es keinen OpenID-Anbieter dieses Namens, wird einer unter diesem Namen angelegt. {1} Gibt es ihn schon, werden dessen Einstellungen aktualisiert.",

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -354,6 +354,7 @@
   "config.saml_template_help": "Pre-fills an endpoint placeholder for a SAML identity provider. Use the metadata import below to fill the endpoint and signing certificate from your IdP, then review and save. Nothing is saved automatically.",
   "config.test_connection": "Test Connection",
   "config.save_provider": "Save",
+  "config.readiness_moved": "Whether this provider is ready to serve a login is answered in the Readiness panel.",
   "config.readiness_empty": "Open a provider to see whether it is ready to serve a login.",
   "config.oid_name_label": "Name of OpenID Provider: {0}",
   "config.oid_name_help": "The name used by Jellyfin to identify the OpenID provider. {0} If an OpenID provider with a matching name does not exist, a new provider with this name will be created. {1} If an OpenID provider with a matching name already exists, the settings for that provider will be updated.",

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -389,30 +389,19 @@
                   </p>
 
                   <!--
-                Readiness panel (#1083). One aggregate answer to "is this provider ready for a login
-                attempt, and if not what is left?", assembled from signals the page already has: the
-                required fields on this form, the inline validation messages beside them, the last Test
-                Connection outcome, the computed redirect URI, and the flagged security toggles.
-                ADVISORY ONLY - it never blocks Save, it never writes a toggle's `.checked`, and it issues
-                no request of its own. Every row carries its state as words (#221), never as colour alone,
-                and the field names in a row are read from the form's own labels rather than restated
-                here, so a relabelled field cannot drift against this panel. Rows are built with
-                createElement/textContent, so nothing reaches the DOM as markup.
+                WHERE THE READINESS PANEL WENT (#1664). It was a section here (#1083) and it is now the
+                rail's card, answered once for whichever editor is open. This line is the pointer the
+                issue asks for: a reader of the form meets it where the panel used to be and is told
+                where the answer is, rather than finding the panel gone. It is a sentence and not a
+                second panel - nothing here restates a row, so there is nothing to drift.
               -->
-                  <section class="sso-readiness" id="OidReadiness">
-                    <h4
-                      class="checkboxListLabel"
-                      data-i18n="config.readiness_title"
-                    >
-                      Readiness
-                    </h4>
-                    <ul
-                      class="sso-readiness-list"
-                      id="OidReadinessList"
-                      role="status"
-                      aria-live="polite"
-                    ></ul>
-                  </section>
+                  <p
+                    class="fieldDescription sso-readiness-pointer"
+                    data-i18n="config.readiness_moved"
+                  >
+                    Whether this provider is ready to serve a login is answered
+                    in the Readiness panel.
+                  </p>
 
                   <!--
                 The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
@@ -3400,30 +3389,17 @@
                   </p>
 
                   <!--
-                Readiness panel (#1083). One aggregate answer to "is this provider ready for a login
-                attempt, and if not what is left?", assembled from signals the page already has: the
-                required fields on this form, the inline validation messages beside them, the last Test
-                Connection outcome, the computed reply URL (ACS), and the flagged security toggles.
-                ADVISORY ONLY - it never blocks Save, it never writes a toggle's `.checked`, and it issues
-                no request of its own. Every row carries its state as words (#221), never as colour alone,
-                and the field names in a row are read from the form's own labels rather than restated
-                here, so a relabelled field cannot drift against this panel. Rows are built with
-                createElement/textContent, so nothing reaches the DOM as markup.
+                WHERE THE READINESS PANEL WENT (#1664), the SAML half of the move the OpenID form above
+                carries the same note for. The rail answers for whichever editor is open, so one card
+                serves both forms and neither holds a panel of its own.
               -->
-                  <section class="sso-readiness" id="saml-Readiness">
-                    <h4
-                      class="checkboxListLabel"
-                      data-i18n="config.readiness_title"
-                    >
-                      Readiness
-                    </h4>
-                    <ul
-                      class="sso-readiness-list"
-                      id="saml-ReadinessList"
-                      role="status"
-                      aria-live="polite"
-                    ></ul>
-                  </section>
+                  <p
+                    class="fieldDescription sso-readiness-pointer"
+                    data-i18n="config.readiness_moved"
+                  >
+                    Whether this provider is ready to serve a login is answered
+                    in the Readiness panel.
+                  </p>
 
                   <!--
                 The "managed by file" state (#1104). Deliberately carries NO data-i18n marker, for the same
@@ -5670,6 +5646,27 @@
                 >
                   Open a provider to see whether it is ready to serve a login.
                 </div>
+                <!--
+                  THE READINESS PANEL, ONCE, FOR WHICHEVER EDITOR IS OPEN (#1664). It was a section inside
+                  each provider form (#1083) and the two could never both be answering, because only one
+                  workspace is open at a time (#1527). One list here is the same answer with one place to
+                  read it, and each form keeps a pointer where its panel was.
+
+                  EMPTY IN THE MARKUP AND THE LINE ABOVE VISIBLE, so a page whose script never ran shows
+                  the invitation rather than a headed panel with nothing in it. sso-core.js swaps the two
+                  whenever an editor opens or closes, and it is the only thing that writes here.
+
+                  role="status" and aria-live="polite" ride along from the panel this replaces: the list
+                  is rebuilt on every field change, and a reader who has moved past the form is told what
+                  changed without being interrupted. Every row still carries its state as words (#221).
+                -->
+                <ul
+                  class="sso-readiness-list"
+                  id="sso-rail-readiness-list"
+                  role="status"
+                  aria-live="polite"
+                  hidden
+                ></ul>
               </div>
               <!--
                 THE WHOLE TEXT OF THE FIELD THAT HAS FOCUS (#1663), the same card slice 1 put on the small

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -246,6 +246,11 @@ const OIDC_PRESET_MANAGED_TOGGLES = [
 ];
 const SAML_PRESET_MANAGED_TOGGLES = ["DoNotValidateAudience"];
 
+// The one list the readiness panel writes into (#1664). It is named once because both protocol specs
+// point at it now: a second spelling is a second place for the two forms to disagree about where the
+// answer goes, and the whole point of the move is that there is only one.
+const RAIL_READINESS_LIST = "sso-rail-readiness-list";
+
 const ssoConfigurationPage = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
   // Toggles that disable an OpenID Connect security defense. An active one is a downgrade the admin must
@@ -806,9 +811,11 @@ const ssoConfigurationPage = {
   showEditor: (page) => {
     ssoConfigurationPage.hideSamlEditor(page);
     page.querySelector("#sso-editor").hidden = false;
+    ssoConfigurationPage.railReadiness(page);
   },
   hideEditor: (page) => {
     page.querySelector("#sso-editor").hidden = true;
+    ssoConfigurationPage.railReadiness(page);
   },
   setEditorTitle: (page, title) => {
     page.querySelector("#sso-editor-title").textContent = title;
@@ -3249,7 +3256,46 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.readinessTestState[key] = ok;
     ssoConfigurationPage.refreshReadiness(page, key);
   },
-  // ---- Readiness panel (#1083) ----
+  // ---- Readiness panel (#1083), answered once in the rail (#1664) ----
+  // WHICH PROTOCOL THE PAGE IS CURRENTLY ABOUT, or null when it is about neither. COMPUTED RATHER THAN
+  // REMEMBERED: the two editors are mutually exclusive (#1527) and every route that opens one hides the
+  // other, so this is a function of two `hidden` attributes and never of a variable somebody has to keep
+  // in step.
+  //
+  // ONE READING, USED BY THE RAIL AND BY THE PANEL ITSELF, because two readings disagreeing is the
+  // failure this arrangement can have: one list shared by both forms shows whatever was written into it
+  // last, whichever form is on screen.
+  openEditorKey: (page) => {
+    const oid = page.querySelector("#sso-editor");
+    const saml = page.querySelector("#saml-editor");
+    if (!oid || !saml) {
+      return null;
+    }
+    return !oid.hidden ? "oid" : !saml.hidden ? "saml" : null;
+  },
+  // The rail, brought into line with whatever is on screen. Both openers and both closers call it, and a
+  // doubled call is a rebuild of the same list - which the panel was already safe for, being idempotent
+  // and request-free.
+  //
+  // BOTH HIDDEN IS THE INVITATION, not an empty panel: a headed list with no rows reads as a provider
+  // that answered nothing, which is the opposite of the truth when no provider is open.
+  railReadiness: (page) => {
+    const list = page.querySelector("#" + RAIL_READINESS_LIST);
+    const empty = page.querySelector("#sso-rail-readiness");
+    if (!list || !empty) {
+      return;
+    }
+    const open = ssoConfigurationPage.openEditorKey(page);
+    if (open === null) {
+      list.replaceChildren();
+      list.hidden = true;
+      empty.hidden = false;
+      return;
+    }
+    empty.hidden = true;
+    list.hidden = false;
+    ssoConfigurationPage.refreshReadiness(page, open);
+  },
   // The last Test Connection outcome per protocol, so the reachability row can report it WITHOUT
   // re-issuing the request. null means "not yet tested in this page session", which is what a provider
   // that has never been tested must read as - not as a failure. resetEditor / resetSamlEditor clear it,
@@ -3259,7 +3305,6 @@ const ssoConfigurationPage = {
   // panel adds no field, no request and no state of its own beyond the test outcome above.
   readinessSpecs: {
     oid: {
-      listId: "OidReadinessList",
       testKey: "oid",
       requiredIds: ["OidProviderName", "OidEndpoint", "OidClientId"],
       errorIds: [
@@ -3273,7 +3318,6 @@ const ssoConfigurationPage = {
       urlId: "OidRedirectUri",
     },
     saml: {
-      listId: "saml-ReadinessList",
       testKey: "saml",
       requiredIds: [
         "saml-provider-name",
@@ -3373,8 +3417,32 @@ const ssoConfigurationPage = {
   // Rebuild a panel from the form's current state. Cheap and idempotent, so it is safe to call from a
   // field event; it issues no request and reads nothing the page does not already hold.
   refreshReadiness: (page, key) => {
+    // ONLY THE OPEN EDITOR MAY WRITE, and this is not belt-and-braces on top of
+    // railReadiness - it is the half railReadiness cannot cover (#1664). Three callers
+    // reach here ASYNCHRONOUSLY with a protocol decided when the request went out: the
+    // redirect-URI debounce, the two loadProvider replies, and recordTestOutcome. While
+    // each protocol wrote into its own list inside its own editor those late writes were
+    // harmless - they landed in a hidden panel and were rebuilt on the next open. One
+    // shared list removed that isolation, so an OpenID reply arriving after the
+    // administrator clicked a SAML provider painted the OpenID answer under the SAML
+    // form, including "Ready - Endpoint test", and it stood until the next keystroke.
+    // Found by a review that drove it rather than by a reading of this file.
+    //
+    // A LATE WRITE IS DROPPED RATHER THAN QUEUED, because it is stale by then: the panel
+    // is rebuilt from the form on the next open and on every field event, so nothing is
+    // owed to the reply that lost the race.
+    if (ssoConfigurationPage.openEditorKey(page) !== key) {
+      return;
+    }
     const spec = ssoConfigurationPage.readinessSpecs[key];
-    const list = page.querySelector("#" + spec.listId);
+    // THE LIST IS READ FROM THE CONSTANT AND NOT FROM THE SPEC, so the two cannot diverge.
+    // Each spec carried a listId until the review of 2026-09-12 pointed out that both had come
+    // to hold the same value: a per-protocol field that no longer varies is a place for one of
+    // them to be edited alone, and that is the last route left to the shape this card is
+    // supposed to be free of - railReadiness unhides the list and hands over, so a lookup that
+    // misses below leaves a headed panel with no rows. Driven on a tree with the old literals
+    // put back, it produced exactly that. One name, one lookup, no divergence to have.
+    const list = page.querySelector("#" + RAIL_READINESS_LIST);
     if (!list) {
       return;
     }
@@ -4743,9 +4811,11 @@ const ssoConfigurationPage = {
   showSamlEditor: (page) => {
     ssoConfigurationPage.hideEditor(page);
     page.querySelector("#saml-editor").hidden = false;
+    ssoConfigurationPage.railReadiness(page);
   },
   hideSamlEditor: (page) => {
     page.querySelector("#saml-editor").hidden = true;
+    ssoConfigurationPage.railReadiness(page);
   },
   setSamlEditorTitle: (page, title) => {
     page.querySelector("#saml-editor-title").textContent = title;
@@ -6307,9 +6377,15 @@ function initProvidersPage(view) {
   // Populate the computed URLs once at init (blank editor shows the placeholders until a name is typed).
   ssoConfigurationPage.updateSamlUrls(view);
 
-  // ---- Readiness panel (#1083) ----
+  // ---- Readiness panel (#1083), in the rail (#1664) ----
   // Advisory and read-only: these handlers re-read the form and rebuild the panel. They set no value,
   // check no box, and issue no request, so nothing here can change what a Save would send.
+  //
+  // NO PRIMING CALL HERE, AND THE ONE THAT STOOD HERE WAS DEAD. It rebuilt both panels at init, from a
+  // time when each editor held its own; the rail answers only for an open editor and neither is open at
+  // init, so the call returned at the gate every time. The card's starting state is the invitation the
+  // markup ships, which a conformance rule pins. Removed rather than left as a line that reads like it
+  // does something.
   [
     ["#sso-editor", "oid"],
     ["#saml-editor", "saml"],
@@ -6323,7 +6399,6 @@ function initProvidersPage(view) {
         ssoConfigurationPage.refreshReadiness(view, key),
       ),
     );
-    ssoConfigurationPage.refreshReadiness(view, key);
   });
   // The per-provider selectors, on both forms. The handler asks before the inline policy is discarded and
   // then syncs the note and the disabled state, so the page reflects the choice immediately rather than

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -637,11 +637,16 @@
    form rather than beside it.
 
    NO `position: sticky` HERE, and it was written before it was thought about. The stated purpose was to
-   survive a scroll, and `.sso-columns` sets `align-items: start` while the rail holds nothing but this
-   card - so the sticky element's containing block is its own height and there is nowhere to travel. It
-   would have been a declaration that does nothing, asserting a behaviour in a comment beside it. What
-   the rail should do when the form is taller than the screen is a question for the walk, not for a
-   property nobody measured. */
+   survive a scroll, and `.sso-columns` sets `align-items: start`, so a sticky element whose containing
+   block is the rail's own content has nowhere to travel. It would have been a declaration that does
+   nothing, asserting a behaviour in a comment beside it.
+
+   THE REASON SAID "THE RAIL HOLDS NOTHING BUT THIS CARD" AND THAT STOPPED BEING TRUE (#1664). The
+   Providers rail holds the readiness card as well now, so the rail's content is no longer one card's
+   height, and whether that changes the answer is not settled here - it is measured on a walk or not at
+   all. The declaration is still absent and the sentence that justified it is repaired rather than left
+   standing as a fact about a page that has moved on. What the rail should do when the form is taller
+   than the screen remains the walk's question. */
 .sso-help-card {
   max-height: 60vh;
   overflow-y: auto;


### PR DESCRIPTION
# What & why

Slice 3 of stage 2 of the 4.4 surface (#1528): readiness answered once, in the
right column. The per-provider panel (#1083) was a `<section>` inside each of the
two provider forms, so the page carried two panels that could never both be
answering - only one workspace is open at a time (#1527). Both are gone; the
rail's Readiness card holds the one list and answers for whichever editor is
open. Each form keeps a one-line pointer where its panel was, naming the card it
sends the reader to.

**Refs #1664.** See Notes for what it does not close. This branch REPLACES the one
of #1680 after the re-run, which is what the issue asks for and the only shape
available here, since a force-push is not.

## What did not change

Nothing about what the panel SAYS. The same rows come out of the same
`refreshReadiness`, from the same signals the page already holds: the required
fields, the inline validation messages beside them, the last Test Connection
outcome, the computed URL, and the flagged security toggles. It stays advisory -
no request of its own, no write to a field or a toggle, every state carried in
words rather than colour alone (#221), every row built with
`createElement`/`textContent`. Field names are still read from the form's own
labels, so a relabelled field cannot drift against the panel.

Both protocol specs now name one list id, declared once as `RAIL_READINESS_LIST`.
A second spelling would be a second place for the two forms to disagree about
where the answer goes, which is the thing this slice removes.

## Which editor is open is computed, never remembered

`railReadiness(page)` reads the two editors' `hidden` attributes and rebuilds.
Every route that opens one already hides the other, so there is no third state
and no variable anybody has to keep in step; both openers and both closers call
it, and a doubled call is a rebuild of the same list - which the panel was
already safe for, being idempotent and request-free.

With both editors hidden the card shows its invitation rather than a headed list
with no rows. An empty panel reads as a provider that answered nothing, which is
the opposite of the truth when no provider is open.

The markup ships the list `hidden` and the invitation visible, so a page whose
script never arrived shows the invitation rather than a headed empty panel.

## The Test Connection result stays in the editor, and that is a decision

#1664 allows moving it into the rail "if the pull request shows a better place".
This one does not move it, for three reasons stated together rather than by
default:

- it is the outcome of an act the administrator just performed, at the button
  they performed it at, and a result that jumps to the other side of the page is
  a result they have to go looking for;
- the rail answers a standing question about the form as a whole, and the
  readiness list already carries the endpoint test as one of its rows, so the
  verdict is in the rail either way;
- moving it would put one verdict in two places, which is what this slice is
  removing rather than adding.

## The catalogue

One row in both languages, `config.readiness_moved`, which is the pointer
sentence. It names the card - "in the Readiness panel" / "unter »Bereitschaft«" - and
asserts no geometry: the rail is beside the form on a wide screen and above it on
a narrow one, so a sentence saying "beside this form" is false half the time. A
review found it saying exactly that.

Catalogue-Vouch: de read by iderex

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not a login-path, crypto, config-persistence or release-pipeline change: this is
admin-page markup and one browser module's rendering of an advisory panel.

- [ ] Fail-closed preserved - not applicable, no validation path is touched.
- [x] No secrets logged; secrets are redacted on config export - unchanged. The
      panel reads whether a required field is empty, never a value, and the
      client secret is one of the fields it reports on by NAME only.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline - none of those is touched.
      The adversarial review that was run is recorded below, because CI cannot
      exercise a browser and the review is the primary verification here.
- [x] Review record: see below.
- [ ] Log inputs from the IdP are sanitized inline at the log call - not
      applicable, no logging is touched.

### Review record

Two refute-by-default lenses were run against the first head, each driving the
shipped `sso-core.js` over the shipped `providersPage.html` rather than reasoning
about it - one in jsdom through the real `pageControllers.providers(view)` with
real `MouseEvent`s on the provider cards, one over a stub built from the page's
own ids. Raised: **CONFIRMED 1 / PLAUSIBLE 2**, plus three defects that are not
hypotheses at all and so are neither - a missing gate, a false claim and a stale
comment, each verified by reading the tree rather than by running it. The
template reserves CONFIRMED for a finding with a reproduction behind it, and only
one of these has one; inflating the count would be the easiest place in this body
to be dishonest.

**Both lenses returned a verdict against the change** - one FAIL, one
NEEDS_IMPROVEMENT - and they found the same blocking defect independently.

- **CONFIRMED - FIXED. A late asynchronous refresh painted one protocol's
  readiness under the other protocol's open form.** This is the finding that
  matters and it is a regression this change introduced: while each protocol
  wrote into its own list inside its own editor, a reply that arrived after the
  administrator had switched landed in a hidden panel and was rebuilt on the next
  open. One shared list removed that isolation, and five callers reach
  `refreshReadiness` asynchronously with a protocol decided when the request went
  out - `loadProvider`'s config reply, both arms of the redirect-URI debounce,
  `recordTestOutcome`, and `loadSamlProvider`'s config reply. Driven from plain
  clicks on two provider cards, with an A/B against the parent commit:

  ```
  --------- AFTER  ---------  the one rail list (#sso-rail-readiness-list):
         Ready - Insecure or sensitive options - None of the flagged options is active on this provider.
  --------- BEFORE ---------  the SAML form's own panel (#saml-ReadinessList):
         Needs attention - Insecure or sensitive options - Active: Do Not Validate Audience (Insecure)
  ```

  beside an open SAML editor whose provider has that toggle on. The other lens
  reached the same state by a different route and added `Ready - Endpoint test -
  The last Test Connection reached this provider` about an OpenID endpoint under
  an untested SAML provider. It persisted until the next keystroke in the open
  form, so an administrator reviewing rather than typing kept it.

  **Fixed**: `openEditorKey(page)` is the one reading of which protocol the page
  is about, and `refreshReadiness` returns when its key is not that one. A late
  write is dropped rather than queued, because the panel is rebuilt from the form
  on the next open and on every field event, so nothing is owed to the reply that
  lost the race. The fix is re-driven below.

- **CONFIRMED - FIXED. Nothing pinned the rail's ids.** `sso-core.js` reaches the
  list through a named constant, which is deliberate - both specs point at one
  list and a second spelling would be a second place for them to disagree - and
  that is exactly the shape `tools/ui-mock-fields.js` skips: it refuses to read a
  concatenated selector on purpose, so no gate named the id at all. Renaming the
  element would have taken readiness off the page in silence, and the forms no
  longer carry panels to fall back on. **Fixed**: a conformance rule beside the
  one that exists for the aggregate check, asserting the constant, the reference,
  both ids on the page, and that the list ships `hidden`. Proven by renaming the
  id and watching it go red:

  ```
  SSO-Auth.Tests\ArchitectureConformanceTests.ProviderCheckSurface.cs(160,0):
     at …TheReadinessRail_IsAddressedByIdsTheProvidersPageCarries()
  SSO-Auth.Tests  Total: 1, Errors: 0, Failed: 1
  ```

- **CONFIRMED - FIXED. The pointer asserted a position that is false in the
  layout this page was tuned for.** It said "beside this form", and
  `.sso-columns--rail-first .sso-column-rail { order: -1 }` under `max-width:
  60em` puts the rail above the form. The sentence now names the card and asserts
  no geometry, in both languages.

- **CONFIRMED - FIXED. A comment in `style.css` had stopped being true.** The
  "no `position: sticky`" decision rested on "the rail holds nothing but this
  card", and this change puts a second card in that rail. The sentence is
  repaired where it stands rather than left as a fact about a page that has moved
  on; the declaration is still absent and whether the second card changes the
  answer is the walk's question.

- **PLAUSIBLE - FIXED INCIDENTALLY.** Page init wrote five rows into the hidden
  list, leaving a `role="status" aria-live="polite"` region mutated while nothing
  was open. Not user-visible - `[hidden]` is unopposed by any rule in
  `style.css` or `emby-restyle.css`, which both lenses checked precisely because
  an author `display` would beat it - but the same gate that fixed the blocking
  finding drops those writes too, because no editor is open at init.

- **PLAUSIBLE - DEFERRED. The pointer is a sentence with no mechanism.** The rail
  it names is ~5,200 lines later in DOM order, past the whole second editor; it is
  not a link, carries no `aria-details`, and the list has no `aria-labelledby` to
  its heading. For a screen-reader or keyboard user the answer moved from "the
  next paragraph" to "the end of the document". Neither lens could measure what
  an assistive technology makes of it, and this is the same class as #1672, which
  is open on the slice before this one. Recorded rather than changed on an
  unmeasured reading.

- Refuted, each with the work behind it: every synchronous route is correct - add, open, switch, close, the delete path, the never-saved delete, and the SAML
  delete - with exactly one of invitation and list visible, the list always
  holding its five rows for the open protocol, never both shown and never a
  headed empty list. With no script at all both editors stay hidden (no CSS
  defeats `[hidden]`), so the pointer is never visible on a dead page and the
  rail shows its invitation. With no localization module both new strings fall
  back to the authored English. No live reference to `OidReadinessList`,
  `saml-ReadinessList`, `#OidReadiness` or `#saml-Readiness` remains anywhere in
  the source tree. `railReadiness` cannot throw on a page without a rail.

**The lens that failed it was re-run against the repaired state and the blocking
finding is refuted.** Same method: the real page in jsdom, the real `sso-core.js`
through a data: URL, initialised through the real `pageControllers.providers`,
with an `ApiClient` that parks replies so they settle out of order.

Eight sequences, every one of which put the wrong protocol in the rail before:

```
R1 OIDC test in flight   -> click SAML -> reply   about=SAML
R2 OIDC redirect URI     -> SAML       -> reply   about=SAML
R3 OIDC config load      -> SAML       -> reply   about=SAML
R4 same, editor closed instead                    invite=SHOWN list=hidden rows=0
M1 SAML test in flight   -> OpenID     -> reply   about=OIDC
M2 SAML config load      -> OpenID     -> reply   about=OIDC
M3 the named state: OpenID reply under a SAML form with DoNotValidateAudience on
     Needs attention - Insecure or sensitive options - Active: Do Not Validate Audience (Insecure)
M4 SAML test in flight, editor closed             invite=SHOWN list=hidden rows=0
```

M3 is the row that read `Ready - None of the flagged options is active` before.
Beside those, 16 checkpoints over the ordinary routes driven by real clicks on
the shipped controls, then a 600-step randomised fuzz over all 17 routes with
parked, out-of-order and rejected replies: **0 violations** of "exactly one of
invitation and list visible", "a visible list is never empty", "a hidden list
holds no rows", "rail protocol equals open editor".

**And the gate is proven load-bearing rather than decorative**: with its three
lines stripped from the same head, the identical fuzz produces **598 distinct
violations, the first at step 0**.

The re-run returned two residuals, neither of them the blocking finding. Both are
answered here:

- **FIXED. `readinessSpecs.*.listId` had become a field that no longer varies**,
  and it was the one route left to a headed empty panel: `railReadiness` unhides
  the list and hands over, so a lookup that misses below it leaves the card
  headed and empty. The lens drove exactly that by putting the old literals back.
  The field is gone from both specs and `refreshReadiness` reads the one name.
- **FIXED. The priming `refreshReadiness` at init was dead** and its comment said
  it rebuilt the panel. The rail answers only for an open editor and neither is
  open at init, so it returned at the gate every time. Removed rather than left
  as a line that reads like it does something; the card's starting state is the
  invitation the markup ships, which the conformance rule pins.

The re-run's own verdict line is NEEDS_IMPROVEMENT and it says why in the same
breath: nothing in CI fails if the gate is deleted or inverted. That is **#1678**,
filed before the re-run and named in this body above, and the lens calls it a
follow-up rather than a merge blocker for the reason this repository already
states - for browser code CI cannot exercise, the review is the primary
verification, and this review drove it.

One observation from the re-run is filed rather than fixed here: `loadProvider`
and its SAML twin call `getPluginConfiguration(...).then(onFulfilled)` with no
rejection arm, so a failed config read on open leaves the editor up and the rail
asserting "Still empty" about a saved, fully configured provider, plus an
unhandled rejection. It is pre-existing and out of this slice's scope; the move
to an always-visible rail raises its visibility, which is why it is **#1681**
rather than a line in this body.

**No second reader.** There is one person on this account, so this is
self-witnessed; what stands in place of a second reading is two lenses given the
same change with different questions, neither shown the other's output, and a
third run against the repaired state.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose unit.
      `railReadiness` is one function and the only thing that decides what the
      rail holds; the two panels it replaces were the duplication.
- [x] The change adds no more code than the problem requires. `refreshReadiness`
      and everything under it is untouched.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass (the full suite is green on both
      target frameworks, below).
- [x] Docs impact considered: the wiki's description of the settings surface is
      already open as #1574 on this milestone, and this change is one more page
      difference for it rather than a new one.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, both frameworks, 0
      warnings.
- [x] `dotnet test` is green: 3959 on net9.0 and 3960 on net10.0, 0 failed, 4
      skipped. The four skips are the loopback-binding tests that need a Windows
      firewall consent dialog (#1227); they are skipped rather than worked
      around, and they are skipped on the mainline too.
- [x] Prettier is clean for the four changed files, checked over LF copies
      because this working tree is CRLF and Prettier's default `endOfLine` is
      `lf`.

All ten UI gates the `.NET` workflow runs are green, `ui-mock-fields` and
`ui-folder-checklist` among them, which is what #1664 asks for.

**What none of them covers is this change's behaviour, and saying so is the
point of this paragraph.** No runner in this tree drives the readiness panel:
`ui-mock-fields` asks where controls live, `ui-folder-checklist` asks about
folder rows, `ui-unsaved-state` drives the unsaved-changes state and nothing
else, and the C# conformance rules read the surface's text. So "the rail shows
the list when an editor is open and the invitation when none is", "the list
answers for the editor that is open", and "changing a required field rebuilds
the rows without a save" are held by the review below and by the walk this issue
still owes - not by CI. The missing runner is **#1678**, filed with the four
statements it would have to refuse.

## Notes

**This does not close #1664.** Its last Done-when is a walk on the walk server,
wide and narrow, with screenshots on the pull request. No walk was run: the walk
server on this machine is shared with work that is not mine, and replacing its
plugin binary and restarting it would disturb whatever is using it; screenshots
cannot be attached to a pull request from a terminal either way. The box is not
ticked.

**The narrow screen is where this slice and #1663 now share space.**
`.sso-columns--rail-first .sso-column-rail { order: -1 }` under `max-width: 60em`
puts the whole rail above the form on this page - which this issue's own second
bullet states as intended for readiness. The rail now holds two cards: this one,
always present while an editor is open, and the help card from #1663, which
appears on focus. What that combination does at 375 is not measured here, and no
media rule was added on reasoning alone; it is the walk's to answer.

**Follow-ups.** #1678 is the runner. #1669 and #1672 are the two deferred
findings from the slice before this one and are untouched by it.
