### PR TITLE
Close the editor when a provider's configuration cannot be read [#1681]

### DIFF
--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -216,6 +216,7 @@
   "config.provider_removed": "Anbieter entfernt.",
   "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.config_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
+  "config.provider_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde dieses Formular geschlossen und nicht mit Werten stehen gelassen, die nicht die gespeicherten sind. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.validation_required": "{label} ist erforderlich.",
   "config.validation_endpoint_required": "Der OpenID-Endpunkt ist erforderlich.",
   "config.validation_endpoint_absolute": "Geben Sie eine absolute URL an, z. B. https://id.example.com",

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -216,6 +216,7 @@
   "config.provider_removed": "Provider removed.",
   "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
   "config.config_read_failed": "Could not read the stored configuration, so nothing was changed. Reload the page and try again.",
+  "config.provider_read_failed": "Could not read the stored configuration, so this form was closed rather than left showing values that are not the stored ones. Reload the page and try again.",
   "config.validation_required": "{label} is required.",
   "config.validation_endpoint_required": "OpenID Endpoint is required.",
   "config.validation_endpoint_absolute": "Enter an absolute URL, e.g. https://id.example.com",

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -2784,6 +2784,17 @@ const ssoConfigurationPage = {
         // against what was filled in rather than against what stood here before (#1572).
         ssoConfigurationPage.markPageClean(page);
       },
+      // The read failed, so there is nothing to fill the form from (#1681). Attached as the SECOND
+      // argument to then rather than as a catch, for the reason saveProvider states at its own handler:
+      // a catch here would also fire for anything thrown by the fill above, and a fill that threw
+      // halfway would then be reported as a server that could not be reached.
+      () => {
+        ssoConfigurationPage.hideEditor(page);
+        ssoConfigurationPage.reportUnreadableProviderConfiguration(page);
+        // The form is gone, so nothing in it is unsaved, and the notice that says otherwise would
+        // outlive the editor it is about (#1572).
+        ssoConfigurationPage.markPageClean(page);
+      },
     );
   },
   // Serial of the most recent redirect-URI request. A reply for an older provider name must never land in
@@ -3100,6 +3111,35 @@ const ssoConfigurationPage = {
     if (message) {
       box.classList.add(ok ? "sso-status-ok" : "sso-status-fail");
     }
+  },
+  // THE ONE ANSWER TO A CONFIGURATION READ THAT FAILED WHILE AN EDITOR WAS BEING FILLED (#1681).
+  //
+  // Both loaders fill a form from a read that can fail, and until this existed neither had a rejection
+  // arm at all: the editor was already open over the fields resetEditor had blanked, so the form read as
+  // an empty provider, the readiness rail had been rebuilt from those blanks and asserted "Still empty"
+  // about a provider that is saved and fully configured, and the rejection surfaced in the browser
+  // console and nowhere a reader of the page will look. The rail is the part worth stating plainly: since
+  // #1664 it is the only place readiness appears, so it was not silent, it was confidently wrong, and
+  // what it said was the opposite of the truth.
+  //
+  // THE EDITOR IS CLOSED RATHER THAN ANNOTATED, and that is the decision. A note above a form full of
+  // blanks leaves the blanks on screen, one Save away from writing them over a provider that is fine, and
+  // leaves the rail answering about them. Closing it takes all three at once: nothing reads as the
+  // provider's values, the Save goes with the form, and hideEditor / hideSamlEditor put the rail back to
+  // its invitation through railReadiness, which is the state that matches a page with no editor open.
+  //
+  // THE PAGE REGION AND NOT THE EDITOR'S, for the reason deleteProvider states where it does the same
+  // thing: the editor's status box lives inside the element that was just hidden, so an outcome written
+  // there would be invisible.
+  reportUnreadableProviderConfiguration: (page) => {
+    ssoConfigurationPage.renderPageStatus(
+      page,
+      tr(
+        "config.provider_read_failed",
+        "Could not read the stored configuration, so this form was closed rather than left showing values that are not the stored ones. Reload the page and try again.",
+      ),
+      false,
+    );
   },
   saveProvider: (page, provider_name) => {
     return new Promise((resolve, reject) => {
@@ -5075,6 +5115,14 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.refreshReadiness(page, "saml");
         // The editor now holds the stored provider, so the page is clean and the Save gate is re-run
         // against what was filled in rather than against what stood here before (#1572).
+        ssoConfigurationPage.markPageClean(page);
+      },
+      // The same arm the OpenID loader carries, for the same reason and written the same way (#1681).
+      // Both protocols reach this through one read of one configuration document, so a failure here is
+      // never about one of them: whichever editor was being filled is closed and the page says why.
+      () => {
+        ssoConfigurationPage.hideSamlEditor(page);
+        ssoConfigurationPage.reportUnreadableProviderConfiguration(page);
         ssoConfigurationPage.markPageClean(page);
       },
     );

--- a/tools/ui-readiness-rail.js
+++ b/tools/ui-readiness-rail.js
@@ -180,6 +180,9 @@ class Page {
     this.elements = elements;
     this.byId = new Map(elements.map((el) => [el.id, el]));
     this.labelFor = labels;
+    // The page is a class target too: markPageClean takes the dirty marker off it, and a
+    // stub without this throws inside the rejection arm rather than judging it.
+    this.classList = new Classes();
   }
 
   querySelector(selector) {
@@ -191,6 +194,16 @@ class Page {
       return this.labelFor.get(label[1]) || null;
     }
     throw new Error("the stub does not resolve the selector " + selector);
+  }
+
+  // TAG LISTS ONLY, which is the one form reached from here: editableControls asks for
+  // "input, select, textarea" on the way to the unsaved-changes baseline that the failed-read
+  // arm below takes. Written the same way tools/ui-unsaved-state.js writes it, because the
+  // two stubs answer the same question and two different answers to "which controls are on
+  // this page" would let one gate pass a page the other refuses.
+  querySelectorAll(selector) {
+    const tags = selector.split(",").map((part) => part.trim());
+    return this.elements.filter((el) => tags.includes(el.tag));
   }
 }
 
@@ -671,6 +684,14 @@ function installHost(counter) {
         }
         return (...args) => {
           counter.calls.push(String(name) + "(" + args.length + ")");
+          // THE ONE REPLY THIS CLIENT CAN REFUSE (#1681), because a read that fails is a
+          // state the page has to be driven through rather than reasoned about: the server
+          // unreachable, a 500, a configuration the host cannot deserialize. Served as a
+          // rejected promise and not as an empty object, which is what the success arm
+          // already gets and is a different failure.
+          if (counter.refuseRead && name === "getPluginConfiguration") {
+            return Promise.reject(new Error("the stub refused this read"));
+          }
           return Promise.resolve({});
         };
       },
@@ -718,7 +739,12 @@ async function run() {
     return started;
   }
   const { arms, mustPass, faults, refuse } = started;
-  const counter = { calls: [] };
+  const counter = { calls: [], refuseRead: false };
+  // EVERY REJECTION NOBODY HANDLED IS RECORDED, which is a thing node tells you and a
+  // browser does not tell an administrator. The arm below asks for it by name, because
+  // "it surfaces in the console" is exactly the reporting #1681 is about the absence of.
+  const unhandled = [];
+  process.on("unhandledRejection", (reason) => unhandled.push(String(reason)));
   installHost(counter);
   const core = await loadCore();
 
@@ -1101,6 +1127,84 @@ async function run() {
     });
   }
 
+  // ---- Arm: the configuration read fails while an editor is being filled ----
+  //
+  // THE RAIL IS WHY THIS IS HERE RATHER THAN IN A GATE OF ITS OWN (#1681). An editor is
+  // already open over the fields resetEditor blanked when the read is asked for, so a
+  // failure used to leave the form reading as an empty provider AND the rail asserting
+  // "Still empty" about a provider that is saved and fully configured. The rail is the
+  // confident half: it was not silent, it was wrong, and what it said was the opposite of
+  // the truth. So the three things this arm asks for are the editor, the rail and the
+  // sentence, and the fourth is that node found nobody handling the rejection.
+  for (const protocol of ["oid", "saml"]) {
+    const page = providersFixture();
+    const open = protocol === "oid" ? core.showEditor : core.showSamlEditor;
+    const load = protocol === "oid" ? core.loadProvider : core.loadSamlProvider;
+    open(page);
+    if (rowsOf(page).length === 0) {
+      refuse(
+        "read-failed",
+        "the " +
+          protocol +
+          " fixture for this arm never filled the rail, so it proves nothing",
+      );
+    }
+    counter.refuseRead = true;
+    load(page, "a-saved-provider");
+    // Two turns: one for the rejection to settle and one for the handler's own work, and
+    // a third for node to decide a rejection was nobody's.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    counter.refuseRead = false;
+
+    if (!page.querySelector("#" + EDITORS[protocol]).hidden) {
+      refuse(
+        "read-failed",
+        "the " +
+          protocol +
+          " editor stayed open after the read failed, so its blanked fields read as the provider's values and one Save would write them over it",
+      );
+    }
+    inspectRail(page, { open: null, rows: [] }).forEach((detail) =>
+      refuse("read-failed", protocol + ": " + detail),
+    );
+    const status = page.querySelector("#sso-page-status");
+    if (!status) {
+      refuse(
+        "read-failed",
+        "providersPage.html declares no #sso-page-status, so a failed read has nowhere to be reported",
+      );
+    } else {
+      if (status.textContent === "") {
+        refuse(
+          "read-failed",
+          "the " +
+            protocol +
+            " read failed and the page said nothing, so the only report is in the browser console",
+        );
+      }
+      // THE CLASS AS WELL AS THE WORDS. The page marks an outcome ok or failed, and a
+      // failure rendered in the success colour is a worse read than no colour at all.
+      if (!status.classList.contains("sso-status-fail")) {
+        refuse(
+          "read-failed",
+          "the " +
+            protocol +
+            " read failure is not marked as one: " +
+            JSON.stringify(status.textContent),
+        );
+      }
+    }
+  }
+  if (unhandled.length > 0) {
+    refuse(
+      "read-failed",
+      unhandled.length +
+        " rejection(s) reached nobody: " +
+        unhandled.join("; "),
+    );
+  }
+
   if (faults.length) {
     faults.forEach((fault) => console.error(fault));
     console.error(faults.length + " refusal(s) in the readiness rail (#1678)");
@@ -1142,6 +1246,12 @@ async function run() {
   );
   console.log(
     "  labels           every field the rail names is named by the page's label and not by its id",
+  );
+  console.log(
+    "  read-failed      a configuration read that fails closes the editor, returns the rail to its",
+  );
+  console.log(
+    "                   invitation, says so on the page, and leaves no rejection unhandled (#1681)",
   );
   console.log(
     "  NOT driven:      the input/change listeners initProvidersPage binds on the two editors, and the",


### PR DESCRIPTION
# What & why

`loadProvider` and `loadSamlProvider` in `SSO-Auth/Web/sso-core.js` fill a provider form from `ApiClient.getPluginConfiguration`, and neither call had a rejection arm. When that read failed - the server unreachable, a 500, a configuration the host cannot deserialize - three things happened and none of them told the administrator anything:

1. The editor was already open by then, over the fields `resetEditor` had blanked, so the form read as an empty provider.
2. The readiness rail had been rebuilt from those blanks, so it asserted `Needs attention - Required fields - Still empty: ...` about a provider that is saved and fully configured.
3. The rejection surfaced in the browser console and nowhere a reader of the page will look.

The rail is the part worth stating plainly. Since #1664 it is the only place readiness appears, so it was not silent, it was **confidently wrong**, and what it said was the opposite of the truth.

**The editor is closed rather than annotated**, and that is the decision this takes. A note above a form full of blanks leaves the blanks on screen, one Save away from writing them over a provider that is fine, and leaves the rail answering about them. Closing it takes all three at once: nothing reads as the provider's values, the Save goes with the form, and `hideEditor` / `hideSamlEditor` put the rail back to its invitation through `railReadiness` - which is the state that matches a page with no editor open. The report goes in the PAGE region and not the editor's, for the reason `deleteProvider` states where it does the same thing: the editor's status box lives inside the element that was just hidden, so an outcome written there would be invisible.

Both arms are attached as the SECOND argument to `then` rather than as a `catch`, for the reason `saveProvider` states at its own handler: a `catch` would also fire for anything thrown by the fill above, and a fill that threw halfway would then be reported as a server that could not be reached.

Closes #1681

Catalogue-Vouch: de read by iderex

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED __ / PLAUSIBLE __** counts as raised.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Two of those boxes are unticked and the reason is that no such review was run, not that it passed. This is browser-side reading of the admin page: it touches no login path, no SAML or OIDC validation, no server-side config persistence and no release pipeline, and it logs nothing. No lens read it and none is claimed.

The first box is ticked in the direction that applies here, and it is the reason this change exists rather than a formality. The failing branch now **fails closed**: the form that could not be filled is removed, so the Save that would have written blanks over a configured provider is off the page, and the rail stops asserting a readiness it cannot know. Before this, the same failure fell open - an editable, savable form over a provider whose stored values nobody had read. Nothing new reaches the DOM as markup: `renderPageStatus` writes `textContent`, and the one sentence is a catalogue row with no interpolation.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

The two arms share one reporter, `reportUnreadableProviderConfiguration`, because the sentence and the region are the same for both protocols and two copies are two things to edit apart. What differs between them is one line - which editor to close - and that stays at each call site rather than becoming a parameter nobody reads.

Architecture-conformance adds no C# and establishes no structural property in that surface, so it locks in no new rule; it runs unchanged in the suite below.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   ->  0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   ->  0 warnings, 0 errors
SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    ->  Total: 3960, Failed: 0, Skipped: 4
SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   ->  Total: 3961, Failed: 0, Skipped: 4
npx prettier --check SSO-Auth/Web/sso-core.js tools/ui-readiness-rail.js \
  SSO-Auth/Localization/en.json SSO-Auth/Localization/de.json
  ->  All matched files use Prettier code style!
```

The four skips are the loopback-bind tests that raise the Windows firewall consent dialog and need an administrator (#1227). They were skipped rather than worked around.

All eleven UI gates, each run at this head:

```
for f in tools/ui-*.js; do node "$f" >/dev/null 2>&1; echo "$f exit=$?"; done
  ->  all eleven exit=0
```

### It is driven, not asserted - which is the fourth Done-when

`tools/ui-readiness-rail.js` (landed for #1678 in PR #1688) gains a `read-failed` arm that runs over BOTH protocols against an `ApiClient` whose configuration read can be refused. It asks for four things per protocol: the editor is closed, the rail is back to its invitation with an empty list, the page says so and says it in the failure colour, and node found nobody handling the rejection.

```
node tools/ui-readiness-rail.js
calibration:       12 arms, 2 that must pass and 10 that must be refused, all as expected
...
  read-failed      a configuration read that fails closes the editor, returns the rail to its
                   invitation, says so on the page, and leaves no rejection unhandled (#1681)
```

The unhandled-rejection half is recorded through `process.on("unhandledRejection")`, because "it surfaces in the console" is exactly the reporting this issue is about the absence of, and node is the one place that can be asked.

### Every guard deleted, and the gate watched go red

```
the whole OpenID rejection arm removed
  -> read-failed: the oid editor stayed open after the read failed, so its blanked fields read as
                  the provider's values and one Save would write them over it
  -> read-failed: oid: no editor is open and the invitation is hidden, so the rail card is blank
  -> read-failed: 1 rejection(s) reached nobody: Error: the stub refused this read

the whole SAML rejection arm removed
  -> read-failed: the saml editor stayed open after the read failed, ...
  -> read-failed: saml: no editor is open and the invitation is hidden, so the rail card is blank

hideEditor taken out of the OpenID arm      -> the first two refusals, without the third
hideSamlEditor taken out of the SAML arm    -> the same, for saml

the report suppressed
  -> read-failed: the oid read failed and the page said nothing, so the only report is in the
                  browser console

the report marked ok instead of failed
  -> read-failed: the oid read failure is not marked as one: "Could not read the stored ..."
  -> read-failed: the saml read failure is not marked as one: "Could not read the stored ..."
```

Six mutations, six red, the file restored after each and the gate re-run to `exit=0`.

**What that proof does NOT show, and it is worth being exact about.** Deleting one of the arm's own four refusals leaves the gate green, because with the real code in place nothing is wrong for it to catch. Each of those four is proven by one of the six mutations above rather than by its own deletion: the editor refusal by the arm removals, the silent-page refusal by the suppressed report, the colour refusal by the `ok` flip, and the unhandled-rejection refusal by the OpenID arm removal. That mapping is the proof; a deletion run over them alone would have said nothing.

### The sentence, and why it is a new row

`config.config_read_failed` already exists and says "Could not read the stored configuration, so nothing was changed." That is true on the open path and **false** on the other caller - the re-read a successful save makes, where something was changed. So one new row goes in both catalogues rather than a reuse that would have shipped a false sentence on one of two paths:

```
en  "Could not read the stored configuration, so this form was closed rather than left showing
     values that are not the stored ones. Reload the page and try again."
de  "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde dieses Formular
     geschlossen und nicht mit Werten stehen gelassen, die nicht die gespeicherten sind. Laden
     Sie die Seite neu und versuchen Sie es erneut."
```

## Notes

**Second reader.** There is none for this change, and the `Catalogue-Vouch` line above is not one. That line attests that the German row was read by somebody who reads German before it shipped, which is what #1494 built it for; it is not a second party's review of the diff, and nothing here was read by a second party. What stands in place of one is the mutation run above.

**What this changes for the second caller, stated rather than left to be found.** `loadProvider` and `loadSamlProvider` are each called from two places: the open path, and the re-read a successful save makes. A save that succeeds and whose re-read then fails now closes the editor and reports the read, rather than leaving the saved form open under its inline confirmation. The save stands - it had already returned - and the page's unsaved notice is cleared with the form, so a successful save is not left reading as unsaved. What is lost is the inline confirmation; what is gained is that the page never shows a form it could not verify against the store. A sharper sentence for that one path would be a second catalogue row and a branch the loaders cannot see, because neither knows which caller it is serving.

**What is NOT covered.** The arm drives the rejection through the shipped loaders, so it reaches everything after the read fails. It does not reach the route that got there: `openProvider` is not driven end to end, because its fill path wants the whole provider-form fixture, and the arm opens the editor through `showEditor` / `showSamlEditor` instead - the same two functions every open route goes through. Nothing here is a browser: no layout, no real focus, and no screen reader on the page-status region, whose announcement is the kind of question #1672 is open for.
