### PR TITLE
Refuse a help fold that is not its block's own child [#1684]

### DIFF
--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -253,13 +253,21 @@ function refresh(help) {
   // anything focused inside it; three of these bodies carry a link, and this function
   // runs again on every catalogue pass.
   //
-  // AND THE REFERENCE NODE IS ONLY USED WHERE IT IS A CHILD OF THIS BLOCK. Every page
-  // authors the fold as a direct child, but `details` comes out of a querySelector over
-  // the whole block, so a page that ever wrapped it would hand insertBefore a node that
-  // is not a sibling - which THROWS, out of a forEach, taking the rest of the
-  // condensing and the rail listener with it. A null reference appends instead, which
-  // puts the body after a fold that is hidden anyway: the wrong order in a state
-  // nobody can see, rather than a page that stops being condensed.
+  // AND THE REFERENCE NODE IS ONLY USED WHERE IT IS A CHILD OF THIS BLOCK. `details`
+  // comes out of a querySelector over the whole block, so a page that wrapped the fold
+  // would hand insertBefore a node that is not a sibling - which THROWS, out of a
+  // forEach, taking the rest of the condensing and the rail listener with it. A null
+  // reference appends instead, which puts the body after a fold that is hidden anyway:
+  // the wrong order in a state nobody can see, rather than a page that stops being
+  // condensed. That branch is driven: the arm is called "a fold the page wrapped still
+  // gets its one-sentence body onto the page" in tools/ui-condensed-help.js.
+  //
+  // AND THE SHAPE IS NOW REFUSED WHERE IT IS AUTHORED (#1684), so this branch is a floor
+  // rather than the rule - which is what it used to be, under a sentence saying every
+  // page happens to author the fold as a direct child and nothing checks it. The markup
+  // reader in the same gate walks each block's authored nesting and refuses a fold that
+  // is not its block's own child, naming the page and the key. What is left to this
+  // branch is markup that reached a browser without passing that gate.
   if (sentence === null) {
     if (body.parentNode !== help) {
       help.insertBefore(body, details.parentNode === help ? details : null);

--- a/tools/ui-condensed-help.js
+++ b/tools/ui-condensed-help.js
@@ -384,6 +384,36 @@ function elementBody(markup, from, tag) {
 }
 
 /*
+ * How many elements are still open at `at` inside `inner` - zero when whatever starts
+ * there is a direct child of the element `inner` is the body of.
+ *
+ * A SELF-CLOSING TAG IS DEPTH-NEUTRAL AND A VOID NAME IS NOT READ, which is the bound to
+ * know rather than a simplification. These pages write every void element with its slash -
+ * nineteen `<br />` on the Providers page and every `<input>` closed the same way - because
+ * Prettier formats this markup and the `prettier` gate runs on every change, so `<br>` with
+ * no slash cannot land. A name list instead would have to be right about every void element
+ * these pages use, and the direction it fails in is silent: an `<input>` counted as an
+ * element that opens makes every tag after it read as nested inside it, and this reader
+ * would then refuse honest markup. One was written here first and deleted, because the
+ * proof run showed every branch of it could go with the gate staying green - no block on
+ * any of the four pages authors a void element before its fold today, so nothing drove it.
+ * The arm below does drive the self-closing branch.
+ */
+function depthAt(inner, at) {
+  let depth = 0;
+  for (const m of inner.matchAll(/<(\/?)([a-z][a-z0-9]*)\b[^>]*?(\/?)>/g)) {
+    if (m.index >= at) {
+      break;
+    }
+    if (m[3] === "/") {
+      continue;
+    }
+    depth += m[1] === "/" ? -1 : 1;
+  }
+  return depth;
+}
+
+/*
  * Refuses the markup half, page by page: what a reader of a page whose script
  * never arrived is left with.
  */
@@ -487,9 +517,29 @@ function inspectMarkup(page, source) {
         `${key} on ${page} has no empty lead line for the first sentence to be written into`,
       );
     }
-    if (!/<details\b[^>]*class="sso-help-full"/.test(body)) {
+    const fold = /<details\b[^>]*class="sso-help-full"/.exec(body);
+    if (fold === null) {
       refusals.push(
         `${key} on ${page} has no fold to put the whole text behind`,
+      );
+    } else if (depthAt(body, fold.index) > 0) {
+      // THE FOLD IS A DIRECT CHILD OF ITS BLOCK, WHICH THE APPLIER RELIES ON AND NOTHING
+      // REFUSED UNTIL NOW (#1684). `refresh` in SSO-Auth/Web/i18n.js finds the fold with a
+      // querySelector over the WHOLE block, so it finds one at any depth, and then promotes
+      // a one-sentence body with `help.insertBefore(body, details)` - which needs the fold
+      // to be that element's own child. Every one of these blocks authors it that way and
+      // the applier carries a fallback for the other shape, so this is not a crash waiting
+      // to happen; it is a layout edit that silently changes where a help body ends up,
+      // after the fold rather than in front of it, and takes it out of the stylesheet rule
+      // that gives a promoted body the lead's spacing.
+      //
+      // READ FROM THE SAME WALK AS EVERY OTHER REFUSAL HERE, over the authored source with
+      // its comments stripped, because the runtime reader next door cannot see it at all:
+      // that one drives a tree `buildPage` builds, where the fold is a direct child by
+      // construction. Two green readers over a shape neither of them authors is the "green
+      // for the wrong reason" this file exists to refuse.
+      refusals.push(
+        `the fold of ${key} on ${page} is not a direct child of its block: the applier finds it at any depth and then appends the one-sentence body after it instead of in front of it, where the stylesheet gives it the fold's spacing rather than the lead's`,
       );
     }
     if (!new RegExp(`<summary data-i18n="${SUMMARY_KEY}">`).test(body)) {
@@ -1370,6 +1420,15 @@ function fixtureMarkup(key, parts) {
     `<${tag} class="fieldDescription${p.marked ? " sso-help" : ""}">`,
     p.comment ? `<!-- a note that mentions a closing </div> tag -->` : "",
     p.lead ? `<span class="sso-help-lead"></span>` : "",
+    // `selfClosed` puts the one kind of tag that must NOT move the depth count before the
+    // fold: a void element with its slash, which is how these pages author all of them.
+    // Without this arm the self-closing branch of `depthAt` is driven by nothing, because
+    // no block on any of the four pages carries such a tag before its fold today.
+    p.selfClosed ? `<br />` : "",
+    // `wrapped` puts the fold inside a layout element, which is the edit somebody makes
+    // while rearranging a form and the shape #1684 is about. It is a near-miss of one
+    // opening tag and one closing tag, and nothing else about the block moves.
+    p.wrapped ? `<div class="sso-help-layout">` : "",
     p.details ? `<details class="sso-help-full">` : "<div>",
     p.summary
       ? `<summary data-i18n="${SUMMARY_KEY}">Full text</summary>`
@@ -1380,6 +1439,7 @@ function fixtureMarkup(key, parts) {
         : `<div class="sso-help-body" data-i18n="${key}">whatever</div>`
       : `<div class="sso-help-body"><span data-i18n="${key}">whatever</span></div>`,
     p.details ? `</details>` : "</div>",
+    p.wrapped ? `</div>` : "",
     `</${tag}>`,
   ].join("\n");
 
@@ -1483,6 +1543,14 @@ async function calibrate(i18n) {
     ).refusals,
   );
   record(
+    "a block carrying a self-closed tag before its fold",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { selfClosed: true }),
+    ).refusals,
+  );
+  record(
     "two help blocks in two fields",
     false,
     inspectMarkup(
@@ -1497,6 +1565,7 @@ async function calibrate(i18n) {
       { flat: true, assembled: true },
     ],
     ["a fold authored inside a <p>", { tag: "p" }],
+    ["a fold wrapped in a layout element", { wrapped: true }],
     ["a help marker on a class neither reader enters", { stray: true }],
     ["a rail card with no heading", { heading: false }],
     ["a block the applier will not find", { marked: false }],


### PR DESCRIPTION
# What & why

`refresh()` in `SSO-Auth/Web/i18n.js` reads a help block's fold with `help.querySelector(".sso-help-full")`, which finds one at **any depth** under the block, and then promotes a one-sentence body with `help.insertBefore(body, details)` - which needs the fold to be that element's own child. Every one of the 131 condensed blocks authors it that way. Nothing said it had to.

The applier carries a fallback for the other shape and that fallback is driven, so this is not a crash waiting to happen. What it is, is **silent**: a layout edit that wraps the fold changes where a help body ends up - after the hidden fold instead of in front of it, and out of the `.sso-help > .sso-help-body` rule that gives a promoted body the lead's spacing rather than the fold's. Nothing says so, and the next reader of `refresh()` meets a branch whose reason is a page nobody can point at.

`inspectMarkup` in `tools/ui-condensed-help.js` already walks each block's authored source with a depth counter and already refuses four neighbouring authoring mistakes by name - a block written flat, one authored in a `<p>`, one missing its empty lead, one with no fold at all. The fold's depth inside its block is the same kind of fact, read from the same walk, and the refusal says what the applier does with the shape instead of merely naming it.

It is the right reader for this, and the one next door cannot see it at all: the runtime half drives a tree `buildPage` builds, where the fold is a direct child by construction. Two green readers over a shape neither of them authors is the "green for the wrong reason" that file exists to refuse.

Closes #1684

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, and stated rather than ticked. The diff is one refusal in a developer gate under `tools/` - not shipped, not compiled, not reachable from the plugin - plus a comment in `SSO-Auth/Web/i18n.js`. No behaviour changes: the applier is byte-identical apart from that comment. No login path, no SAML or OIDC validation, no config persistence, no release pipeline, no secret, no catalogue row. No security review was run and none is claimed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

The reader is one function, `depthAt`, twelve lines, and it reads the same whitespace-collapsed and comment-stripped source every other refusal in that file reads - so a comment mentioning a closing tag cannot move the count, which is already a named arm there.

Architecture-conformance adds no C# and establishes no structural property in that surface, so it locks in no new rule; it runs unchanged in the suite below. The new structural property this change establishes is in the JS gate, locked in by the calibration arm below rather than by a C# rule, which is where the other properties of this surface live.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   ->  0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   ->  0 warnings, 0 errors
SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    ->  Total: 3960, Failed: 0, Skipped: 4
SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   ->  Total: 3961, Failed: 0, Skipped: 4
npx prettier --check tools/ui-condensed-help.js SSO-Auth/Web/i18n.js
  ->  All matched files use Prettier code style!
```

The four skips are the loopback-bind tests that raise the Windows firewall consent dialog and need an administrator (#1227). They were skipped rather than worked around.

All eleven UI gates, each run at this head:

```
for f in tools/ui-*.js; do node "$f" >/dev/null 2>&1; echo "$f exit=$?"; done
  ->  all eleven exit=0
```

```
node tools/ui-condensed-help.js
calibration:       79 arms, 49 that must pass and 30 that must be refused, all as expected
providersPage.html  111 condensed help text(s), 100 with a fold that holds more, 11 whose text is one sentence, 35 assembled from parts and driven with their own children, 1 of them holding one sentence, 1 declared flat with a reason
the marked pages:   131 condensed help text(s) over 4 page(s), read in en and de
```

79 arms, up from 78: one negative and one positive. The real pages pass, which is the premise of #1684 measured rather than assumed - all 131 blocks author the fold as their block's own child today.

### The near-miss is one opening tag and one closing tag

The negative wraps the fold in a `<div class="sso-help-layout">` and changes nothing else about the block. That is the edit somebody makes while rearranging a form, which is the shape the refusal exists for; a negative several changes away would be caught by whichever arm noticed first.

### Every branch deleted, and the gate watched go red

```
the refusal itself
  -> CALIBRATION  a fold wrapped in a layout element: no refusal

the walk stopping at the fold
  -> CALIBRATION  a fold wrapped in a layout element: no refusal

a self-closed tag being depth-neutral
  -> CALIBRATION  a block carrying a self-closed tag before its fold: the fold of
                  config.fixture_0_help on fixture is not a direct child of its block: ...

a closing tag taking the depth back down (depth += 1 for both directions)
  -> CALIBRATION  authored markup passes: the fold of config.fixture_0_help on fixture is
                  not a direct child of its block: ...
  -> CALIBRATION  a comment mentioning a closing tag inside a block: ... the same
```

Four branches, four red, each named by its own arm, the file restored after each and the gate re-run to `exit=0`.

### A predicate written here first and deleted

A derived void-name predicate went in before the proof run: it read the tag names a page never closes, so that an `<input>` would not be counted as an element that opens and make every tag after it read as nested. The proof run showed **every branch of it could be removed with the gate staying green** - no block on any of the four pages carries a void element before its fold, so nothing drove it. An arm nothing drives cannot be told apart from one that does not work, so it went.

What is left is the self-closing branch, which IS driven by the new positive arm, and its bound is stated at the reader rather than assumed: these pages write every void element with its slash - nineteen `<br />` on the Providers page among them - because Prettier formats this markup and the `prettier` gate runs on every change, so `<br>` with no slash cannot land.

```
grep -o '<br[^>]*>' SSO-Auth/Web/providersPage.html | sort | uniq -c
     19 <br />
```

## Notes

**Second reader.** There is none for this change. What stands in its place is the mutation run above, which found the deleted predicate by removing it rather than by reading the reasoning for it. Nothing here was read by a second party.

**The third Done-when.** The comment in `refresh()` names the refusal now instead of saying that every page happens to author the fold as a direct child and nothing checks it, and it keeps the fallback as a floor rather than promoting it to the rule: what is left to that branch is markup that reached a browser without passing the gate.

**What is NOT covered.** The refusal reads the authored source of the four pages the condensing gate walks. A block authored on a page that is not marked for condensing is outside it, which is the same scope every other refusal in that reader has. And nothing here is a browser: that a wrapped fold actually renders the body after it rather than in front of it is what the applier's own fallback arm drives in the same file, on a stub - it is not a layout measurement.
