### PR TITLE
Drop a provider reply that no longer speaks for the open editor [#1693]

### DIFF
--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -720,6 +720,16 @@ const ssoConfigurationPage = {
   populateProviders: (page, providers) => {
     const select = page.querySelector("#selectProvider");
 
+    // WHICH PROVIDER THE PAGE IS ABOUT SURVIVES THE RE-POPULATE (#1693). The comment below
+    // calls this selector the state holder the save path reads, and a browser empties
+    // `value` the moment the selected `<option>` is removed - re-adding an option with the
+    // same value does not restore the selection. So a read of the configuration landing after
+    // a save silently took the page's own record of its subject away, and everything that
+    // compares against it - applyManagedState, and since #1693 both loaders - then compared
+    // against the empty string. Read before, restored after, with no branch: assigning a
+    // value no option carries leaves it empty, which is what it would have been anyway.
+    const chosen = select.value;
+
     // Clear providers in case there are out of date ones
     select.querySelectorAll("option").forEach((option) => option.remove());
 
@@ -729,6 +739,7 @@ const ssoConfigurationPage = {
     Object.keys(providers).forEach((provider_name) => {
       select.appendChild(new Option(provider_name, provider_name));
     });
+    select.value = chosen;
 
     ssoConfigurationPage.renderProviderCards(page, providers);
   },
@@ -2707,6 +2718,14 @@ const ssoConfigurationPage = {
   loadProvider: (page, provider_name) => {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
+        // A reply for a provider the editor has since left writes nothing (#1693). Dropped
+        // rather than queued, because it is stale by then: whatever the editor is about now
+        // was filled by its own read.
+        if (
+          !ssoConfigurationPage.replyStillSpeaksFor(page, "oid", provider_name)
+        ) {
+          return;
+        }
         const provider = config.OidConfigs[provider_name] || {};
 
         const form_elements = ssoConfigurationPage.listArgumentsByType(page);
@@ -2789,6 +2808,15 @@ const ssoConfigurationPage = {
       // a catch here would also fire for anything thrown by the fill above, and a fill that threw
       // halfway would then be reported as a server that could not be reached.
       () => {
+        // And a failure for a provider the editor has since left closes nothing and says
+        // nothing (#1693): the editor on screen was filled by its own read, and a sentence
+        // about the provider before it would explain the loss of a form the reader is working
+        // in by naming one they have already left.
+        if (
+          !ssoConfigurationPage.replyStillSpeaksFor(page, "oid", provider_name)
+        ) {
+          return;
+        }
         ssoConfigurationPage.hideEditor(page);
         ssoConfigurationPage.reportUnreadableProviderConfiguration(page);
         // The form is gone, so nothing in it is unsaved, and the notice that says otherwise would
@@ -3131,6 +3159,37 @@ const ssoConfigurationPage = {
   // THE PAGE REGION AND NOT THE EDITOR'S, for the reason deleteProvider states where it does the same
   // thing: the editor's status box lives inside the element that was just hidden, so an outcome written
   // there would be invisible.
+  /*
+   * Whether a reply about `provider_name` on `key` still speaks for what is on screen (#1693).
+   *
+   * A LOADER'S REPLY CAN BE ABOUT A PROVIDER NOBODY IS LOOKING AT ANY MORE, and a failing
+   * request is typically the slower of two, so this is the ordinary ordering rather than an
+   * exotic one: an administrator clicks a, its read stalls, they click b, b answers and fills
+   * the form, and then a's read settles. Before this, a's FAILURE closed b's editor and put a
+   * sentence about a on the page, and a's SUCCESS wrote a's values into b's form under b's
+   * title. The second is the worse of the two, because a Save then persists it.
+   *
+   * THE SUBJECT AND NOT A COUNTER. A serial bumped when a read is issued answers "has another
+   * read started", which is three of the four ways a reply goes stale and not the fourth: the
+   * editor being CLOSED, or the other protocol being opened, issues no read at all. What the
+   * editor is currently ABOUT answers all four at once - another provider opened, a blank New
+   * provider form opened, the editor closed, the protocol switched - and it is read from the
+   * same two places every other part of this page reads it from. `redirectUriSerial` twenty
+   * lines below is the counter shape, for a question where the subject cannot move: that field
+   * follows what is typed rather than which provider is loaded.
+   *
+   * applyManagedState compares the selector's value for the same reason, and this is that
+   * comparison with the open-editor half added.
+   */
+  replyStillSpeaksFor: (page, key, provider_name) => {
+    if (ssoConfigurationPage.openEditorKey(page) !== key) {
+      return false;
+    }
+    const selector = page.querySelector(
+      key === "saml" ? "#saml-selectProvider" : "#selectProvider",
+    );
+    return selector !== null && selector.value === provider_name;
+  },
   reportUnreadableProviderConfiguration: (page) => {
     ssoConfigurationPage.renderPageStatus(
       page,
@@ -4786,10 +4845,13 @@ const ssoConfigurationPage = {
   samlPropOf: (id) => id.slice("saml-".length),
   populateSamlProviders: (page, providers) => {
     const select = page.querySelector("#saml-selectProvider");
+    // The same preservation its OpenID twin does, for the same reason (#1693).
+    const chosen = select.value;
     select.querySelectorAll("option").forEach((option) => option.remove());
     Object.keys(providers).forEach((provider_name) => {
       select.appendChild(new Option(provider_name, provider_name));
     });
+    select.value = chosen;
     ssoConfigurationPage.renderSamlProviderCards(page, providers);
   },
   // SAML provider cards, same inert createElement/textContent construction as renderProviderCards (#221):
@@ -5038,6 +5100,12 @@ const ssoConfigurationPage = {
   loadSamlProvider: (page, provider_name) => {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
+        // The same drop the OpenID loader makes, for the same reason (#1693).
+        if (
+          !ssoConfigurationPage.replyStillSpeaksFor(page, "saml", provider_name)
+        ) {
+          return;
+        }
         const provider = (config.SamlConfigs || {})[provider_name] || {};
 
         const form_elements =
@@ -5121,6 +5189,11 @@ const ssoConfigurationPage = {
       // Both protocols reach this through one read of one configuration document, so a failure here is
       // never about one of them: whichever editor was being filled is closed and the page says why.
       () => {
+        if (
+          !ssoConfigurationPage.replyStillSpeaksFor(page, "saml", provider_name)
+        ) {
+          return;
+        }
         ssoConfigurationPage.hideSamlEditor(page);
         ssoConfigurationPage.reportUnreadableProviderConfiguration(page);
         ssoConfigurationPage.markPageClean(page);

--- a/tools/ui-readiness-rail.js
+++ b/tools/ui-readiness-rail.js
@@ -255,10 +255,11 @@ class Element {
  * on the page" and reports as an empty required field.
  */
 class Page {
-  constructor(elements, labels) {
+  constructor(elements, labels, byClass) {
     this.elements = elements;
     this.byId = new Map(elements.map((el) => [el.id, el]));
     this.labelFor = labels;
+    this.byClass = byClass;
     // The page is a class target too: markPageClean takes the dirty marker off it, and a
     // stub without this throws inside the rejection arm rather than judging it.
     this.classList = new Classes();
@@ -277,6 +278,18 @@ class Page {
     const label = /^label\[for="([^"]+)"\]$/.exec(selector);
     if (label) {
       return this.labelFor.get(label[1]) || null;
+    }
+    // A SINGLE CLASS, RESOLVED OUT OF THE MARKUP like every id here, because the fill path a
+    // resolved read reaches asks for one: fillProvisioningTemplate looks its permissions
+    // container up by class. Its BOUND is the one this whole stub has - a lookup is
+    // page-global rather than scoped to the element it was made on, so where a page carries
+    // the same class twice, once per protocol, the first in document order answers both. No
+    // arm asserts anything about that container; it is resolved so the fill runs instead of
+    // throwing inside a promise, which the unhandled-rejection count would then blame on the
+    // page.
+    const token = /^\.([a-z][a-z0-9-]*)$/.exec(selector);
+    if (token) {
+      return this.byClass.get(token[1]) || null;
     }
     throw new Error("the stub does not resolve the selector " + selector);
   }
@@ -597,7 +610,34 @@ function providersFixture() {
     }
   });
 
-  return new Page(elements, labels);
+  // One entry per class token, the FIRST element in document order that carries it. Read off
+  // each element's own opening tag rather than listed here, so a class that leaves the page
+  // leaves this map with it.
+  const byClass = new Map();
+  elements.forEach((el) => {
+    const at = html.indexOf('id="' + el.id + '"');
+    if (at === -1) {
+      return;
+    }
+    const tag = html.slice(
+      html.lastIndexOf("<", at),
+      html.indexOf(">", at) + 1,
+    );
+    const classes = /class="([^"]*)"/.exec(tag);
+    if (classes === null) {
+      return;
+    }
+    classes[1]
+      .split(/\s+/)
+      .filter(Boolean)
+      .forEach((name) => {
+        if (!byClass.has(name)) {
+          byClass.set(name, el);
+        }
+      });
+  });
+
+  return new Page(elements, labels, byClass);
 }
 
 // ---------------------------------------------------------------------------
@@ -744,7 +784,7 @@ function handRail(open, rowTexts) {
     item.textContent = text;
     list.appendChild(item);
   });
-  return new Page([invitation, list], new Map());
+  return new Page([invitation, list], new Map(), new Map());
 }
 
 const GOOD_ROWS = [
@@ -966,6 +1006,15 @@ function installHost(counter) {
           if (name === "getUrl") {
             return "https://jellyfin.example/" + String(args[0]);
           }
+          // A READ CAN BE PARKED AND SETTLED LATER, IN ANY ORDER (#1693). A reply's order
+          // relative to the clicks around it is the whole subject: a failing request is
+          // typically the slower of two, so the stale case is the ordinary ordering rather
+          // than an exotic one, and it cannot be reached by a client that answers at once.
+          if (counter.park !== null && name === "getPluginConfiguration") {
+            return new Promise((resolve, reject) =>
+              counter.park.push({ resolve, reject }),
+            );
+          }
           if (counter.refuseRead && name === "getPluginConfiguration") {
             return Promise.reject(new Error("the stub refused this read"));
           }
@@ -1043,7 +1092,7 @@ async function run() {
     return started;
   }
   const { arms, mustPass, faults, refuse } = started;
-  const counter = { calls: [], refuseRead: false };
+  const counter = { calls: [], refuseRead: false, park: null };
   // EVERY REJECTION NOBODY HANDLED IS RECORDED, which is a thing node tells you and a
   // browser does not tell an administrator. The arm below asks for it by name, because
   // "it surfaces in the console" is exactly the reporting #1681 is about the absence of.
@@ -1597,6 +1646,164 @@ async function run() {
     }
   }
 
+  // ---- Arm: a reply that no longer speaks for the open editor changes nothing ----
+  //
+  // THE ORDERING IS THE ORDINARY ONE. A failing request is typically the slower of two, so
+  // "the read that fails settles after the one that succeeded" is what a timeout looks like
+  // rather than a race somebody has to contrive. Before #1693 the late FAILURE closed the
+  // editor the administrator was working in and explained it by naming a provider they had
+  // already left; the late SUCCESS was worse, because it wrote the old provider's values into
+  // the open form under the new provider's title and a Save then persisted them.
+  //
+  // Both directions are driven, and so are the two ways the editor stops being about a
+  // provider without any read being issued: it is CLOSED, and the other protocol is opened.
+  // A serial counting reads answers neither of those, which is why the guard compares the
+  // editor's subject instead.
+  for (const protocol of ["oid", "saml"]) {
+    const selectorId =
+      protocol === "saml" ? "#saml-selectProvider" : "#selectProvider";
+    const open = protocol === "oid" ? core.showEditor : core.showSamlEditor;
+    const close = protocol === "oid" ? core.hideEditor : core.hideSamlEditor;
+    const other = protocol === "oid" ? core.showSamlEditor : core.showEditor;
+    const load = protocol === "oid" ? core.loadProvider : core.loadSamlProvider;
+    const nameField =
+      protocol === "saml" ? "#saml-provider-name" : "#OidProviderName";
+    const member = protocol === "saml" ? "SamlConfigs" : "OidConfigs";
+
+    /** Opens `which` the way openProvider does, and parks its read. */
+    const openAndPark = (page, which) => {
+      open(page);
+      page.querySelector(selectorId).value = which;
+      load(page, which);
+    };
+    const settled = () =>
+      new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+
+    // 1. a LATE FAILURE for the provider before the one on screen.
+    {
+      const page = providersFixture();
+      counter.park = [];
+      openAndPark(page, "a");
+      openAndPark(page, "b");
+      const [first, second] = counter.park;
+      second.resolve({ [member]: { b: {} } });
+      await settled();
+      first.reject(new Error("the read for a failed late"));
+      await settled();
+      counter.park = null;
+      if (page.querySelector("#" + EDITORS[protocol]).hidden) {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a late failure for the provider before this one closed the editor the administrator is working in",
+        );
+      }
+      if (page.querySelector("#sso-page-status").textContent !== "") {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a late failure for another provider put a sentence on the page about one the reader has left: " +
+            JSON.stringify(page.querySelector("#sso-page-status").textContent),
+        );
+      }
+    }
+
+    // 2. a LATE SUCCESS for the provider before the one on screen. The name field is what
+    //    the fill writes first, so it is what says whose values landed.
+    {
+      const page = providersFixture();
+      counter.park = [];
+      openAndPark(page, "a");
+      openAndPark(page, "b");
+      const [first, second] = counter.park;
+      second.resolve({ [member]: { b: {} } });
+      await settled();
+      first.resolve({ [member]: { a: {} } });
+      await settled();
+      counter.park = null;
+      const shown = page.querySelector(nameField).value;
+      if (shown !== "b") {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a late reply for another provider filled the open form - the name field reads " +
+            JSON.stringify(shown) +
+            " under an editor opened for b",
+        );
+      }
+    }
+
+    // 3. THE EDITOR CLOSED, which issues no read at all and is the case a serial cannot see.
+    {
+      const page = providersFixture();
+      counter.park = [];
+      openAndPark(page, "a");
+      close(page);
+      const [only] = counter.park;
+      only.reject(new Error("the read for a failed after its editor closed"));
+      await settled();
+      counter.park = null;
+      if (page.querySelector("#sso-page-status").textContent !== "") {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a failure for a provider whose editor was already closed still wrote a page status",
+        );
+      }
+      inspectRail(page, { open: null, rows: [] }).forEach((detail) =>
+        refuse("stale-reply", protocol + " (closed): " + detail),
+      );
+    }
+
+    // 4. THE OTHER PROTOCOL OPENED, the second case a serial cannot see: one workspace at a
+    //    time, so opening the other editor closes this one without any read being issued.
+    {
+      const page = providersFixture();
+      counter.park = [];
+      openAndPark(page, "a");
+      other(page);
+      const [only] = counter.park;
+      only.reject(new Error("the read failed after the other protocol opened"));
+      await settled();
+      counter.park = null;
+      const otherId = protocol === "oid" ? EDITORS.saml : EDITORS.oid;
+      if (page.querySelector("#" + otherId).hidden) {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a failure for the protocol that is no longer open closed the editor that is",
+        );
+      }
+      if (page.querySelector("#sso-page-status").textContent !== "") {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": a failure for the protocol that is no longer open wrote a page status under the other form",
+        );
+      }
+    }
+
+    // 5. AND THE REPLY THAT IS STILL CURRENT STILL LANDS. Without this the guard could be
+    //    "drop everything" and every arm above would pass.
+    {
+      const page = providersFixture();
+      counter.park = [];
+      openAndPark(page, "a");
+      const [only] = counter.park;
+      only.resolve({ [member]: { a: {} } });
+      await settled();
+      counter.park = null;
+      if (page.querySelector(nameField).value !== "a") {
+        refuse(
+          "stale-reply",
+          protocol +
+            ": the reply for the provider that IS open did not fill the form - the name field reads " +
+            JSON.stringify(page.querySelector(nameField).value),
+        );
+      }
+    }
+  }
+
   // ---- Arm: the configuration read fails while an editor is being filled ----
   //
   // THE RAIL IS WHY THIS IS HERE RATHER THAN IN A GATE OF ITS OWN (#1681). An editor is
@@ -1611,6 +1818,13 @@ async function run() {
     const open = protocol === "oid" ? core.showEditor : core.showSamlEditor;
     const load = protocol === "oid" ? core.loadProvider : core.loadSamlProvider;
     open(page);
+    // THE SELECTOR CARRIES WHICH PROVIDER THE EDITOR IS ABOUT, and openProvider sets it
+    // before it loads. This arm sets it too, because both loaders drop a reply that no
+    // longer speaks for what is on screen (#1693), and a fixture that left the selector
+    // blank would have every reply read as stale - a pass for the wrong reason.
+    page.querySelector(
+      protocol === "saml" ? "#saml-selectProvider" : "#selectProvider",
+    ).value = "a-saved-provider";
     if (rowsOf(page).length === 0) {
       refuse(
         "read-failed",
@@ -1734,6 +1948,12 @@ async function run() {
   );
   console.log(
     "                   initProvidersPage bound and rebuild the rail, on both protocols (#1687)",
+  );
+  console.log(
+    "  stale-reply      a reply that no longer speaks for the open editor writes nothing and closes",
+  );
+  console.log(
+    "                   nothing, in five orderings per protocol, and the current one still lands (#1693)",
   );
   console.log(
     "  read-failed      a configuration read that fails closes the editor, returns the rail to its",


### PR DESCRIPTION
# What & why

Both provider loaders in `SSO-Auth/Web/sso-core.js` read the configuration and fill the form from the reply, and since #1689 they close the editor and report the failure on the page when that read fails. Neither arm asked whether its reply was still the newest.

So a read that stalls and fails late spoke for whatever was on screen by then:

1. An administrator clicks provider **a**. Its read stalls.
2. They click provider **b**. Its read answers, the form fills, the rail is correct.
3. **a**'s read fails.
4. **b**'s editor is closed and the page says the stored configuration could not be read.

The editor they are working in disappears and the sentence explaining it is about a provider they have already left. A failing request is typically the slower of two, so that is the ordinary ordering rather than an exotic one.

The **success** direction is worse and is fixed here too: **a**'s reply landing after **b**'s wrote a's values into b's form, under b's title, where a Save would persist them.

**The subject, not a counter.** A serial bumped when a read is issued answers "has another read started", which is three of the four ways a reply goes stale and not the fourth - the editor being CLOSED, and the other protocol being opened, issue no read at all. `replyStillSpeaksFor` asks what the editor is currently ABOUT: the open protocol, and the protocol selector's value. That answers all four at once, and it is the comparison `applyManagedState` already makes with the open-editor half added. `redirectUriSerial` twenty lines below is the counter shape, for a question whose subject cannot move.

Closes #1693

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED __ / PLAUSIBLE __** counts as raised.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Two boxes are unticked because no such review was run, not because it passed. This is browser-side reading of the admin page: no login path, no SAML or OIDC validation, no server-side config persistence, no release pipeline, and it logs nothing. No lens read it and none is claimed.

The first box is ticked for the direction that matters here, and it is the reason the success arm is in scope rather than only the failure arm. A stale reply that RESOLVES puts one provider's stored values into the form of another under that other's title; the next Save merges the form onto the stored provider, so the values of b would be replaced by a's with no visible cause. Dropping it fails closed - the form keeps what its own read put there.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

One predicate, five lines, used by four arms that each add one early return. Architecture-conformance adds no C# and establishes no structural property in that surface, so it locks in no new rule; it runs unchanged in the suite below.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   ->  0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   ->  0 warnings, 0 errors
SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    ->  Total: 3960, Failed: 0, Skipped: 4
SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   ->  Total: 3961, Failed: 0, Skipped: 4
npx prettier --check SSO-Auth/Web/sso-core.js tools/ui-readiness-rail.js
  ->  All matched files use Prettier code style!
```

The four skips are the loopback-bind tests that raise the Windows firewall consent dialog and need an administrator (#1227). They were skipped rather than worked around.

All eleven UI gates, each run at this head:

```
for f in tools/ui-*.js; do node "$f" >/dev/null 2>&1; echo "$f exit=$?"; done
  ->  all eleven exit=0
```

### Five orderings per protocol, driven

`tools/ui-readiness-rail.js` gains a `stale-reply` arm whose `ApiClient` can **park** a configuration read and settle it later, in any order - the ordering relative to the clicks around it is the whole subject, and it cannot be reached by a client that answers at once.

```
  stale-reply      a reply that no longer speaks for the open editor writes nothing and closes
                   nothing, in five orderings per protocol, and the current one still lands (#1693)
```

1. a late **failure** for the provider before the one on screen - the editor stays open and the page says nothing
2. a late **success** for it - the name field still reads `b`, so a's values did not land in b's form
3. a failure after the editor was **closed** - no page status, and the rail is its invitation with an empty list
4. a failure after the **other protocol** was opened - the other editor stays open and nothing is written under it
5. the reply that IS current still fills the form - without this the guard could be "drop everything" and the four above would pass

### Every guard deleted, and the gate watched go red

Eight mutations, eight red, the file restored after each and the gate re-run to `exit=0`:

```
the guard on the OpenID fulfilled arm
  -> stale-reply: oid: a late reply for another provider filled the open form - the name
                  field reads "a" under an editor opened for b
the guard on the SAML fulfilled arm            -> the same, for saml
the guard on the OpenID rejected arm
  -> stale-reply: oid: a late failure for the provider before this one closed the editor the
                  administrator is working in
  -> stale-reply: oid: a late failure for another provider put a sentence on the page about
                  one the reader has left: "Could not read the stored configuration, ..."
the guard on the SAML rejected arm             -> the same, for saml
the open-editor half of the subject test removed
  -> stale-reply: oid: a failure for a provider whose editor was already closed still wrote a
                  page status
  -> stale-reply: oid: a failure for the protocol that is no longer open wrote a page status
                  under the other form
the selector half removed                      -> the late failure closes the editor again
the subject test forced true                   -> the same
the subject test forced false (drop everything)
  -> stale-reply: oid: the reply for the provider that IS open did not fill the form
```

Both directions of the predicate, which is what separates this from a guard that simply drops replies.

### The selector had to become reliable first

`populateProviders` and `populateSamlProviders` rebuild the hidden provider selector by removing every `<option>` and adding the set back, and **a browser empties `select.value` the moment the selected option is removed** - re-adding an option with the same value does not restore the selection. So a configuration read landing after a save silently took away the page's own record of its subject, which `applyManagedState` already compared against and which this guard now does too. The value is read before the clear and written back after, with no branch: assigning a value no option carries leaves it empty, which is what it would have been anyway.

**That preservation is proven by nothing, and it is the one thing here shipped on a reading of the DOM specification rather than on a measurement.** The gate's stub does not model what a browser does to a select's `value`, so it is green with the preservation and green without it. **#1696** carries what would read it: the stub modelling that behaviour for a select and for nothing else, an arm driving a save whose configuration read lands before its provider read, and `applyManagedState`'s comparison covered by the same fixture since it is the other reader of the same value and predates this change.

### Two smaller things the gate needed

- the `read-failed` arm now sets the protocol's selector, because `openProvider` does and a fixture that left it blank would read every reply as stale - a pass for the wrong reason
- the stub resolves a single-class selector out of the markup, because the fill path a resolved read reaches looks its permissions container up by class. Its bound is the one this stub already has: a lookup is page-global rather than scoped, so where a page carries the same class once per protocol the first in document order answers both. No arm asserts anything about that container; it is resolved so the fill runs instead of throwing inside a promise, which the unhandled-rejection count would then blame on the page.

## Notes

**Second reader.** There is none for this change. What stands in its place is the mutation run above. This issue itself came from a reading somebody else's session made of #1689 against #1691 and #1694, which is the closest thing to a second reader this work has had tonight - and it found a defect my own change introduced.

**What is NOT covered.** The preservation above, which is #1696. And the two remaining halves of the same family, both filed and neither touched here: #1694, a fulfilled read whose body is not the configuration document, which throws inside the fill and is reported by nothing; and #1691, the Save left open over a form whose fill did not complete, reachable only through #1694 today.
