### PR TITLE
Report a 200 that is not the configuration, and a fill that throws [#1694]

### DIFF
--- a/SSO-Auth/Localization/de.json
+++ b/SSO-Auth/Localization/de.json
@@ -216,6 +216,8 @@
   "config.provider_removed": "Anbieter entfernt.",
   "config.provider_remove_failed": "Der Anbieter konnte nicht entfernt werden: Der Server hat die gespeicherte Konfiguration abgelehnt, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.config_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde nichts geändert. Laden Sie die Seite neu und versuchen Sie es erneut.",
+  "config.provider_read_not_configuration": "Der Server hat geantwortet, aber das Gesendete ist nicht die Konfiguration dieses Plugins. Dieses Formular wurde daher geschlossen und nicht daraus gefüllt. Laden Sie die Seite neu und versuchen Sie es erneut; tritt es weiterhin auf, prüfen Sie, ob etwas vor Jellyfin an seiner Stelle antwortet.",
+  "config.provider_fill_failed": "Die gespeicherte Konfiguration wurde gelesen, aber dieses Formular konnte nicht daraus gefüllt werden. Es wurde daher geschlossen und nicht halb gefüllt stehen gelassen. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.provider_read_failed": "Die gespeicherte Konfiguration konnte nicht gelesen werden, daher wurde dieses Formular geschlossen und nicht mit Werten stehen gelassen, die nicht die gespeicherten sind. Laden Sie die Seite neu und versuchen Sie es erneut.",
   "config.validation_required": "{label} ist erforderlich.",
   "config.validation_endpoint_required": "Der OpenID-Endpunkt ist erforderlich.",

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -216,6 +216,8 @@
   "config.provider_removed": "Provider removed.",
   "config.provider_remove_failed": "Could not remove the provider: the server refused the saved configuration, so nothing was changed. Reload the page and try again.",
   "config.config_read_failed": "Could not read the stored configuration, so nothing was changed. Reload the page and try again.",
+  "config.provider_read_not_configuration": "The server answered, but what it sent is not this plugin's configuration, so this form was closed rather than filled from it. Reload the page and try again; if it keeps happening, check whether something in front of Jellyfin is answering for it.",
+  "config.provider_fill_failed": "The stored configuration was read, but this form could not be filled from it, so it was closed rather than left half filled. Reload the page and try again.",
   "config.provider_read_failed": "Could not read the stored configuration, so this form was closed rather than left showing values that are not the stored ones. Reload the page and try again.",
   "config.validation_required": "{label} is required.",
   "config.validation_endpoint_required": "OpenID Endpoint is required.",

--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -2716,7 +2716,9 @@ const ssoConfigurationPage = {
     return out;
   },
   loadProvider: (page, provider_name) => {
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+    const read = ApiClient.getPluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+    ).then(
       (config) => {
         // A reply for a provider the editor has since left writes nothing (#1693). Dropped
         // rather than queued, because it is stale by then: whatever the editor is about now
@@ -2724,6 +2726,14 @@ const ssoConfigurationPage = {
         if (
           !ssoConfigurationPage.replyStillSpeaksFor(page, "oid", provider_name)
         ) {
+          return;
+        }
+        // A 200 that is not the configuration is a state the page can reach, rather than a
+        // TypeError on the next line that nobody handles (#1694).
+        if (!ssoConfigurationPage.isProviderConfiguration(config, "oid")) {
+          ssoConfigurationPage.hideEditor(page);
+          ssoConfigurationPage.reportUnrecognisedProviderConfiguration(page);
+          ssoConfigurationPage.markPageClean(page);
           return;
         }
         const provider = config.OidConfigs[provider_name] || {};
@@ -2824,6 +2834,21 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.markPageClean(page);
       },
     );
+    // A THROW FROM THE FILL IS SETTLED HERE AND NOWHERE ELSE (#1694). This catch is on the
+    // promise the two arms above RETURN, so it sees what the fulfilled arm threw and never the
+    // original rejection - that one was handled by the second argument, which is the separation
+    // #1689 asked for and could not express. A fill that threw used to run off the end of the
+    // promise: the editor stayed open over blanks, the rail asserted "Still empty" about a
+    // configured provider, and the only trace was in the browser console.
+    //
+    // A SECOND STATEMENT RATHER THAN A THIRD LINK, so the arms above keep the depth they had.
+    // As a chain, Prettier breaks the call onto its own lines and re-indents two hundred
+    // untouched lines of fill with it, which buries the three lines that changed.
+    read.catch(() => {
+      ssoConfigurationPage.hideEditor(page);
+      ssoConfigurationPage.reportUnfillableProviderForm(page);
+      ssoConfigurationPage.markPageClean(page);
+    });
   },
   // Serial of the most recent redirect-URI request. A reply for an older provider name must never land in
   // the field after a newer one has already answered it, which per-keystroke requests otherwise allow.
@@ -3189,6 +3214,59 @@ const ssoConfigurationPage = {
       key === "saml" ? "#saml-selectProvider" : "#selectProvider",
     );
     return selector !== null && selector.value === provider_name;
+  },
+  /*
+   * Whether a body a 200 carried is this plugin's configuration at all (#1694).
+   *
+   * A FULFILLED READ IS NOT A READ THAT WORKED. A proxy's error page that happens to parse, a
+   * version-skewed endpoint, a truncated body: each arrives as a resolved promise, and the
+   * first line of the fill then reads a member of undefined. The OpenID loader threw a
+   * TypeError there and ran off the end of the promise, so the editor stayed open over the
+   * fields resetEditor blanked, the rail asserted "Still empty" about a provider that is saved
+   * and fully configured, and the only trace was in the browser console. The SAML loader read
+   * `(config.SamlConfigs || {})` and so presented a blank provider as successfully read, which
+   * is quieter and no better.
+   *
+   * THE MEMBER FOR THE PROTOCOL BEING READ, AND AN OBJECT. PluginConfiguration declares
+   * OidConfigs and SamlConfigs as dictionaries that are always serialized, so a body missing
+   * the one this loader needs is not the document whatever else it holds. Empty is fine and
+   * must stay fine - a server with no provider of that protocol is the commonest installation
+   * there is, and refusing it would close the editor on every one of them.
+   */
+  isProviderConfiguration: (config, key) => {
+    if (config === null || typeof config !== "object") {
+      return false;
+    }
+    const member = key === "saml" ? config.SamlConfigs : config.OidConfigs;
+    return member !== null && typeof member === "object";
+  },
+  // A body that arrived and is not the configuration (#1694). A SECOND SENTENCE RATHER THAN
+  // THE ONE ABOVE: the server answered, so "could not read the stored configuration" would
+  // describe the wrong failure to whoever has to act on it - the thing to look at is what is
+  // answering for Jellyfin, not whether Jellyfin is up.
+  reportUnrecognisedProviderConfiguration: (page) => {
+    ssoConfigurationPage.renderPageStatus(
+      page,
+      tr(
+        "config.provider_read_not_configuration",
+        "The server answered, but what it sent is not this plugin's configuration, so this form was closed rather than filled from it. Reload the page and try again; if it keeps happening, check whether something in front of Jellyfin is answering for it.",
+      ),
+      false,
+    );
+  },
+  // And a fill that threw part way (#1694). A third state, because the two above are both
+  // about the ANSWER and this one is about this page: the document was the document and
+  // something in it was not the shape this form expects, so the form is closed rather than
+  // left holding half of a provider.
+  reportUnfillableProviderForm: (page) => {
+    ssoConfigurationPage.renderPageStatus(
+      page,
+      tr(
+        "config.provider_fill_failed",
+        "The stored configuration was read, but this form could not be filled from it, so it was closed rather than left half filled. Reload the page and try again.",
+      ),
+      false,
+    );
   },
   reportUnreadableProviderConfiguration: (page) => {
     ssoConfigurationPage.renderPageStatus(
@@ -5098,12 +5176,22 @@ const ssoConfigurationPage = {
     };
   },
   loadSamlProvider: (page, provider_name) => {
-    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+    const read = ApiClient.getPluginConfiguration(
+      ssoConfigurationPage.pluginUniqueId,
+    ).then(
       (config) => {
         // The same drop the OpenID loader makes, for the same reason (#1693).
         if (
           !ssoConfigurationPage.replyStillSpeaksFor(page, "saml", provider_name)
         ) {
+          return;
+        }
+        // The same reading the OpenID loader makes (#1694). The `|| {}` below no longer
+        // stands in for it: a missing member used to present a blank provider as read.
+        if (!ssoConfigurationPage.isProviderConfiguration(config, "saml")) {
+          ssoConfigurationPage.hideSamlEditor(page);
+          ssoConfigurationPage.reportUnrecognisedProviderConfiguration(page);
+          ssoConfigurationPage.markPageClean(page);
           return;
         }
         const provider = (config.SamlConfigs || {})[provider_name] || {};
@@ -5199,6 +5287,12 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.markPageClean(page);
       },
     );
+    // The same catch its OpenID twin carries, for the same reason (#1694).
+    read.catch(() => {
+      ssoConfigurationPage.hideSamlEditor(page);
+      ssoConfigurationPage.reportUnfillableProviderForm(page);
+      ssoConfigurationPage.markPageClean(page);
+    });
   },
   // Canonical external base for the computed SAML URLs (mirrors the inline logic in computeRedirectUri,
   // #724): the Base URL Override when set, else this server's address, normalized the way the server's

--- a/tools/ui-readiness-rail.js
+++ b/tools/ui-readiness-rail.js
@@ -1015,6 +1015,16 @@ function installHost(counter) {
               counter.park.push({ resolve, reject }),
             );
           }
+          // A 200 CARRYING WHATEVER THE ARM CHOOSES (#1694). A read that fulfils is not a read
+          // that worked, and the bodies that matter here - a proxy's error page that parses, a
+          // version-skewed member - arrive as resolved promises. A client that could only
+          // reject or answer correctly could not reach either.
+          if (
+            counter.serve !== undefined &&
+            name === "getPluginConfiguration"
+          ) {
+            return Promise.resolve(counter.serve);
+          }
           if (counter.refuseRead && name === "getPluginConfiguration") {
             return Promise.reject(new Error("the stub refused this read"));
           }
@@ -1092,7 +1102,12 @@ async function run() {
     return started;
   }
   const { arms, mustPass, faults, refuse } = started;
-  const counter = { calls: [], refuseRead: false, park: null };
+  const counter = {
+    calls: [],
+    refuseRead: false,
+    park: null,
+    serve: undefined,
+  };
   // EVERY REJECTION NOBODY HANDLED IS RECORDED, which is a thing node tells you and a
   // browser does not tell an administrator. The arm below asks for it by name, because
   // "it surfaces in the console" is exactly the reporting #1681 is about the absence of.
@@ -1804,6 +1819,136 @@ async function run() {
     }
   }
 
+  // ---- Arm: a 200 that is not the configuration, and a fill that throws ----
+  //
+  // A FULFILLED READ IS NOT A READ THAT WORKED (#1694). Each of the bodies below arrives as a
+  // resolved promise, and before this each left the editor open over the fields resetEditor
+  // blanked, the rail asserting "Still empty" about a provider that is saved and fully
+  // configured, and the only trace in the browser console. The three states are kept apart
+  // because the act they ask for differs: a server that could not be reached, a server that
+  // answered with something else, and a document this form could not be filled from.
+  for (const protocol of ["oid", "saml"]) {
+    const member = protocol === "saml" ? "SamlConfigs" : "OidConfigs";
+    const selectorId =
+      protocol === "saml" ? "#saml-selectProvider" : "#selectProvider";
+    const open = protocol === "oid" ? core.showEditor : core.showSamlEditor;
+    const load = protocol === "oid" ? core.loadProvider : core.loadSamlProvider;
+    const settled = () =>
+      new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+
+    const drive = async (body) => {
+      const page = providersFixture();
+      open(page);
+      page.querySelector(selectorId).value = "a-saved-provider";
+      counter.serve = body;
+      load(page, "a-saved-provider");
+      await settled();
+      counter.serve = undefined;
+      return page;
+    };
+    const closedAndSaid = async (what, body, fragment) => {
+      const page = await drive(body);
+      if (!page.querySelector("#" + EDITORS[protocol]).hidden) {
+        refuse(
+          "not-the-configuration",
+          protocol +
+            ": " +
+            what +
+            " left the editor open over the blanks resetEditor wrote, one Save away from replacing a configured provider with them",
+        );
+      }
+      inspectRail(page, { open: null, rows: [] }).forEach((detail) =>
+        refuse(
+          "not-the-configuration",
+          protocol + " (" + what + "): " + detail,
+        ),
+      );
+      const status = page.querySelector("#sso-page-status").textContent;
+      if (!status.includes(fragment)) {
+        refuse(
+          "not-the-configuration",
+          protocol +
+            ": " +
+            what +
+            " should be reported in its own words and the page says " +
+            JSON.stringify(status),
+        );
+      }
+      if (
+        !page
+          .querySelector("#sso-page-status")
+          .classList.contains("sso-status-fail")
+      ) {
+        refuse(
+          "not-the-configuration",
+          protocol + ": " + what + " is not marked as a failure",
+        );
+      }
+    };
+
+    // A proxy's error page that happens to parse: an object with none of the members.
+    await closedAndSaid(
+      "a body carrying none of the configuration's members",
+      { error: "Bad Gateway" },
+      "is not this plugin's configuration",
+    );
+    // The member present and not an object, which is the version-skew shape: the OpenID
+    // loader threw a TypeError on it and the SAML loader presented a blank provider as read.
+    await closedAndSaid(
+      "a body whose " + member + " is not a dictionary",
+      { [member]: "unexpected" },
+      "is not this plugin's configuration",
+    );
+    // A body of null, which `typeof` calls an object and which every member lookup throws on.
+    await closedAndSaid(
+      "a body of null",
+      null,
+      "is not this plugin's configuration",
+    );
+
+    // A WHOLE DOCUMENT, because the fill reads all three members and a body short of one
+    // throws in the fill rather than failing the shape test - which the arm below would then
+    // report as a server with nothing configured having its editor closed. Found by writing
+    // the short version first and reading the refusal.
+    const document = (providers) => ({
+      OidConfigs: {},
+      SamlConfigs: {},
+      ProvisioningProfiles: {},
+      [member]: providers,
+    });
+
+    // AND A DOCUMENT THAT IS THE DOCUMENT, whose provider holds a member of the wrong type, so
+    // the FILL throws part way rather than the shape test catching it first. A different
+    // sentence, because the read worked and this page is what could not use it.
+    await closedAndSaid(
+      "a provider whose role mapping is not a list",
+      document({ "a-saved-provider": { FolderRoleMapping: 5 } }),
+      "could not be filled from it",
+    );
+
+    // THE OTHER DIRECTION, which is what stops all of the above passing on a loader that
+    // closes the editor for every reply: an EMPTY configuration is the commonest installation
+    // there is, and it must fill the form and leave the rail answering.
+    {
+      const page = await drive(document({}));
+      if (page.querySelector("#" + EDITORS[protocol]).hidden) {
+        refuse(
+          "not-the-configuration",
+          protocol +
+            ": a server with no provider of this protocol had its editor closed, which is every fresh installation",
+        );
+      }
+      if (page.querySelector("#sso-page-status").textContent !== "") {
+        refuse(
+          "not-the-configuration",
+          protocol +
+            ": a server with nothing configured was reported as a failure: " +
+            JSON.stringify(page.querySelector("#sso-page-status").textContent),
+        );
+      }
+    }
+  }
+
   // ---- Arm: the configuration read fails while an editor is being filled ----
   //
   // THE RAIL IS WHY THIS IS HERE RATHER THAN IN A GATE OF ITS OWN (#1681). An editor is
@@ -1954,6 +2099,12 @@ async function run() {
   );
   console.log(
     "                   nothing, in five orderings per protocol, and the current one still lands (#1693)",
+  );
+  console.log(
+    "  not-the-configuration  a 200 whose body is not the configuration, and a fill that throws,",
+  );
+  console.log(
+    "                   each close the editor and say so in their own words; an empty one fills (#1694)",
   );
   console.log(
     "  read-failed      a configuration read that fails closes the editor, returns the rail to its",


### PR DESCRIPTION
# What & why

Both provider loaders in `SSO-Auth/Web/sso-core.js` attach their failure arm as the SECOND argument to `then` rather than as a `catch`, and #1689 gave the reason: a `catch` would also fire for anything thrown by the fill, so a fill that threw halfway would be reported as a server that could not be reached. **The cost of that choice was that neither case was reported at all.**

**A fulfilled read is not a read that worked.** A proxy's error page that happens to parse, a version-skewed endpoint, a truncated body: each arrives as a resolved promise, and the OpenID loader's first line

```js
const provider = config.OidConfigs[provider_name] || {};
```

then read a member of undefined and threw a `TypeError` off the end of the promise. The SAML loader read `(config.SamlConfigs || {})` and so presented a blank provider as successfully read, which is quieter and no better. Either way the editor stayed open over the fields `resetEditor` blanked, the rail asserted `Still empty` about a provider that is saved and fully configured, and the only trace was in the browser console.

**Three states, three sentences**, because the act each asks for differs: a server that could not be reached (#1689), a server that answered with something else, and a document this form could not be filled from. Collapsing the second into the first would tell an administrator to check whether Jellyfin is up when what is answering *for* it is the thing to look at.

Closes #1694

Catalogue-Vouch: de read by iderex

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED __ / PLAUSIBLE __** counts as raised.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Two boxes are unticked because no such review was run, not because it passed. This is browser-side reading of the admin page: no login path, no SAML or OIDC validation, no server-side config persistence, no release pipeline, and it logs nothing. No lens read it and none is claimed.

The first box is ticked for the direction that applies, and it is what this change is for. Every branch added here **fails closed**: a read this page cannot use removes the form rather than leaving an editable, savable one over a provider whose stored values nobody read. That is the hazard #1691 is filed for, and this is the path it is reachable through. Nothing new reaches the DOM as markup - `renderPageStatus` writes `textContent`, and the two sentences are catalogue rows with no interpolation.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

One predicate and two reporters, each used by both loaders. Architecture-conformance adds no C# and establishes no structural property in that surface, so it locks in no new rule; it runs unchanged in the suite below.

**sso-core.js changes in 96 added lines and 2 removed** rather than in a two-hundred-line re-indent (`git diff --stat origin/5.0...HEAD -- SSO-Auth/Web/sso-core.js`), and that took a decision worth stating: the new `catch` is a second STATEMENT on a named promise rather than a third link in the chain. As a chain, Prettier breaks the call onto its own lines and re-indents every untouched line of fill inside it, which buries the three that changed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   ->  0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   ->  0 warnings, 0 errors
SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    ->  Total: 3960, Failed: 0, Skipped: 4
SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   ->  Total: 3961, Failed: 0, Skipped: 4
npx prettier --check SSO-Auth/Web/sso-core.js tools/ui-readiness-rail.js \
  SSO-Auth/Localization/en.json SSO-Auth/Localization/de.json
  ->  All matched files use Prettier code style!
```

The four skips are the loopback-bind tests that raise the Windows firewall consent dialog and need an administrator (#1227). They were skipped rather than worked around.

All eleven UI gates, each run at this head:

```
for f in tools/ui-*.js; do node "$f" >/dev/null 2>&1; echo "$f exit=$?"; done
  ->  all eleven exit=0
```

### What the shape test asks, and what it deliberately does not

`isProviderConfiguration` asks for the member of the protocol being read, and asks that it is an object. `PluginConfiguration` declares both as dictionaries that are always serialized:

```
SSO-Auth/Config/PluginConfiguration.cs:43  public SerializableDictionary<string, SamlConfig> SamlConfigs { get; set; }
SSO-Auth/Config/PluginConfiguration.cs:49  public SerializableDictionary<string, OidConfig> OidConfigs { get; set; }
```

so a body missing the one this loader needs is not the document whatever else it holds. **Empty stays fine**, because a server with no provider of that protocol is the commonest installation there is and refusing it would close the editor on every one of them. That direction has its own arm, and narrowing the test to a non-empty dictionary reddens it.

### Five bodies per protocol, driven

`tools/ui-readiness-rail.js` gains a `not-the-configuration` arm against a client that can serve a 200 carrying whatever the arm chooses:

```
  not-the-configuration  a 200 whose body is not the configuration, and a fill that throws,
                   each close the editor and say so in their own words; an empty one fills (#1694)
```

- a body with **none** of the members - a proxy's error page that parses
- a body whose member **is not a dictionary** - the version-skew shape
- a body of **null** - what `typeof` calls an object and what every member lookup throws on
- a document whose provider carries a **role mapping that is not a list**, so the FILL throws part way rather than the shape test catching it first, and the page says the form could not be filled from it
- an **empty document** - the editor stays open and nothing is reported

Each of the first four also asserts that the rail is back to its invitation with an empty list, and that the page status carries the failure class.

### Every guard deleted, and the gate watched go red

Eight mutations, eight red, the file restored after each and the gate re-run to `exit=0`:

```
the shape guard in the OpenID loader            RED
the shape guard in the SAML loader              RED
the member test forced true                     RED
the null test removed                           RED
the member test narrowed to a non-empty dictionary   RED
the OpenID catch emptied                        RED
the SAML catch emptied                          RED
the two sentences collapsed into one            RED
```

The last two matter most for what this issue is about: an emptied catch restores exactly the silence #1694 describes, and collapsing the sentences restores exactly the wrong instruction #1689's reasoning was protecting against.

### Two defects in my own first draft, both found by running it

- the arm's client used `null` as its "serve nothing" switch, so the arm meant to serve a body of **null** fell through to the ordinary path and passed for the wrong reason. The switch is `undefined` now, and the reason is written at the line.
- three of the arm's bodies were short of the members they do not name. A document short of a member makes the FILL throw rather than the shape test catch it, so "a server with nothing configured" was being reported as a failure by my own fixture. The arm builds whole documents now.

## Notes

**Second reader.** There is none for this change. The issue itself came from another session reading the two answers to #1681 against each other, which is the nearest thing to one this work has had; what stands in its place here is the mutation run above.

**The `Catalogue-Vouch` line is not a second reader.** It attests that the two German rows were read by somebody who reads German before they shipped, which is what #1494 built it for. It is not a review of this diff.

**What is NOT covered.** #1691 is the last of this family and is reachable only through what this change closes: the Save left open over a form whose fill did not complete. Its own body says it should be closed naming the change that removes its route rather than built twice - and that is what this is, so it is worth re-reading against this head rather than taken as still open. I have not closed it here, because deciding that is a reading of #1691's own Done-when against the tree and the editor now being closed on a fill throw is necessary but perhaps not sufficient for it.
