### PR TITLE
Keep the computed address out of the unsaved-changes baseline

### DIFF
--- a/SSO-Auth/Web/sso-core.js
+++ b/SSO-Auth/Web/sso-core.js
@@ -1265,6 +1265,25 @@ const ssoConfigurationPage = {
     [...page.querySelectorAll("input, select, textarea")].filter(
       (element) =>
         element.type !== "file" &&
+        // A READ-ONLY CONTROL IS NOT ONE AN ADMINISTRATOR EDITS, which is what this function is
+        // named for, and leaving the three this surface has in it cost the notice that says work is
+        // about to be lost (#1701). All three are computed addresses no save reads: the OpenID
+        // redirect URI the SERVER answers with, and the two SAML URLs. The first is the one that
+        // bit. `loadProvider` empties it, schedules the request behind a debounce, and calls
+        // `markPageClean` twenty lines later - so the baseline is taken with the field EMPTY and the
+        // reply writes into it a quarter of a second afterwards, with no second baseline. From the
+        // first load onwards `pageDiffersFromBaseline` therefore answered true on a page nobody had
+        // typed into: the tab asserted an edit that did not exist, and `refreshOnShow` took its
+        // edit-protecting arm every time, so it stopped re-reading for the life of the view.
+        //
+        // EXCLUDED HERE RATHER THAN BY RE-TAKING THE BASELINE, because the other repair swallows
+        // real work: a keystroke made while the address was in flight falls inside the window a
+        // blind re-take covers, and would afterwards read as part of what the server put there.
+        // This direction cannot lose an edit, because the fields it drops are ones no edit reaches.
+        //
+        // DERIVED FROM THE CONTROL rather than from a list of three ids, so a computed field added
+        // tomorrow is covered by being read-only, which is the property that makes it one.
+        element.readOnly !== true &&
         ssoConfigurationPage.navigationControlIds.indexOf(element.id) === -1,
     ),
   // What the tracked controls hold right now, as one comparable string. A checkbox is read from

--- a/tools/ui-unsaved-state.js
+++ b/tools/ui-unsaved-state.js
@@ -184,7 +184,19 @@ function pageFixture(file, regionIds) {
   const html = withoutComments(fs.readFileSync(file, "utf8"));
   const controls = [
     ...html.matchAll(/<(input|select|textarea)\b[\s\S]*?>/g),
-  ].map((m) => new Element(m[1], attr(m[0], "id"), attr(m[0], "type") || m[1]));
+  ].map((m) => {
+    const control = new Element(
+      m[1],
+      attr(m[0], "id"),
+      attr(m[0], "type") || m[1],
+    );
+    // READ OFF THE TAG, because whether a control is read-only is a fact the state now reads
+    // (#1701): the three computed addresses on the Providers page leave the baseline by it. A
+    // fixture that invented the flag would prove this stub rather than the page, and one that
+    // ignored it would report the whole repair as working on markup that had dropped it.
+    control.readOnly = m[0].split(/[\s>]+/).includes("readonly");
+    return control;
+  });
   if (controls.length === 0) {
     throw new Error(
       path.basename(file) +
@@ -1095,6 +1107,79 @@ async function main() {
     core.managedReportUnread = originalUnread;
   }
 
+  // ---- A computed address is not an edit (#1701) ----
+  //
+  // THE SHAPE IS A REPLY THAT LANDS AFTER THE BASELINE, and it is the ordinary path rather than a race
+  // somebody has to arrange: `loadProvider` empties `#OidRedirectUri`, schedules the request behind a
+  // 250 ms debounce, and calls `markPageClean` twenty lines later. So the baseline holds that field
+  // empty and the server's answer arrives into it afterwards, with no second baseline taken. While the
+  // field was in the tracked set, every OpenID provider ever loaded left the page reporting an edit
+  // nobody had made - and `refreshOnShow` then took its edit-protecting arm on every return, so the tab
+  // also stopped re-reading.
+  //
+  // DRIVEN THROUGH THE SHIPPED FUNCTIONS on the shipped markup: the flag is read off the page's own
+  // tag, so a `readonly` that leaves the markup takes this arm's premise with it and the arm says so
+  // rather than passing.
+  {
+    const page = providersPageFixture();
+    const uri = page.querySelector("#OidRedirectUri");
+    if (uri === null) {
+      refuse(
+        "computed-address",
+        "the Providers page declares no #OidRedirectUri, so this arm judges nothing",
+      );
+    } else {
+      if (uri.readOnly !== true) {
+        refuse(
+          "computed-address",
+          "#OidRedirectUri is not read-only in the markup, so the page now offers an address the server computes as something to type into",
+        );
+      }
+      wire(core, page);
+
+      // The reply, landing after the baseline exactly as the load leaves it.
+      uri.value = "https://jellyfin.example/sso/OID/redirect/example";
+      page.dispatch("input", uri, true);
+
+      if (core.isPageDirty(page)) {
+        refuse(
+          "computed-address",
+          "the address the server answered with was counted as something an administrator typed",
+        );
+      }
+      if (core.pageDiffersFromBaseline(page)) {
+        refuse(
+          "computed-address",
+          "a page holding nothing but the address the server computed reads as holding an edit, so the tab asserts one and stops re-reading",
+        );
+      }
+      if (!core.mayReplacePageContents(page)) {
+        refuse(
+          "computed-address",
+          "a tab that has only received its computed address refuses to be re-read",
+        );
+      }
+
+      // THE NEAR MISS, and it is the half that keeps the repair from being a deletion: a real edit made
+      // in the same window is still an edit. One character into a field beside the address.
+      const endpoint = page.querySelector("#OidEndpoint");
+      endpoint.value = "https://idp.example/";
+      page.dispatch("input", endpoint, true);
+      if (!core.isPageDirty(page)) {
+        refuse(
+          "computed-address",
+          "a field an administrator typed into beside the computed address did not mark the page dirty",
+        );
+      }
+      if (!core.pageDiffersFromBaseline(page)) {
+        refuse(
+          "computed-address",
+          "a real edit went invisible to the baseline, which is the repair overshooting into the loss it exists to prevent",
+        );
+      }
+    }
+  }
+
   if (faults.length) {
     faults.forEach((fault) => console.error(fault));
     console.error(
@@ -1159,6 +1244,9 @@ async function main() {
   );
   console.log(
     "  managed-report-failure a failed managed-set read keeps the last set it read and says it failed",
+  );
+  console.log(
+    "  computed-address the address the server answers with is not an edit, and a real one beside it still is",
   );
 }
 


### PR DESCRIPTION
# What & why

A control nobody can type into is not an editable control, which is what
`editableControls` is named for. Three on this surface were in it anyway: the
OpenID redirect URI the server answers with, and the two SAML URLs. All three
are read-only computed addresses, and no save reads any of them. Closes #1701.

The first is the one that bit. `loadProvider` empties `#OidRedirectUri`,
schedules the request behind a 250 ms debounce, and calls `markPageClean`
twenty lines later — so the baseline is taken with the field EMPTY and the
server's answer lands in it a quarter of a second afterwards, with no second
baseline:

```
$ git show origin/5.0:SSO-Auth/Web/sso-core.js | sed -n '2794p;2814p'
        ssoConfigurationPage.updateRedirectUri(page);
        ssoConfigurationPage.markPageClean(page);
$ git show origin/5.0:SSO-Auth/Web/sso-core.js | sed -n '2881p;2901p'
    field.value = "";
    ssoConfigurationPage.redirectUriTimer = setTimeout(() => {
```

From the first OpenID provider ever loaded onwards, `pageDiffersFromBaseline`
therefore answered true on a page nobody had typed into. Two things followed,
and both read as the page being wrong about the administrator rather than about
itself: returning to the Providers tab took the edit-protecting arm of
`refreshOnShow` every time, so the page asserted "Unsaved changes in this
editor … or they are lost" over an edit that did not exist — and an
administrator who learns not to believe that line has been taught to ignore the
one notice that says work is about to be lost. That arm returns before the
read, so the tab also stopped re-reading for the life of the view, which is the
refresh #1576 built.

**Why this repair and not the other one.** Re-taking the baseline when a
computed field is written swallows real work: a keystroke made while the
address was in flight falls inside the window a blind re-take covers, and would
afterwards read as part of what the server put there. This direction cannot
lose an edit, because the fields it drops are ones no edit reaches. It is
derived from the control rather than from a list of three ids, so a computed
field added tomorrow is covered by being read-only, which is the property that
makes it one — and today that set is exactly three, all on one page:

```
$ for f in providersPage configPage accountsPage policiesPage serverPage; do
    echo -n "$f: "; git show origin/5.0:SSO-Auth/Web/$f.html | grep -c '^\s*readonly\s*$'; done
providersPage: 3
configPage: 0
accountsPage: 0
policiesPage: 0
serverPage: 0
```

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Nothing here touches SAML or OIDC validation. The
      direction this change moves the unsaved-state in is the safe one: it stops
      the page claiming an edit that does not exist, and the arm's near-miss
      holds that a real edit is still seen.
- [x] No secrets logged; secrets are redacted on config export. No log call and
      no export path is touched.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. None of those is touched;
      this is the unsaved-changes state of the configuration pages, and its
      proof is the running gate below.
- [x] Review record: this defect IS a review finding. It was raised by the
      availability lens of the #1665 review gate, which drove the shipped module
      rather than reading it, and re-derived here from the mainline before the
      repair was written. **CONFIRMED 1 / PLAUSIBLE 0**, disposition FIX.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is added.

## Quality checklist

- [x] No duplicated logic; the change is one condition in the function that
      already answers this question.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comment says which failure it prevents
      and why the other repair was refused.
- [x] Architecture-conformance tests pass. The new property — a read-only
      control is outside the unsaved-changes baseline — is locked in by an arm
      in `tools/ui-unsaved-state.js` rather than by a C# rule, because it is a
      behaviour and no reading of the bytes makes it.
- [x] Docs impact considered: none. Nothing operator-visible is added; what
      changes is that a notice stops appearing when it was never true.

## Verification

- [x] `dotnet build --warnaserror` green on BOTH target frameworks, 0 warnings.
- [x] `dotnet test` green: 3960 passed on net9.0, 3961 on net10.0, 0 failed,
      4 skipped (the firewall-consent tests of #1227).
- [x] Prettier clean for both files this change touches.
- [x] Every UI gate exits 0.
- [x] Three mutations driven against the new arm, all three refused:

```
caught  the read-only exclusion is taken out again (the defect restored)
        -> computed-address: the address the server answered with was counted as something an administrator typed
caught  the exclusion is inverted, so only read-only controls are tracked
        -> TypeError: Cannot read properties of undefined (reading 'id')
caught  the fixture stops reading readonly off the tag, so every control looks editable
        -> computed-address: #OidRedirectUri is not read-only in the markup ...
3 of 3 run mutations caught
```

The middle one is refused by a crash rather than by name, and that is stated
rather than dressed up: inverting the filter leaves the tracking reading a set
that does not describe the page, and the run ends non-zero without the arm
getting to say why.

## Notes

Found while the #1665 review gate was reading that branch, and deliberately not
landed inside it: this is on the mainline, reachable without opening the wizard,
and it is a different topic.

The arm reads the read-only flag off the page's own tag rather than declaring
it, so markup that drops the attribute takes the arm's premise with it and the
arm refuses instead of passing.
