### PR TITLE
Name every help fold after its field and speak the redirect URI's whole text [#1672]

### DIFF
--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -275,6 +275,121 @@ function refresh(help) {
   } else if (body.parentNode !== details) {
     details.appendChild(body);
   }
+
+  nameFold(help, details);
+  speak(help, body);
+}
+
+/*
+ * Names the fold after the field it belongs to (#1672).
+ *
+ * WHAT A SCREEN READER IS HANDED WAS MEASURED RATHER THAN REASONED, on 2026-09-12 in Chromium 152's
+ * accessibility tree over the shipped Providers page with this applier run on it: every one of the
+ * page's 111 folds is a disclosure triangle named "Full text", so a list of the page's controls reads
+ * as 111 identical rows and none of them says which field it opens. The name is computed from the
+ * summary's own text, which is one catalogue row shared by every fold on purpose.
+ *
+ * SO THE FIELD'S LABEL IS PUT IN FRONT OF THAT WORD, BY REFERENCE AND NOT BY COPY. `aria-labelledby`
+ * names the label and then the summary itself, so the computed name is the label's text followed by
+ * the catalogue word - "Redirect URI (register this at your provider): Full text" - and it follows
+ * both texts through every later catalogue pass with no second string anybody has to keep in step.
+ * The two ids the reference needs are written here where they are missing, derived from the control
+ * the label is for, so no page authors them.
+ *
+ * ONLY WHERE THE PAGE DRAWS A CONTAINER AROUND ONE CONTROL. `fieldOf` falls back to the block's own
+ * parent for the blocks that sit in no `inputContainer` or `checkboxContainer` - the empty states, the
+ * danger zone, the test block - and the first label under such a parent belongs to some other field.
+ * A fold named after a field it does not open is worse than one named "Full text", so those keep the
+ * bare word, and how many there are is a number the gate prints rather than one this comment promises.
+ */
+function nameFold(help, details) {
+  const summary = details.querySelector("summary");
+  const field = fieldOf(help);
+  const label =
+    field &&
+    (hasClass(field, "inputContainer") || hasClass(field, "checkboxContainer"))
+      ? labelBefore(field, help)
+      : null;
+  if (!summary || !label) {
+    return;
+  }
+
+  // A label FOR its control, or one WRAPPED AROUND it, which is how the checkbox rows are authored.
+  const wrapped = label.querySelector("input");
+  const control =
+    label.getAttribute("for") || (wrapped && wrapped.getAttribute("id"));
+  if (!control) {
+    return;
+  }
+  if (!label.hasAttribute("id")) {
+    label.setAttribute("id", control + "-label");
+  }
+  if (!summary.hasAttribute("id")) {
+    summary.setAttribute("id", control + "-full-text");
+  }
+  summary.setAttribute(
+    "aria-labelledby",
+    label.getAttribute("id") + " " + summary.getAttribute("id"),
+  );
+}
+
+/*
+ * The label that names the block's field: the last one before the block in document order that
+ * carries text.
+ *
+ * THE LAST, because one container on the SAML form holds two labelled controls and one help block
+ * under the second, and the first label would name that fold after the field above it (review of
+ * 2026-09-12). WITH TEXT, because jellyfin-web's `emby-input`, `emby-textarea` and `emby-select`
+ * insert an EMPTY label of their own directly in front of every control they upgrade; that one
+ * stands closer to the block than the authored label on every field, and taking it would name
+ * every fold by the bare word again. Neither shape is visible to the gate's markup reader, which
+ * is why both are driven as arms in tools/ui-condensed-help.js rather than only stated here.
+ */
+function labelBefore(field, help) {
+  const labels = new Set(all(field, "label"));
+  let found = null;
+  const walk = (el) => {
+    for (const child of el.children) {
+      if (child === help) {
+        return true;
+      }
+      if (labels.has(child) && child.textContent.trim() !== "") {
+        found = child;
+      }
+      if (walk(child)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  walk(field);
+  return found;
+}
+
+/*
+ * Writes the whole text into the block's spoken copy, where a page authors one (#1672).
+ *
+ * A FIELD DESCRIBED BY ITS WHOLE BLOCK IS DESCRIBED BY THE LEAD LINE AND THE WORD "FULL TEXT", and
+ * that too was measured, on the same page and the same day. `aria-describedby` is computed from what
+ * the referenced element RENDERS, and a closed `<details>` renders its summary and nothing behind it.
+ * Opening the fold made the description the whole text. Pointing the reference at the body inside
+ * the closed fold made it EMPTY, because a closed fold's content is not in the rendered tree at all,
+ * so that repair is dead. What does carry the whole text is a hidden element the reference names
+ * DIRECTLY - accessible-name computation walks into those - and that is the spoken copy: a
+ * `<span class="sso-help-spoken" hidden>` beside the fold, filled here from the body, named by the
+ * field's `aria-describedby` in place of the block. Measured: the description is then the whole text
+ * with the fold closed.
+ *
+ * FILLED FROM THE BODY AND NEVER FROM THE CATALOGUE, for the reason the rail card is: the copy and
+ * the fold cannot say different things, and a parts body arrives assembled. One page authors one such
+ * span today, for the redirect-URI field. tools/ui-condensed-help.js refuses a field described by its
+ * block and a spoken copy nothing names, so the shape cannot drift in either direction unnoticed.
+ */
+function speak(help, body) {
+  const spoken = help.querySelector(".sso-help-spoken");
+  if (spoken) {
+    spoken.textContent = body.textContent;
+  }
 }
 
 /*

--- a/SSO-Auth/Web/providersPage.html
+++ b/SSO-Auth/Web/providersPage.html
@@ -573,7 +573,7 @@
                             id="OidRedirectUri"
                             type="text"
                             readonly
-                            aria-describedby="OidRedirectUri-help"
+                            aria-describedby="OidRedirectUri-help-spoken"
                           />
                           <button
                             is="emby-button"
@@ -624,6 +624,19 @@
                               instead; register that one too if any of them do.
                             </div>
                           </details>
+                          <!--
+                    The copy the field's aria-describedby names (#1672). A description computed from
+                    the block itself is the lead line and the word "Full text" while the fold is
+                    closed, and empty when it names the body inside the closed fold; a hidden element
+                    named directly carries the whole text. i18n.js fills it from the body on every
+                    catalogue pass, and tools/ui-condensed-help.js refuses a field described by its
+                    block or a copy nothing names.
+                  -->
+                          <span
+                            class="sso-help-spoken"
+                            id="OidRedirectUri-help-spoken"
+                            hidden
+                          ></span>
                         </div>
                       </div>
 

--- a/tools/ui-condensed-help.js
+++ b/tools/ui-condensed-help.js
@@ -54,6 +54,17 @@
  * exactly the reasons the element is native rather than rebuilt, and they are a
  * walk's to confirm rather than this tool's.
  *
+ * WHAT WAS MEASURED WHERE THIS TOOL CANNOT LOOK (#1672): Chromium 152's accessibility
+ * tree, read on 2026-09-12 over the shipped Providers page with the shipped applier
+ * run on it. A field whose `aria-describedby` names its whole block is described by
+ * the lead line and the word "Full text" while the fold is closed, and by nothing at
+ * all when the reference names the body inside the closed fold; a hidden element
+ * named directly carries the whole text; and every fold's summary is a disclosure
+ * triangle named by the one catalogue word, 111 rows alike. The applier answers both
+ * with `nameFold` and `speak`, and the arms below hold the ATTRIBUTES that computation
+ * reads, because the stub computes no accessible name. What a screen reader then
+ * says is still measured by nothing in this tree.
+ *
  * WHAT KEEPS IT FROM BEING A PROOF ABOUT ITSELF. The code under test is the
  * shipped i18n.js, loaded whole, not a copy and not an extract. The pages read
  * are the ones carrying the opt-in attribute, so a page joining the slice is
@@ -439,6 +450,7 @@ function inspectMarkup(page, source) {
   const refusals = [];
   const at = [];
   let blocks = 0;
+  let named = 0;
   HELP_BLOCK.lastIndex = 0;
   let match;
   while ((match = HELP_BLOCK.exec(markup)) !== null) {
@@ -558,6 +570,80 @@ function inspectMarkup(page, source) {
     }
   }
 
+  // A FIELD DESCRIBED BY ITS WHOLE BLOCK (#1672). Measured in Chromium's accessibility
+  // tree over the shipped Providers page: `aria-describedby` is computed from what the
+  // named element RENDERS, and a closed fold renders its summary and nothing behind it,
+  // so the description a screen reader is handed is the lead line and the word "Full
+  // text" - and empty when the reference names the body inside the closed fold. The
+  // shape a description can be computed from is the block's spoken copy, a hidden span
+  // the applier fills from the body; so a reference to a block is refused by name and
+  // a copy nothing names is refused as dead weight, both here where the page is
+  // authored, because the runtime reader drives a fixture whose references are right
+  // by construction.
+  const described = new Set(
+    [...markup.matchAll(/aria-describedby="([^"]*)"/g)].flatMap((m) =>
+      m[1].split(/\s+/).filter(Boolean),
+    ),
+  );
+  // THE BLOCK'S EXTENT AND NOT ONLY ITS OPENING TAG, because the review of 2026-09-12
+  // drove a reference to the body inside the fold past a reader that knew the block by
+  // its class alone - which is the EMPTY case, worse than the one it refused - and a
+  // spoken copy authored one element outside its block, which `speak` looks for inside
+  // the block and never fills.
+  const blockSpans = elementSpans(markup).filter((span) =>
+    hasClassToken(
+      markup.slice(markup.lastIndexOf("<", span.from - 1), span.from),
+      "sso-help",
+    ),
+  );
+  const insideBlock = (index) =>
+    blockSpans.some((span) => index >= span.from && index < span.to);
+  described.forEach((id) => {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // `\sid=` and not `\bid=`: a hyphen is a word boundary, so `data-id="x"` read as an id.
+    const target = new RegExp(
+      `<[a-z][a-z0-9]*\\b[^>]*\\sid="${escaped}"[^>]*>`,
+    ).exec(markup);
+    if (!target) {
+      return;
+    }
+    if (hasClassToken(target[0], "sso-help")) {
+      refusals.push(
+        `${id} on ${page} is a condensed block and a field's aria-describedby names it: with the fold closed the description a screen reader is handed is the lead line and the word "Full text", so name the block's spoken copy instead`,
+      );
+    } else if (
+      insideBlock(target.index) &&
+      !hasClassToken(target[0], "sso-help-spoken")
+    ) {
+      refusals.push(
+        `${id} on ${page} sits inside a condensed block and a field's aria-describedby names it: the lead line, the fold and the body inside it describe the field with a sentence, a word or nothing, so name the block's spoken copy instead`,
+      );
+    }
+  });
+  for (const tag of markup.matchAll(/<[a-z][a-z0-9]*\b[^>]*>/g)) {
+    if (!hasClassToken(tag[0], "sso-help-spoken")) {
+      continue;
+    }
+    const id = /\sid="([^"]*)"/.exec(tag[0]);
+    if (!id || !described.has(id[1])) {
+      refusals.push(
+        `a spoken copy on ${page}${id ? ` (${id[1]})` : ""} is named by no aria-describedby, so the applier fills a text nothing reads`,
+      );
+    }
+    // The ATTRIBUTE, read with every quoted value blanked first, so a class token spelled
+    // `hidden` does not pass for it.
+    if (!/\shidden(?=[\s>/=])/.test(tag[0].replace(/="[^"]*"/g, '=""'))) {
+      refusals.push(
+        `the spoken copy${id ? ` ${id[1]}` : ""} on ${page} is not hidden, so the whole text stands on the page twice`,
+      );
+    }
+    if (!insideBlock(tag.index)) {
+      refusals.push(
+        `the spoken copy${id ? ` ${id[1]}` : ""} on ${page} is authored outside any condensed block, where the applier never fills it, so the field it describes is described by nothing`,
+      );
+    }
+  }
+
   // WHERE THE CARD SITS, not merely whether the page holds one, and the review of
   // 2026-09-12 is why this is not a page-wide grep. The applier looks for the card
   // UNDER the marked container and attaches no focus listener when it does not find
@@ -571,7 +657,7 @@ function inspectMarkup(page, source) {
       refusals.push(
         `${page} condenses ${blocks} help text(s) and carries no readable ${CONDENSE_ROOT} container, so the applier is handed nothing to walk`,
       );
-      return { refusals, blocks, declared: flat, markup };
+      return { refusals, blocks, declared: flat, markup, named };
     }
 
     const card = markup.indexOf('class="verticalSection sso-help-card"');
@@ -635,6 +721,12 @@ function inspectMarkup(page, source) {
       ),
     );
 
+    // HOW MANY FOLDS A BROWSER NAMES AFTER THEIR FIELD (#1672), read the way the applier
+    // decides it: a block under a field container that carries a label. The rest keep
+    // the catalogue word, on purpose, and the run prints both so the split is a number
+    // rather than a sentence.
+    named = resolveFields(markup, at).filter((each) => each.labelled).length;
+
     // THE COUNT IS CLOSED, CLASS-AGNOSTIC (#1677). Everything above enters a help text
     // through its CLASS - `fieldDescription` for a block, `sso-help` for a condensed one
     // - so a `*_help` marker written on a class neither reader knows is in NEITHER
@@ -663,7 +755,7 @@ function inspectMarkup(page, source) {
     }
   }
 
-  return { refusals, blocks, declared: flat, markup };
+  return { refusals, blocks, declared: flat, markup, named };
 }
 
 // Elements a browser closes without a closing tag; they never contain a help block
@@ -737,6 +829,28 @@ function elementSpans(markup) {
  * spans are taken over every element rather than over the two class names.
  */
 function forEachSharedField(markup, blocks, say) {
+  const held = new Map();
+  resolveFields(markup, blocks).forEach(({ block, field, parent }) => {
+    const at = field || parent;
+    if (at === null) {
+      return;
+    }
+    if (held.has(at.from)) {
+      say(held.get(at.from), block.key);
+      return;
+    }
+    held.set(at.from, block.key);
+  });
+}
+
+/*
+ * Where each block sits, both halves of the applier's walk: the innermost field
+ * container holding it, and the innermost element of any kind. `labelled` says whether
+ * that container carries a label, which is what `nameFold` in i18n.js names the fold
+ * after (#1672); a block under no container is never named, whatever labels its parent
+ * happens to hold.
+ */
+function resolveFields(markup, blocks) {
   const spans = elementSpans(markup);
   const isField = (span) => {
     const opening = markup.slice(
@@ -749,8 +863,7 @@ function forEachSharedField(markup, blocks, say) {
     );
   };
 
-  const held = new Map();
-  blocks.forEach((block) => {
+  return blocks.map((block) => {
     // INNERMOST WINS in both halves: a container nested in another is the one the
     // applier stops at first on its way up, and the parent is the innermost element
     // of any kind. Picking an outer one would collapse a whole section into one field
@@ -768,16 +881,18 @@ function forEachSharedField(markup, blocks, say) {
         field = span;
       }
     });
-
-    const at = field || parent;
-    if (at === null) {
-      return;
-    }
-    if (held.has(at.from)) {
-      say(held.get(at.from), block.key);
-      return;
-    }
-    held.set(at.from, block.key);
+    return {
+      block,
+      field,
+      parent,
+      // A label FOR a control, or one wrapped around an input with an id: the two shapes
+      // `nameFold` derives its ids from. A bare `<label>` is not enough to be counted.
+      labelled:
+        field !== null &&
+        /<label\b[^>]*\sfor="[^"]+"|<label\b(?:(?!<\/label>)[\s\S])*<input\b[^>]*\sid="/.test(
+          markup.slice(field.from, field.to),
+        ),
+    };
   });
 }
 
@@ -983,10 +1098,16 @@ function buildPage(keys, texts, summary, options) {
 
   const main = new El("div");
   main.className = "sso-column-main";
-  const fields = keys.map((key) => {
+  const fields = keys.map((key, index) => {
     const container = new El("div");
     container.className = "inputContainer";
+    // A LABEL FOR THE CONTROL, as the pages author one per field (#1672): the fold is
+    // named after it, so the fixture carries the thing the name is derived from.
+    const label = new El("label");
+    label.setAttribute("for", `fixture_${index}`);
+    label.textContent = `Field ${index}`;
     const input = new El("input");
+    input.setAttribute("id", `fixture_${index}`);
 
     const lead = new El("span");
     lead.className = "sso-help-lead";
@@ -1022,16 +1143,32 @@ function buildPage(keys, texts, summary, options) {
     help.className = "fieldDescription sso-help";
     help.replaceChildren(lead, details);
 
-    container.replaceChildren(input, help);
+    // A SPOKEN COPY where the arm asks for one (#1672), named by the field's
+    // aria-describedby in place of the block: the one shape a description can be
+    // computed from with the fold closed.
+    let spoken = null;
+    if (options && options.spoken) {
+      spoken = new El("span");
+      spoken.className = "sso-help-spoken";
+      spoken.hidden = true;
+      spoken.setAttribute("hidden", "");
+      spoken.setAttribute("id", `fixture_${index}-help-spoken`);
+      input.setAttribute("aria-describedby", `fixture_${index}-help-spoken`);
+      help.appendChild(spoken);
+    }
+
+    container.replaceChildren(label, input, help);
     main.appendChild(container);
     return {
       key,
       container,
+      label,
       input,
       help,
       lead,
       details,
       body,
+      spoken,
       parts: assembled ? assembled.length : undefined,
     };
   });
@@ -1067,7 +1204,7 @@ function buildPage(keys, texts, summary, options) {
 function inspect(page, texts, summary) {
   const refusals = [];
   const say = (message) => refusals.push(message);
-  const counts = { folded: 0, flat: 0, flatParts: 0 };
+  const counts = { folded: 0, flat: 0, flatParts: 0, named: 0 };
 
   page.fields.forEach((field) => {
     const whole = texts[field.key];
@@ -1110,6 +1247,40 @@ function inspect(page, texts, summary) {
       say(
         `${field.key} names its fold ${JSON.stringify(summaryEl ? summaryEl.textContent : null)} and the catalogue says ${JSON.stringify(summary)}`,
       );
+    }
+
+    // THE FOLD IS NAMED AFTER ITS FIELD (#1672): the summary's aria-labelledby names the
+    // field's label and then the summary itself, by ids the applier writes. Measured in
+    // Chromium's accessibility tree, a summary without it is a disclosure triangle named
+    // by the catalogue word alone, the same as every other fold on the page.
+    const labelId = field.label.getAttribute("id");
+    const summaryId = summaryEl ? summaryEl.getAttribute("id") : null;
+    const namedBy = summaryEl
+      ? summaryEl.getAttribute("aria-labelledby")
+      : null;
+    if (!labelId || !summaryId || namedBy !== `${labelId} ${summaryId}`) {
+      say(
+        `${field.key} folds under a summary named by ${JSON.stringify(namedBy)} rather than by its field's label and its own word, so a list of the page's folds reads as one row repeated`,
+      );
+    } else {
+      counts.named += 1;
+    }
+
+    // AND THE SPOKEN COPY, WHERE THE FIELD HAS ONE, HOLDS THE WHOLE TEXT AND STAYS HIDDEN.
+    // It is what the field's aria-describedby hands a screen reader, so a copy short of
+    // the text describes the field with less than the fold holds, and one that is shown
+    // puts the text on the page twice.
+    if (field.spoken) {
+      if (field.spoken.textContent !== whole) {
+        say(
+          `${field.key} has a spoken copy holding ${field.spoken.textContent.length} character(s) and its text has ${whole.length}: what aria-describedby hands a screen reader is not the whole text`,
+        );
+      }
+      if (!field.spoken.hidden && !field.spoken.hasAttribute("hidden")) {
+        say(
+          `${field.key} shows its spoken copy on the page, so the whole text stands twice`,
+        );
+      }
     }
 
     // THE ONE-SENTENCE STATE IS A PLACE RATHER THAN A COPY (#1669). The body itself is
@@ -1417,7 +1588,7 @@ function fixtureMarkup(key, parts) {
   // asks for `p`, which is the tag a browser will not keep a `<details>` inside.
   const tag = p.tag || "div";
   const block = [
-    `<${tag} class="fieldDescription${p.marked ? " sso-help" : ""}">`,
+    `<${tag} class="fieldDescription${p.marked ? " sso-help" : ""}"${p.described ? ' id="fixture-help"' : ""}>`,
     p.comment ? `<!-- a note that mentions a closing </div> tag -->` : "",
     p.lead ? `<span class="sso-help-lead"></span>` : "",
     // `selfClosed` puts the one kind of tag that must NOT move the depth count before the
@@ -1436,10 +1607,14 @@ function fixtureMarkup(key, parts) {
     p.body
       ? p.assembled
         ? `<div class="sso-help-body" data-i18n-parts="${key}">whatever <strong data-i18n="config.fixture_emphasis">this</strong></div>`
-        : `<div class="sso-help-body" data-i18n="${key}">whatever</div>`
+        : `<div${p.describedBody ? ' id="fixture-help-body"' : ""} class="sso-help-body" data-i18n="${key}">whatever</div>`
       : `<div class="sso-help-body"><span data-i18n="${key}">whatever</span></div>`,
     p.details ? `</details>` : "</div>",
     p.wrapped ? `</div>` : "",
+    // The spoken copy (#1672): named by the field below, or by nothing, or shown.
+    p.spoken || p.spokenUnnamed || p.spokenShown || p.spokenClassHidden
+      ? `<span class="sso-help-spoken${p.spokenClassHidden ? " hidden" : ""}" id="fixture-help-spoken"${p.spokenShown || p.spokenClassHidden ? "" : " hidden"}></span>`
+      : "",
     `</${tag}>`,
   ].join("\n");
 
@@ -1460,9 +1635,24 @@ function fixtureMarkup(key, parts) {
       ? `<div class="sso-callout"${p.declared ? ' data-sso-flat-help="a warning, not a field description"' : ""} data-i18n-parts="config.fixture_9_help">a warning</div>`
       : "";
 
+  // The field the block describes (#1672): by its block, which is refused, or by the
+  // block's spoken copy, which is the shape the Providers page authors.
+  const field = p.described
+    ? `<input id="fixture-input" aria-describedby="fixture-help" />`
+    : p.describedBody
+      ? `<input id="fixture-input" aria-describedby="fixture-help-body" />`
+      : p.spoken || p.spokenShown || p.spokenClassHidden || p.spokenOutside
+        ? `<input id="fixture-input" aria-describedby="fixture-help-spoken" />`
+        : "";
+
   return [
     `<div ${CONDENSE_ROOT}>`,
+    field,
     block,
+    // `spokenOutside` is the copy one element past its block: named, hidden, and never filled.
+    p.spokenOutside
+      ? `<span class="sso-help-spoken" id="fixture-help-spoken" hidden></span>`
+      : "",
     extra,
     p.card ? card : "",
     `</div>`,
@@ -1551,6 +1741,14 @@ async function calibrate(i18n) {
     ).refusals,
   );
   record(
+    "a field described by its block's spoken copy",
+    false,
+    inspectMarkup(
+      "fixture",
+      fixtureMarkup("config.fixture_0_help", { spoken: true }),
+    ).refusals,
+  );
+  record(
     "two help blocks in two fields",
     false,
     inspectMarkup(
@@ -1575,6 +1773,15 @@ async function calibrate(i18n) {
     ["a key that is not on the body of its own fold", { body: false }],
     ["a condensed page with no rail card", { card: false }],
     ["a rail card outside the container the applier walks", { scoped: false }],
+    ["a field described by its whole block", { described: true }],
+    ["a spoken copy nothing names", { spokenUnnamed: true }],
+    ["a spoken copy authored shown", { spokenShown: true }],
+    ["a field described by the body inside its fold", { describedBody: true }],
+    ["a spoken copy authored outside its block", { spokenOutside: true }],
+    [
+      "a spoken copy hidden by a class token rather than the attribute",
+      { spokenClassHidden: true },
+    ],
   ];
   markupNegatives.forEach(([name, parts]) =>
     record(
@@ -1728,6 +1935,145 @@ async function calibrate(i18n) {
       ...inspect(page, texts, "Full text").refusals,
       ...inspectRail(page, texts, "Full text", true),
     ]);
+  }
+
+  /*
+   * --- the fold's name and the spoken copy (#1672) ---
+   *
+   * Both were measured in a browser's accessibility tree and neither can be measured
+   * here: the stub computes no accessible name. What the arms hold is the ATTRIBUTES
+   * that computation reads, which the applier writes and which a mutation removes.
+   */
+  {
+    const texts = fixtureTexts([TWO, ONE]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {
+      spoken: true,
+    });
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    // Twice, because the ids are written where they are missing and a second pass has
+    // to find them rather than mint a second set.
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    const summaryEl = page.fields[0].details.querySelector("summary");
+    record(
+      "a fold is named by its field's label and its own word, and a spoken copy holds the whole text",
+      false,
+      [
+        ...inspect(page, texts, "Full text").refusals,
+        ...inspectRail(page, texts, "Full text", true),
+        ...(summaryEl.getAttribute("aria-labelledby") ===
+          "fixture_0-label fixture_0-full-text" &&
+        page.fields[0].label.getAttribute("id") === "fixture_0-label"
+          ? []
+          : [
+              `the summary is named by ${JSON.stringify(summaryEl.getAttribute("aria-labelledby"))} and the ids the applier derives from the control are fixture_0-label and fixture_0-full-text`,
+            ]),
+        ...(page.fields[0].spoken.textContent === TWO
+          ? []
+          : ["the spoken copy does not hold the whole text"]),
+      ],
+    );
+  }
+
+  // A LABEL WRAPPED AROUND ITS CONTROL, which is how every checkbox row is authored:
+  // no `for`, the input inside the label, and the id taken from that input.
+  {
+    const texts = fixtureTexts([TWO]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {});
+    const field = page.fields[0];
+    field.container.className = "checkboxContainer";
+    field.label.removeAttribute("for");
+    field.label.appendChild(field.input);
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    const summaryEl = field.details.querySelector("summary");
+    record(
+      "a fold under a label wrapped around its checkbox is named by that label",
+      false,
+      summaryEl.getAttribute("aria-labelledby") ===
+        "fixture_0-label fixture_0-full-text"
+        ? []
+        : [
+            `the summary under a wrapping label is named by ${JSON.stringify(summaryEl.getAttribute("aria-labelledby"))}`,
+          ],
+    );
+  }
+
+  // A BLOCK IN NO FIELD CONTAINER KEEPS THE BARE WORD: the first label under its parent
+  // belongs to some other field, and a fold named after a field it does not open is
+  // worse than one named "Full text". The arm holds that the applier does NOT reach
+  // for that label; deleting the container test in `nameFold` is what turns it red.
+  {
+    const texts = fixtureTexts([TWO]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {});
+    const field = page.fields[0];
+    field.container.className = "sso-test-block";
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    const summaryEl = field.details.querySelector("summary");
+    record(
+      "a fold in no field container is not named after somebody else's label",
+      false,
+      summaryEl.hasAttribute("aria-labelledby")
+        ? [
+            `a fold under a plain parent was named by ${JSON.stringify(summaryEl.getAttribute("aria-labelledby"))}, the label of a field it does not open`,
+          ]
+        : [],
+    );
+  }
+
+  // TWO LABELLED CONTROLS IN ONE CONTAINER, the help under the second: the SAML form's
+  // Live TV rows author this once, and the FIRST label named that fold after the field
+  // above it (review of 2026-09-12). The label that names a fold is the last one before
+  // its block.
+  {
+    const texts = fixtureTexts([TWO]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {});
+    const field = page.fields[0];
+    const second = new El("label");
+    second.setAttribute("for", "fixture_0b");
+    second.textContent = "Second field";
+    const control = new El("input");
+    control.setAttribute("id", "fixture_0b");
+    field.container.insertBefore(second, field.help);
+    field.container.insertBefore(control, field.help);
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    const summaryEl = field.details.querySelector("summary");
+    record(
+      "a fold under the second of two labelled controls is named by the second label",
+      false,
+      summaryEl.getAttribute("aria-labelledby") ===
+        "fixture_0b-label fixture_0b-full-text"
+        ? []
+        : [
+            `the fold under the second control is named by ${JSON.stringify(summaryEl.getAttribute("aria-labelledby"))}`,
+          ],
+    );
+  }
+
+  // THE HOST'S OWN EMPTY LABEL. jellyfin-web's emby-input, emby-textarea and emby-select
+  // insert `<label for=id></label>` with no text directly in front of every control they
+  // upgrade, so on a real page an empty label stands between the authored one and the
+  // block on every field. The stub has no custom elements, so the label is authored here;
+  // the arm also asks that no id was minted on it, because the id it would get is the
+  // authored label's, and the same attribute string would then name an empty element.
+  {
+    const texts = fixtureTexts([TWO]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {});
+    const field = page.fields[0];
+    const host = new El("label");
+    host.setAttribute("for", "fixture_0");
+    field.container.insertBefore(host, field.input);
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    const summaryEl = field.details.querySelector("summary");
+    record(
+      "the empty label the host inserts before a control does not name the fold",
+      false,
+      summaryEl.getAttribute("aria-labelledby") ===
+        "fixture_0-label fixture_0-full-text" &&
+        host.getAttribute("id") === null
+        ? []
+        : [
+            `with the host's empty label in front of the control the fold is named by ${JSON.stringify(summaryEl.getAttribute("aria-labelledby"))}${host.getAttribute("id") === null ? "" : " and the empty label was given the id"}`,
+          ],
+    );
   }
 
   /*
@@ -2040,6 +2386,50 @@ async function calibrate(i18n) {
     ]);
   }
 
+  // The fold's name and the spoken copy (#1672), one negative per refusal.
+  const namedNegatives = [
+    [
+      "a fold named by nothing but the catalogue word",
+      (page) => {
+        page.fields[0].details
+          .querySelector("summary")
+          .removeAttribute("aria-labelledby");
+      },
+    ],
+    [
+      "a fold named by an id that is not its field's label",
+      (page) => {
+        const summaryEl = page.fields[0].details.querySelector("summary");
+        summaryEl.setAttribute(
+          "aria-labelledby",
+          "elsewhere " + summaryEl.getAttribute("id"),
+        );
+      },
+    ],
+    [
+      "a spoken copy that is not the whole text",
+      (page) => {
+        page.fields[0].spoken.textContent = "cut short.";
+      },
+    ],
+    [
+      "a spoken copy the applier left shown",
+      (page) => {
+        page.fields[0].spoken.hidden = false;
+        page.fields[0].spoken.removeAttribute("hidden");
+      },
+    ],
+  ];
+  for (const [name, mutate] of namedNegatives) {
+    const texts = fixtureTexts([TWO, ONE]);
+    const page = buildPage(Object.keys(texts), texts, "Full text", {
+      spoken: true,
+    });
+    await render(i18n, page, { ...texts, [SUMMARY_KEY]: "Full text" });
+    mutate(page);
+    record(name, true, inspect(page, texts, "Full text").refusals);
+  }
+
   // TWO HELP BLOCKS IN ONE FIELD CONTAINER. No page carries the shape and nothing
   // refuses it, which `i18n.js` says of itself at the map it builds; what this arm
   // holds is that the applier is DETERMINISTIC about it - the first block in
@@ -2339,7 +2729,7 @@ async function run() {
       });
       if (name === "en") {
         console.log(
-          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence` +
+          `${page.padEnd(20)}${String(keys.length).padStart(3)} condensed help text(s), ${runtime.counts.folded} with a fold that holds more, ${runtime.counts.flat} whose text is one sentence, ${authored.named} named after their field's label and ${keys.length - authored.named} by the catalogue word alone` +
             (assembled === 0
               ? ""
               : `, ${assembled} assembled from parts and driven with their own children, ${runtime.counts.flatParts} of them holding one sentence`) +


### PR DESCRIPTION
# What & why

Names every help fold after the field it opens, and hands the redirect-URI field its whole help text as its description again. It closes nothing on its own: #1672 stays open on the screen-reader run its first Done-when asks for, which I did not do. What lands here is the measurement the two reviews behind #1672 could not take, the repair that measurement chose, and the rule where it lives.

**What I measured.** Chromium 152's accessibility tree, read over the shipped Providers page with the shipped applier run on it, before this change:

- the redirect-URI field, fold closed: description `The exact redirect URI the login uses. Full text`, the lead line and the summary's word, exactly what the reviews predicted;
- fold open: the whole text, with the lead once more in front of it;
- `aria-describedby` re-pointed at the body inside the closed fold: description **empty**, so that repair is dead;
- a hidden element the reference names directly: the whole text;
- every one of the page's 111 folds is a disclosure triangle named `Full text`; the tree renders 92 of them and all 92 read alike.

After this change, same page, same reader:

- the redirect-URI field: the whole text, fold closed or open, identical both ways;
- the fold under it: `Redirect URI (register this at your provider): Full text`;
- a checkbox row, whose label wraps its input: `Hide from managed login-page buttons Full text`;
- the one container holding two labelled controls and one fold, the SAML Live TV rows: `Live TV Management Roles: Full text`, the label above the fold and not the first in the container;
- 63 distinct fold names among the 92 rendered, 8 still `Full text`; the ids the applier mints collide with nothing on any of the five pages.

**What changed.** `refresh` in `i18n.js` runs two more steps per block. `nameFold` gives the summary an `aria-labelledby` naming the field's label and then itself, minting `<control>-label` and `<control>-full-text` where missing, and only for a block under an `inputContainer` or `checkboxContainer`: under any other parent the first label belongs to somebody else's field, and a fold named after a field it does not open is worse than the bare word. The label is the last text-bearing one before the block, because jellyfin-web's `emby-input`, `emby-textarea` and `emby-select` insert an empty label of their own in front of every control they upgrade. `speak` fills an authored `<span class="sso-help-spoken" hidden>` from the body, and the redirect-URI input's `aria-describedby` names that span instead of the block. Nothing is copied from the catalogue; both follow the body through every later pass and every language.

`tools/ui-condensed-help.js` holds it: the fixture carries a label per field, the runtime reader refuses a summary not named by its label and itself and a spoken copy that is short of the text or shown, and the markup reader refuses a field described by its whole block, or by anything inside a block other than the spoken copy, a spoken copy nothing names, one hidden by a class token rather than the attribute, and one authored outside its block. It prints how many folds a browser names after their field: 101 of 111 on Providers, 12 of 13 on Policies, 2 of 3 on Server, 1 of 4 on Accounts.

Refs #1672.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not on the login path, not crypto, not config persistence, not the release pipeline: the change is the admin pages' markup, the runtime help applier, and a Node gate. Two read-only review lenses ran over the diff anyway, because browser JS is not exercised by CI and the review is its primary verification.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
      **Correctness lens: NEEDS_IMPROVEMENT, CONFIRMED 5 / PLAUSIBLE 2**, each reproduced by a stack-parser probe over the four marked pages or by driving the gate's regexes over hand-built shapes. F1, the SAML Live TV container names its fold after the first of its two labels: FIX, the label is now the last text-bearing one before the block, with an arm. F2, a reference to the body or the fold inside a block passes the markup reader: FIX, anything inside a block but the spoken copy is refused, with a negative. F3, a spoken copy authored outside its block passes and is never filled: FIX, refused by the block's extent, with a negative. F4, `hidden` accepted as a class token: FIX, the tag is read with every quoted value blanked, with a negative. F5, `\bid=` also matched `data-id=`: FIX, `\sid=`. F6, the no-script description of the redirect field goes from the word "Full text" to nothing: DECLINE, without the applier no page carries a lead line either and the bare word described nothing; the whole text is one click away in both states. F7, the printed count of named folds could exceed what the applier names for a wrapping label with no id'd input: FIX, the count now needs a `for` or an id'd input. Re-run on the fixed state: the same probe counts agree with the gate's printed line and every shape above is refused.
      **Integration lens: PASS, CONFIRMED 0 / PLAUSIBLE 2.** The host's empty label insertion is the one real hazard and is clear on all 116 labelled containers today; the lens's two advisories are F3 above and the same host label, both taken as FIX with arms, since the stub cannot see either shape.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The property is a page-and-applier one and is locked in `tools/ui-condensed-help.js`, where the other condensed-help rules live; the C# conformance suite reads none of this.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).
      No wiki page describes what a screen reader is handed on the settings pages, so there is nothing to bring into step.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ node tools/ui-condensed-help.js
calibration:       95 arms, 55 that must pass and 40 that must be refused, all as expected
providersPage.html  111 condensed help text(s), 100 with a fold that holds more, 11 whose text is one sentence, 101 named after their field's label and 10 by the catalogue word alone, 35 assembled from parts and driven with their own children, 1 of them holding one sentence, 1 declared flat with a reason
the marked pages:   131 condensed help text(s) over 4 page(s), read in en and de
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
Total: 3960, Errors: 0, Failed: 0, Skipped: 4
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
Total: 3961, Errors: 0, Failed: 0, Skipped: 4
```

Every other gate under `tools/ui-*.js` exits 0, and Prettier reports the three changed files clean.

**The guards bite.** Each was deleted and the gate watched go red, then restored:

- the `nameFold` call deleted: every runtime arm refuses with `folds under a summary named by null`;
- the `speak` call deleted: `a spoken copy holding 0 character(s) and its text has 57`;
- the page's `aria-describedby` pointed back at the block: `OidRedirectUri-help on providersPage.html is a condensed block and a field's aria-describedby names it`, and the spoken copy is refused as named by nothing;
- the container test in `nameFold` deleted: `a fold under a plain parent was named by "fixture_0-label fixture_0-full-text", the label of a field it does not open`;
- the first label taken instead of the last: `the fold under the second control is named by "fixture_0-label fixture_0-full-text"`;
- the text condition on the label dropped: `with the host's empty label in front of the control the fold is named by "fixture_0-label fixture_0-full-text" and the empty label was given the id`.

## Notes

**What this is measured with, and what it is not.** The measurement is the accessibility tree the browser computes, which is what a screen reader reads, taken headlessly over the tree's own page and applier served from disk. It is not a screen reader run and it is not the walk server. The description string and the fold names above are what the tree holds; what a screen reader then says, in which order and with which pauses, is still unmeasured. #1672 stays open on exactly that, and the walk #1663 and #1664 wait on is the place to take it.

**The ten folds that keep the bare word** sit in no field container, the two empty states, the collapse contents, the subgroups, the danger zone and the test block, and are left that way on purpose, for the reason in `nameFold`. Naming them wants a decision about what they belong to, and that is not taken here.

**One spoken copy, not 111.** Only the redirect-URI field has an `aria-describedby`, so only its block authors a copy. The other folds are reached in reading order and by their new names; giving every field a 600-character description on focus would change what the page says rather than repair it, and is not done here.
