### PR TITLE
Tag plugin assets by a digest of the build, not the file version [#1705]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,7 +753,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Fixed
 
+- **A browser no longer keeps the previous build's scripts after an upgrade
+  (#1705).** Every plugin asset carries a tag a browser sends back to ask
+  whether its copy is still current, and that tag was the assembly's file
+  version, which the project pins at the line's three-part number: every build
+  of one line answered the same tag, the server said 304, and the dashboard
+  ran the old build's script against the new build's pages with nothing on
+  the page saying so. The tag is now a digest of the assembly's bytes, so two
+  builds whose bytes differ cannot share one, whatever any version field says;
+  where the bytes cannot be read it falls back to the assembly version rather
+  than to no tag. The `no-cache` answer is unchanged: a browser keeps the
+  asset and asks, and after an upgrade the first ask is now answered in full.
 - **A settings tab returned to now shows what the server holds, instead of what
+
   it last loaded (#1576, #1572).** The Jellyfin dashboard keeps three views
   alive and hands a cached one back without re-running its controller, so a
   settings tab left and returned to went on showing the configuration as it was

--- a/SSO-Auth.Tests/Http/PluginAssetVersionTests.cs
+++ b/SSO-Auth.Tests/Http/PluginAssetVersionTests.cs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using Xunit;
 
@@ -8,20 +13,83 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// The one lifetime answer both asset routes give (#1627), pinned independently of either route: the tag is
-/// the plugin's file version, which the release build stamps per release, and the header is the one that
-/// makes a browser ask.
+/// a digest of the build of the assembly that is serving (#1705), and the header is the one that makes a
+/// browser ask.
 /// </summary>
 public class PluginAssetVersionTests
 {
     [Fact]
-    public void TheTag_IsThePluginsFileVersion_Quoted_AndStrong()
+    public void TheTag_IsADigestOfThisBuildOfTheAssembly_Quoted_AndStrong()
     {
-        // Recomputed here from the same source, the SSO-Auth assembly's FILE version, so a regression to
-        // the assembly version (static across releases, #253) or to a weak tag is caught.
+        // Recomputed here from the same source, the bytes of the SSO-Auth assembly on disk, so a regression
+        // to any version field - static across the builds of one line - is caught.
+        var bytes = File.ReadAllBytes(typeof(SSOPlugin).Assembly.Location);
+        var digest = Convert.ToHexStringLower(SHA256.HashData(bytes))[..16];
+
+        Assert.Equal("\"" + digest + "\"", PluginAssetVersion.ETag.ToString());
+        Assert.False(PluginAssetVersion.ETag.IsWeak);
+    }
+
+    [Fact]
+    public void TheTag_IsNotTheFileVersion_WhichEveryBuildOfALineShares()
+    {
+        // The defect of #1705: the project pins the file version at the line's three-part number and the
+        // build number lives in meta.json only, so a tag from the file version let a browser keep the
+        // previous build's script after an upgrade.
         var fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(SSOPlugin).Assembly.Location).FileVersion;
 
-        Assert.Equal("\"" + fileVersion + "\"", PluginAssetVersion.ETag.ToString());
-        Assert.False(PluginAssetVersion.ETag.IsWeak);
+        Assert.NotEqual("\"" + fileVersion + "\"", PluginAssetVersion.ETag.ToString());
+    }
+
+    [Fact]
+    public void TwoBuildsWhoseBytesDiffer_AnswerDifferentTags_AndTheSameBytesTheSameTag()
+    {
+        var one = new byte[64];
+        for (var i = 0; i < one.Length; i++)
+        {
+            one[i] = (byte)i;
+        }
+
+        var other = (byte[])one.Clone();
+        other[40] ^= 1;
+
+        Assert.NotEqual(PluginAssetVersion.TagOf(one).ToString(), PluginAssetVersion.TagOf(other).ToString());
+        Assert.Equal(PluginAssetVersion.TagOf(one).ToString(), PluginAssetVersion.TagOf((byte[])one.Clone()).ToString());
+        Assert.Matches("^\"[0-9a-f]{16}\"$", PluginAssetVersion.TagOf(one).ToString());
+    }
+
+    [Fact]
+    public void AnAssemblyWithNoLocation_FallsBackToItsVersion_RatherThanNoTag()
+    {
+        // A dynamic assembly has no location, which is one of the two shapes the fallback exists for: the
+        // tag is then the assembly's version, static across builds, and still a validator rather than a
+        // failed type initializer that would take both asset routes down.
+        var name = new AssemblyName("Jellyfin.Plugin.SSO_Auth.Tests.Fallback") { Version = new Version(9, 8, 7, 6) };
+        var dynamic = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.Run);
+
+        Assert.Equal("\"9.8.7.6\"", PluginAssetVersion.TagOf(dynamic).ToString());
+    }
+
+    [Fact]
+    public void AnAssemblyWhoseFileCannotBeRead_FallsBackToItsVersion_RatherThanThrowing()
+    {
+        // The other shape: a location that exists and a read that fails at the moment the type initializes.
+        // Driven through the injectable read, because a file that cannot be read is not a state a test can
+        // put the real assembly into.
+        var tag = PluginAssetVersion.TagOf("C:/nowhere/SSO-Auth.dll", _ => throw new IOException("gone"), new Version(1, 2, 3, 4));
+
+        Assert.Equal("\"1.2.3.4\"", tag.ToString());
+    }
+
+    [Fact]
+    public void AReadThatSucceeds_IsTheDigest_NotTheVersion()
+    {
+        // The same seam the fallback is driven through, on its main arm: the version is ignored where the
+        // bytes can be read, so a regression that always answered the version would be caught here and
+        // not only by the real-assembly test above.
+        var tag = PluginAssetVersion.TagOf("C:/somewhere/SSO-Auth.dll", _ => new byte[] { 1, 2, 3 }, new Version(1, 2, 3, 4));
+
+        Assert.Equal(PluginAssetVersion.TagOf(new byte[] { 1, 2, 3 }).ToString(), tag.ToString());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Http/PluginPageCacheFilterTests.cs
+++ b/SSO-Auth.Tests/Http/PluginPageCacheFilterTests.cs
@@ -90,6 +90,26 @@ public class PluginPageCacheFilterTests
     }
 
     [Fact]
+    public void OurPage_HeldAtThePreviousBuildsTag_IsServedInFull()
+    {
+        // The defect of #1705: two builds of one line whose bytes differ shared a tag, so a browser holding
+        // the previous build's script was told 304 against the new build's markup. The previous build is
+        // stood in for by other bytes run through the same derivation as the current tag.
+        var previous = PluginAssetVersion.TagOf(new byte[] { 9, 9, 9 }).ToString();
+        Assert.NotEqual(CurrentTag, previous);
+
+        var (filter, _) = Build();
+        var context = Context("Dashboard", "GetDashboardConfigurationPage", OurPage, File(out var stream), ifNoneMatch: previous);
+        var served = context.Result;
+
+        filter.OnResultExecuting(context);
+
+        Assert.Same(served, context.Result);
+        Assert.True(stream.CanRead);
+        Assert.Equal(CurrentTag, context.HttpContext.Response.Headers.ETag.ToString());
+    }
+
+    [Fact]
     public void AWeakTag_Validates_AsTheStandardRequiresForIfNoneMatch()
     {
         // RFC 9110 requires the weak comparison for If-None-Match, and the plugin's own route answers that

--- a/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
+++ b/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
@@ -18,7 +19,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// Tests for <see cref="SSOViewsController.GetView"/> - the endpoint that serves the plugin's embedded
 /// view assets (the linking page, its stylesheet and scripts). The action itself resolves the requested
 /// name against <see cref="SSOPlugin.GetViews"/>, streams the matching embedded resource, and tags the
-/// response with the version-derived tag of <c>PluginAssetVersion</c> so clients can 304-revalidate (#253)
+/// response with the build-derived tag of <c>PluginAssetVersion</c> so clients can 304-revalidate (#253)
+
 /// and, since #1627, with no-cache so that they ask. These tests
 /// pin exactly that action-level behavior: an unknown name 404s, a known name streams the resource with
 /// the content type derived from the embedded resource path and the version ETag. The conditional
@@ -45,15 +47,15 @@ public class SSOViewsControllerTests
         };
     }
 
-    // The version-derived ETag the action stamps on every asset, recomputed here from the same source the
-    // controller uses (the SSO-Auth assembly's FILE version) so the assertions catch a regression to a
-    // null, weak, or lastModified-only tag.
+    // The build-derived ETag the action stamps on every asset, recomputed here from the same source the
+    // tag is derived from (the bytes of the SSO-Auth assembly on disk, #1705) so the assertions catch a
+    // regression to a null, weak, lastModified-only or version-derived tag.
     private static string ExpectedAssetETag()
     {
-        var fileVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(
-            typeof(SSOPlugin).Assembly.Location).FileVersion;
-        return "\"" + fileVersion + "\"";
+        var bytes = File.ReadAllBytes(typeof(SSOPlugin).Assembly.Location);
+        return "\"" + Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes))[..16] + "\"";
     }
+
 
     [Fact]
     public void GetView_KnownView_SaysABrowserMustAskBeforeReusingIt()

--- a/SSO-Auth/Api/Http/PluginAssetVersion.cs
+++ b/SSO-Auth/Api/Http/PluginAssetVersion.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.Net.Http.Headers;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
@@ -12,17 +16,28 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The assets are embedded in the assembly, so they change exactly when the plugin's file version does,
-/// and the file version is what the build stamps per release; the assembly version can stay static across
-/// releases and would then validate stale assets after an upgrade (#253). One tag for every asset is
-/// correct: a client sends the tag it cached for a URL, and the server compares it against that URL's
-/// current tag.
+/// The assets are embedded in the assembly, so they change exactly when the assembly's bytes do, and the
+/// tag is a digest of those bytes (#1705). It was the file version until that issue, on the reasoning that
+/// the build stamps one per release; the build does not. The project pins the file version at the line's
+/// three-part number and the build number lives in the package's <c>meta.json</c> only, so every build of
+/// one line answered the same tag, a browser holding the previous build's script was told 304, and the
+/// dashboard ran that script against the new build's markup with nothing on the page saying so. A digest
+/// of the assembly cannot agree across two builds whose bytes differ, whatever any version field says.
+/// One tag for every asset is still correct: a client sends the tag it cached for a URL, and the server
+/// compares it against that URL's current tag.
 /// </para>
 /// <para>
 /// <c>no-cache</c> rather than a lifetime: a browser may keep the asset but must ask before using it, and
 /// with the tag the answer is a 304 until the plugin changes. Without the header a browser falls back to
 /// heuristic freshness and can run the previous release's script for as long as it likes after an
 /// upgrade, with nothing on the page saying so; a fixed lifetime would only bound that, not end it.
+/// </para>
+/// <para>
+/// THE TAG NEVER FAILS TO EXIST. The digest needs the assembly's bytes from disk: an assembly loaded from
+/// memory has no location, and a file can be unreadable at the moment the type initializes. In both
+/// cases the tag falls back to the assembly's version, quoted, which is the static answer this replaces
+/// and is still a valid validator. A type initializer that threw here would take both asset routes down
+/// with it, so the read is injectable and the throwing case is driven by a test rather than reasoned.
 /// </para>
 /// </remarks>
 internal static class PluginAssetVersion
@@ -32,9 +47,59 @@ internal static class PluginAssetVersion
     /// </summary>
     internal const string CacheControl = "no-cache";
 
+    // Sixteen hex digits, 64 bits of the digest: enough that two builds of one line cannot collide by
+    // accident, short enough to read in a response header.
+    private const int TagDigits = 16;
+
     /// <summary>
-    /// Gets the strong entity tag every plugin asset carries: the plugin's file version, quoted.
+    /// Gets the strong entity tag every plugin asset carries: a digest of this build of the assembly.
     /// </summary>
-    internal static EntityTagHeaderValue ETag { get; } = new(
-        "\"" + System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(PluginAssetVersion).Assembly.Location).FileVersion + "\"");
+    internal static EntityTagHeaderValue ETag { get; } = TagOf(typeof(PluginAssetVersion).Assembly);
+
+    /// <summary>
+    /// The tag for one build of the assembly, from its bytes: the first sixteen hex digits of their
+    /// SHA-256, quoted and strong.
+    /// </summary>
+    /// <param name="assembly">The bytes of the assembly file.</param>
+    /// <returns>The tag those bytes answer.</returns>
+    internal static EntityTagHeaderValue TagOf(ReadOnlySpan<byte> assembly) =>
+        new("\"" + Convert.ToHexStringLower(SHA256.HashData(assembly))[..TagDigits] + "\"");
+
+    /// <summary>
+    /// The tag for a loaded assembly: a digest of its file on disk, or its version quoted where the
+    /// file cannot be read.
+    /// </summary>
+    /// <param name="assembly">The loaded assembly.</param>
+    /// <returns>The tag this build of it answers.</returns>
+    internal static EntityTagHeaderValue TagOf(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return TagOf(assembly.Location, File.ReadAllBytes, assembly.GetName().Version);
+    }
+
+    /// <summary>
+    /// The tag for an assembly at <paramref name="location"/> read through <paramref name="read"/>, or
+    /// <paramref name="version"/> quoted where there is no location or the read fails.
+    /// </summary>
+    /// <param name="location">The assembly's path on disk, or empty for one that has none.</param>
+    /// <param name="read">Reads the bytes at a path.</param>
+    /// <param name="version">The assembly's version, the fallback.</param>
+    /// <returns>The tag.</returns>
+    internal static EntityTagHeaderValue TagOf(string? location, Func<string, byte[]> read, Version? version)
+    {
+        ArgumentNullException.ThrowIfNull(read);
+        try
+        {
+            if (!string.IsNullOrEmpty(location))
+            {
+                return TagOf(read(location));
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            // The version below: a tag that is static across builds beats no tag at all.
+        }
+
+        return new("\"" + (version?.ToString() ?? "0.0.0.0") + "\"");
+    }
 }

--- a/SSO-Auth/Api/Http/PluginPageCacheFilter.cs
+++ b/SSO-Auth/Api/Http/PluginPageCacheFilter.cs
@@ -34,8 +34,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
 /// </para>
 /// <para>
 /// The action is reachable without authentication today, so the 304 grants nothing a 200 would not, and
-/// the tag is the plugin's file version, which <see cref="SSOViewsController"/> has exposed the same way
-/// since #253 (T-I, decided on #1627).
+/// the tag is a digest of the build, which <see cref="SSOViewsController"/> has exposed the same way
+/// since #253 (T-I, decided on #1627), from the file version until #1705.
 /// </para>
 /// </remarks>
 internal sealed class PluginPageCacheFilter : IResultFilter


### PR DESCRIPTION
# What & why

Every plugin asset carries a tag a browser sends back to ask whether its copy is still current, and that tag was the assembly's file version. The project pins the file version at the line's three-part number and the build number lives in `meta.json` only, so every build of one line answered the same tag: the server said 304, and the dashboard ran the previous build's `i18n.js` against the new build's pages, which is what #1705 saw on the walk server going from 5.0.0.86 to 5.0.0.87. Read off the shipped assembly of build 5.0.0.87 on this machine:

```
FileVersion    : 5.0.0
ProductVersion : 1.0.0+3792b7b6574183b1a5af7348a715510ae2c536ed
```

The tag is now a digest of the assembly's bytes, the first sixteen hex digits of their SHA-256, quoted and strong. Two builds whose bytes differ cannot share one, whatever any version field says, and the same bytes answer the same tag across restarts. Where the bytes cannot be read, an assembly with no location or a file that fails to read at the moment the type initializes, the tag falls back to the assembly version quoted: the static answer this replaces, still a validator, and not a failed type initializer that would take both asset routes down. The read is injectable so that arm is driven and not reasoned. `no-cache` is unchanged: a browser keeps the asset and asks, and after an upgrade the first ask is now answered in full.

**The other line.** The third Done-when asks that the 4.4 line be read for the same shape. `branches/4.4` on the API resolves to `5.0`, so that line is this one. The line that still carries the shape is `main`, the frozen 4.3 line, where `SSOViewsController.AssetETag` is the file version and the project pins `4.3.0`; that is #1707, labelled for the owner's call because any landing on `main` restarts the soak clock on #1511.

Refs #1705. The issue stays open on its second Done-when, the walk server taken from one build to the next, which I could not run.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not on the login path, not crypto, not config persistence, not the release pipeline: the change is how the two asset routes derive a cache validator. No review lens was run over this diff; what stands behind it is the tests and the mutations below.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No new structural property: the tag stays one static value both routes read, and the suite's existing rules pass unchanged.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).
      The changelog carries it under Unreleased / Fixed; no wiki page describes the asset tag.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
Total: 3966, Errors: 0, Failed: 0, Skipped: 4
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
Total: 3967, Errors: 0, Failed: 0, Skipped: 4
$ npx prettier --check CHANGELOG.md
All matched files use Prettier code style!
```

**The guards bite.** Each was mutated, built and run, then restored:

- the tag derived from the file version again: four tests red, the digest pin, the not-the-file-version pin, and both controller tests;
- the digest computed over empty bytes instead of the assembly's: five red, among them `OurPage_HeldAtThePreviousBuildsTag_IsServedInFull`, which is the test the Done-when asks for: a request holding one tag against a server answering another;
- the catch no longer taking an I/O failure: `AnAssemblyWhoseFileCannotBeRead_FallsBackToItsVersion_RatherThanThrowing` red.

## Notes

**Not covered.** The second Done-when, the walk server taken from one build to the next and serving the new `i18n.js` on the first revalidation, needs an installed build and a dashboard session, and I had neither: the walk server's stored token answers 401 and I did not sign in. What this pull request proves is the derivation and the filter's answer to a stale tag, not the browser's behaviour across a real upgrade.

**Why a digest and not the build number.** The build number reaches the assembly in no field: it is written into `meta.json` by the publish workflow after the build. Reading it back at runtime would tie the tag to the host's plugin manifest, and a local build would carry none. The bytes are always there, and a rebuild of the same commit that produces different bytes is, for a browser's cache, a different build.
